### PR TITLE
search: do not return buckets with doc_count 0

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -316,6 +316,14 @@ RECORDS_REST_FACETS = {
                     "ranges": [{"key": "10 authors or less", "from": 1, "to": 11}],
                 },
                 "meta": {"title": "Number of authors", "order": 2},
+                "aggs": {
+                    "doc_count_bucket_filter": {
+                        "bucket_selector": {
+                            "buckets_path": {"count": "_count"},
+                            "script": "params.count > 0",
+                        }
+                    }
+                },
             },
             "author": {
                 "terms": {"field": "facet_author_name", "size": 20},


### PR DESCRIPTION
* Filters out buckets of author_count aggregation where doc_count = 0
so that it they don't show up on the UI leads users to empty searches.

JIRA:INSPIR-1983