### PR TITLE
ui: add search rank for literature results

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -19,7 +19,7 @@
     "test:size": "bundlesize",
     "eject": "react-scripts eject",
     "lint":
-      "./node_modules/eslint/bin/eslint.js ./src --ext .js,.jsx --fix --config .eslintrc"
+      "./node_modules/eslint/bin/eslint.js ./src --ext .js,.jsx --config .eslintrc"
   },
   "dependencies": {
     "@babel/runtime": "7.0.0-beta.55",

--- a/ui/src/App.scss
+++ b/ui/src/App.scss
@@ -74,6 +74,10 @@
       font-size: 1rem;
     }
   }
+
+  .flex-grow-1 {
+    flex-grow: 1;
+  }
 }
 
 .ant-drawer-body {

--- a/ui/src/actions/__tests__/search.test.js
+++ b/ui/src/actions/__tests__/search.test.js
@@ -22,6 +22,12 @@ const stateWithScopeQuery = {
       },
     },
   }),
+  router: {
+    location: {
+      query: {},
+      previousUrl: '',
+    },
+  },
 };
 
 const stateWithoutScopeQuery = {
@@ -31,6 +37,12 @@ const stateWithoutScopeQuery = {
       query: {},
     },
   }),
+  router: {
+    location: {
+      query: {},
+      previousUrl: '',
+    },
+  },
 };
 
 describe('search - action creators', () => {

--- a/ui/src/authors/containers/DetailPage.jsx
+++ b/ui/src/authors/containers/DetailPage.jsx
@@ -114,8 +114,11 @@ class DetailPage extends Component {
                 pidType="literature"
                 baseQuery={authorLiteratureSearchQuery}
                 baseFacetsQuery={authorLiteratureFacetsQuery}
-                renderResultItem={result => (
-                  <LiteratureItem metadata={result.get('metadata')} />
+                renderResultItem={(result, rank) => (
+                  <LiteratureItem
+                    metadata={result.get('metadata')}
+                    searchRank={rank}
+                  />
                 )}
               />
             </ContentBox>

--- a/ui/src/common/__tests__/utils.test.js
+++ b/ui/src/common/__tests__/utils.test.js
@@ -13,6 +13,7 @@ import {
   httpErrorToActionPayload,
   hasAnyOfKeys,
   shallowEqual,
+  getSearchRank,
 } from '../utils';
 
 describe('utils', () => {
@@ -170,6 +171,48 @@ describe('utils', () => {
       const keys = [];
       const result = hasAnyOfKeys(map, keys);
       expect(result).toBe(false);
+    });
+  });
+
+  describe('getSearchRank', () => {
+    it('returns rank for first item', () => {
+      const index = 0;
+      const page = 1;
+      const pageSize = 10;
+      const result = getSearchRank(index, page, pageSize);
+      expect(result).toBe(1);
+    });
+
+    it('returns rank for second page first item', () => {
+      const index = 0;
+      const page = 2;
+      const pageSize = 10;
+      const result = getSearchRank(index, page, pageSize);
+      expect(result).toBe(11);
+    });
+
+    it('returns rank for a first page item', () => {
+      const index = 3;
+      const page = 1;
+      const pageSize = 10;
+      const result = getSearchRank(index, page, pageSize);
+      expect(result).toBe(4);
+    });
+
+    it('returns rank for an item', () => {
+      const index = 4;
+      const page = 5;
+      const pageSize = 10;
+      const result = getSearchRank(index, page, pageSize);
+      expect(result).toBe(45);
+    });
+
+    it('returns NaN if page parameters are undefined', () => {
+      const index = 4;
+      const page = undefined;
+      const pageSize = undefined;
+      const result = getSearchRank(index, page, pageSize);
+      expect(result).toBe(NaN);
     });
   });
 

--- a/ui/src/common/components/EmbeddedSearch.jsx
+++ b/ui/src/common/components/EmbeddedSearch.jsx
@@ -198,6 +198,8 @@ class EmbeddedSearch extends Component {
               <Col span={24}>
                 <SearchResults
                   renderItem={renderResultItem}
+                  page={query.page}
+                  pageSize={query.size}
                   results={results}
                 />
                 <SearchPagination

--- a/ui/src/common/components/SearchResults.jsx
+++ b/ui/src/common/components/SearchResults.jsx
@@ -2,14 +2,16 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Immutable from 'immutable';
 
+import { getSearchRank } from '../utils';
+
 class SearchResults extends Component {
   render() {
-    const { renderItem, results } = this.props;
+    const { renderItem, results, page, pageSize } = this.props;
     return (
       <div>
-        {results.map(result => (
+        {results.map((result, index) => (
           <div className="mv2" key={result.get('id')}>
-            {renderItem(result)}
+            {renderItem(result, getSearchRank(index, page, pageSize))}
           </div>
         ))}
       </div>
@@ -20,10 +22,13 @@ class SearchResults extends Component {
 SearchResults.propTypes = {
   results: PropTypes.instanceOf(Immutable.List),
   renderItem: PropTypes.func.isRequired,
+  page: PropTypes.number,
+  pageSize: PropTypes.number.isRequired,
 };
 
 SearchResults.defaultProps = {
   results: Immutable.List(),
+  page: 1,
 };
 
 export default SearchResults;

--- a/ui/src/common/components/__tests__/SearchResults.test.jsx
+++ b/ui/src/common/components/__tests__/SearchResults.test.jsx
@@ -20,6 +20,18 @@ describe('SearchResults', () => {
       <SearchResults
         results={results}
         renderItem={result => <span>{result.get('value')}</span>}
+        page={2}
+        pageSize={10}
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders with required props', () => {
+    const wrapper = shallow(
+      <SearchResults
+        renderItem={result => <span>{result.get('value')}</span>}
+        pageSize={15}
       />
     );
     expect(wrapper).toMatchSnapshot();

--- a/ui/src/common/components/__tests__/__snapshots__/EmbeddedSearch.test.jsx.snap
+++ b/ui/src/common/components/__tests__/__snapshots__/EmbeddedSearch.test.jsx.snap
@@ -62,6 +62,8 @@ exports[`EmbeddedSearch renders with current results if baseQuery is changed but
           span={24}
         >
           <SearchResults
+            page={1}
+            pageSize={10}
             renderItem={[MockFunction]}
             results={
               Immutable.List [
@@ -138,6 +140,8 @@ exports[`EmbeddedSearch renders with initial search results when base query prop
           span={24}
         >
           <SearchResults
+            page={1}
+            pageSize={10}
             renderItem={[MockFunction]}
             results={
               Immutable.List [
@@ -214,6 +218,8 @@ exports[`EmbeddedSearch renders with loading state true then initial search resu
           span={24}
         >
           <SearchResults
+            page={1}
+            pageSize={10}
             renderItem={[MockFunction]}
             results={Immutable.List []}
           />
@@ -284,6 +290,8 @@ exports[`EmbeddedSearch renders with loading state true then initial search resu
           span={24}
         >
           <SearchResults
+            page={1}
+            pageSize={10}
             renderItem={[MockFunction]}
             results={
               Immutable.List [
@@ -360,6 +368,8 @@ exports[`EmbeddedSearch renders with new results after aggregation change 1`] = 
           span={24}
         >
           <SearchResults
+            page={1}
+            pageSize={10}
             renderItem={[MockFunction]}
             results={
               Immutable.List [
@@ -436,6 +446,8 @@ exports[`EmbeddedSearch renders with new results after baseQuery prop change 1`]
           span={24}
         >
           <SearchResults
+            page={1}
+            pageSize={10}
             renderItem={[MockFunction]}
             results={
               Immutable.List [
@@ -512,6 +524,8 @@ exports[`EmbeddedSearch renders with new results after page change 1`] = `
           span={24}
         >
           <SearchResults
+            page={2}
+            pageSize={10}
             renderItem={[MockFunction]}
             results={
               Immutable.List [
@@ -588,6 +602,8 @@ exports[`EmbeddedSearch renders with new results after pidType prop change 1`] =
           span={24}
         >
           <SearchResults
+            page={1}
+            pageSize={10}
             renderItem={[MockFunction]}
             results={
               Immutable.List [
@@ -664,6 +680,8 @@ exports[`EmbeddedSearch renders with new results after sort change 1`] = `
           span={24}
         >
           <SearchResults
+            page={1}
+            pageSize={10}
             renderItem={[MockFunction]}
             results={
               Immutable.List [

--- a/ui/src/common/components/__tests__/__snapshots__/SearchResults.test.jsx.snap
+++ b/ui/src/common/components/__tests__/__snapshots__/SearchResults.test.jsx.snap
@@ -20,3 +20,5 @@ exports[`SearchResults renders with all props set 1`] = `
   </div>
 </div>
 `;
+
+exports[`SearchResults renders with required props 1`] = `<div />`;

--- a/ui/src/common/containers/ResultsContainer.jsx
+++ b/ui/src/common/containers/ResultsContainer.jsx
@@ -1,9 +1,12 @@
 import { connect } from 'react-redux';
 
 import SearchResults from '../components/SearchResults';
+import { castPropToNumber } from '../utils';
 
 const stateToProps = state => ({
   results: state.search.get('results'),
+  page: castPropToNumber(state.router.location.query.page),
+  pageSize: castPropToNumber(state.router.location.query.size),
 });
 
 export default connect(stateToProps)(SearchResults);

--- a/ui/src/common/utils.js
+++ b/ui/src/common/utils.js
@@ -129,6 +129,10 @@ export function shallowEqual(objA, objB) {
   return true;
 }
 
+export function getSearchRank(index, page, pageSize) {
+  return (page - 1) * pageSize + index + 1;
+}
+
 export function wait(milisec) {
   return new Promise(resolve => {
     setTimeout(() => resolve(), milisec);

--- a/ui/src/fixtures/store.js
+++ b/ui/src/fixtures/store.js
@@ -18,7 +18,9 @@ export function getState() {
     literature,
     router: {
       location: {
-        query: {},
+        query: {
+          size: 25,
+        },
         previousUrl: '',
       },
     },

--- a/ui/src/literature/components/LiteratureItem.jsx
+++ b/ui/src/literature/components/LiteratureItem.jsx
@@ -16,6 +16,7 @@ import ResultItem from '../../common/components/ResultItem';
 import { LITERATURE } from '../../common/routes';
 import EventTracker from '../../common/components/EventTracker';
 import LiteratureTitle from '../../common/components/LiteratureTitle';
+import ResponsiveView from '../../common/components/ResponsiveView';
 
 class LiteratureItem extends Component {
   renderBulletIfPublicationInfoAndEprintsNotEmpty() {
@@ -26,7 +27,7 @@ class LiteratureItem extends Component {
   }
 
   render() {
-    const { metadata } = this.props;
+    const { metadata, searchRank } = this.props;
 
     const title = metadata.getIn(['titles', 0]);
     const authors = metadata.get('authors');
@@ -67,9 +68,17 @@ class LiteratureItem extends Component {
           </Fragment>
         }
       >
-        <Link className="f5" to={`${LITERATURE}/${recordId}`}>
-          <LiteratureTitle title={title} />
-        </Link>
+        <div className="flex flex-nowrap">
+          <div className="flex-grow-1">
+            <Link className="f5" to={`${LITERATURE}/${recordId}`}>
+              <LiteratureTitle title={title} />
+            </Link>
+          </div>
+          <ResponsiveView
+            min="sm"
+            render={() => <div className="light-silver pl2">#{searchRank}</div>}
+          />
+        </div>
         <div className="mt1">
           <AuthorsAndCollaborations
             authorCount={authorCount}
@@ -96,6 +105,7 @@ class LiteratureItem extends Component {
 
 LiteratureItem.propTypes = {
   metadata: PropTypes.instanceOf(Map).isRequired,
+  searchRank: PropTypes.number.isRequired,
 };
 
 export default LiteratureItem;

--- a/ui/src/literature/components/__tests__/LiteratureItem.test.jsx
+++ b/ui/src/literature/components/__tests__/LiteratureItem.test.jsx
@@ -17,7 +17,9 @@ describe('LiteratureItem', () => {
       collaborations: [{ value: 'CMS' }],
       collaborations_with_suffix: [{ value: 'CMS Group' }],
     });
-    const wrapper = shallow(<LiteratureItem metadata={metadata} />);
+    const wrapper = shallow(
+      <LiteratureItem metadata={metadata} searchRank={2} />
+    );
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -26,7 +28,9 @@ describe('LiteratureItem', () => {
       control_number: 12345,
       titles: [{ title: 'test' }],
     });
-    const wrapper = shallow(<LiteratureItem metadata={metadata} />);
+    const wrapper = shallow(
+      <LiteratureItem metadata={metadata} searchRank={1} />
+    );
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -35,7 +39,9 @@ describe('LiteratureItem', () => {
       control_number: 12345,
       titles: [{ title: 'test' }],
     });
-    const wrapper = shallow(<LiteratureItem metadata={metadata} />);
+    const wrapper = shallow(
+      <LiteratureItem metadata={metadata} searchRank={2} />
+    );
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/ui/src/literature/components/__tests__/__snapshots__/LiteratureItem.test.jsx.snap
+++ b/ui/src/literature/components/__tests__/__snapshots__/LiteratureItem.test.jsx.snap
@@ -32,19 +32,31 @@ exports[`LiteratureItem does not arxiv pdf download action if there is no eprint
     </React.Fragment>
   }
 >
-  <Link
-    className="f5"
-    replace={false}
-    to="/literature/12345"
+  <div
+    className="flex flex-nowrap"
   >
-    <LiteratureTitle
-      title={
-        Immutable.Map {
-          "title": "test",
-        }
-      }
+    <div
+      className="flex-grow-1"
+    >
+      <Link
+        className="f5"
+        replace={false}
+        to="/literature/12345"
+      >
+        <LiteratureTitle
+          title={
+            Immutable.Map {
+              "title": "test",
+            }
+          }
+        />
+      </Link>
+    </div>
+    <ResponsiveView
+      min="sm"
+      render={[Function]}
     />
-  </Link>
+  </div>
   <div
     className="mt1"
   >
@@ -108,19 +120,31 @@ exports[`LiteratureItem renders 0 citations if it does not exist 1`] = `
     </React.Fragment>
   }
 >
-  <Link
-    className="f5"
-    replace={false}
-    to="/literature/12345"
+  <div
+    className="flex flex-nowrap"
   >
-    <LiteratureTitle
-      title={
-        Immutable.Map {
-          "title": "test",
-        }
-      }
+    <div
+      className="flex-grow-1"
+    >
+      <Link
+        className="f5"
+        replace={false}
+        to="/literature/12345"
+      >
+        <LiteratureTitle
+          title={
+            Immutable.Map {
+              "title": "test",
+            }
+          }
+        />
+      </Link>
+    </div>
+    <ResponsiveView
+      min="sm"
+      render={[Function]}
     />
-  </Link>
+  </div>
   <div
     className="mt1"
   >
@@ -187,19 +211,31 @@ exports[`LiteratureItem renders with all props set, including sub props 1`] = `
     </React.Fragment>
   }
 >
-  <Link
-    className="f5"
-    replace={false}
-    to="/literature/12345"
+  <div
+    className="flex flex-nowrap"
   >
-    <LiteratureTitle
-      title={
-        Immutable.Map {
-          "title": "test",
-        }
-      }
+    <div
+      className="flex-grow-1"
+    >
+      <Link
+        className="f5"
+        replace={false}
+        to="/literature/12345"
+      >
+        <LiteratureTitle
+          title={
+            Immutable.Map {
+              "title": "test",
+            }
+          }
+        />
+      </Link>
+    </div>
+    <ResponsiveView
+      min="sm"
+      render={[Function]}
     />
-  </Link>
+  </div>
   <div
     className="mt1"
   >

--- a/ui/src/literature/containers/SearchPage.jsx
+++ b/ui/src/literature/containers/SearchPage.jsx
@@ -7,8 +7,8 @@ class SearchPage extends Component {
   render() {
     return (
       <SearchLayout
-        renderResultItem={result => (
-          <LiteratureItem metadata={result.get('metadata')} />
+        renderResultItem={(result, rank) => (
+          <LiteratureItem metadata={result.get('metadata')} searchRank={rank} />
         )}
       />
     );


### PR DESCRIPTION
* Adds search rank for literature search results both on literature
search and author's literature, except small (phone) screens.

* Note that it uses native flexbox because antd's grid wraps Cols
without column size (span) and when it is set, it either takes extra
space for the searchRank unnecessarily and not guaranteed to work
properly for all screen sizes & title, rank lenght

* INSPIR-2062