### PR TITLE
ui: increase timer for Suggester unit tests

### DIFF
--- a/ui/src/common/components/__tests__/Suggester.test.jsx
+++ b/ui/src/common/components/__tests__/Suggester.test.jsx
@@ -7,7 +7,8 @@ import Suggester, { REQUEST_DEBOUNCE_MS } from '../Suggester';
 
 const mockHttp = new MockAdapter(http);
 
-function wait(milisec = REQUEST_DEBOUNCE_MS + 5) {
+// TODO: use fake timers after https://github.com/facebook/jest/pull/7776
+function wait(milisec = REQUEST_DEBOUNCE_MS + 25) {
   return new Promise(resolve => {
     setTimeout(() => resolve(), milisec);
   });


### PR DESCRIPTION
We still can't use jest's fakeTimers because it doesn't work with
lodash.debounce. And we don't want to make `debounce`. Thus this
increases wait timeout by 20milisec to avoid random failures