### PR TITLE
ui: merge persisted state on top of initialState

### DIFF
--- a/ui/src/middlewares/statePersister.js
+++ b/ui/src/middlewares/statePersister.js
@@ -1,33 +1,31 @@
 import { fromJS } from 'immutable';
+import { REDUCERS_TO_PERSISTS } from '../reducers';
 
 export function getStorageKeyForReducer(reducerName) {
   return `state.${reducerName}`;
 }
 
-export function reHydrateRootStateFromStorage(reducerNames) {
-  return reducerNames
-    .map(reducerName => {
-      const rawSubState = localStorage.getItem(
-        getStorageKeyForReducer(reducerName)
-      );
-      
-      if (rawSubState === null) {
-        return { [reducerName]: undefined };
-      }
+export function reHydrateRootStateFromStorage() {
+  return REDUCERS_TO_PERSISTS.map(({ name, initialState }) => {
+    const rawSubState = localStorage.getItem(getStorageKeyForReducer(name));
 
-      const state = fromJS(JSON.parse(rawSubState));
-      return { [reducerName]: state };
-    })
-    .reduce((state, partialState) => Object.assign(state, partialState));
+    if (rawSubState === null) {
+      // set undefined in order to skip reHydrating
+      return { [name]: undefined };
+    }
+
+    const state = fromJS(JSON.parse(rawSubState));
+    // merge persisted on top of initialState in order to keep persisted state updated
+    // when initialState structure is changed
+    return { [name]: initialState.mergeDeep(state) };
+  }).reduce((state, partialState) => Object.assign(state, partialState));
 }
 
-export function createPersistToStorageMiddleware(
-  reducerNames,
-) {
+export function createPersistToStorageMiddleware() {
   const writeStateToStorage = async state => {
-    reducerNames.forEach(reducerName => {
-      const key = getStorageKeyForReducer(reducerName);
-      const serializedData = JSON.stringify(state[reducerName]);
+    REDUCERS_TO_PERSISTS.forEach(({ name }) => {
+      const key = getStorageKeyForReducer(name);
+      const serializedData = JSON.stringify(state[name]);
       localStorage.setItem(key, serializedData);
     });
   };

--- a/ui/src/reducers/index.js
+++ b/ui/src/reducers/index.js
@@ -5,11 +5,11 @@ import search from './search';
 import literature from './literature';
 import exceptions from './exceptions';
 import inspect from './inspect';
-import user from './user';
+import user, { initialState as userInitialState } from './user';
 import submissions from './submissions';
 import citations from './citations';
 import authors from './authors';
-import ui from './ui';
+import ui, { initialState as uiInitialState } from './ui';
 
 const reducers = combineReducers({
   router: routerReducer,
@@ -25,3 +25,8 @@ const reducers = combineReducers({
 });
 
 export default reducers;
+
+export const REDUCERS_TO_PERSISTS = [
+  { name: 'ui', initialState: uiInitialState },
+  { name: 'user', initialState: userInitialState },
+];


### PR DESCRIPTION
* While rehydrating the reducer state from locatStroge, it combines
initialState of reducer too, in order to keep updates to initialData to
the persisted state in localStorage. Otherwise store would always use
persisted one directly and ignore initialState, therefore anything
we'll add to it.