### PR TITLE
records: record create based on pid type

### DIFF
--- a/inspirehep/records/errors.py
+++ b/inspirehep/records/errors.py
@@ -27,3 +27,7 @@ class MissingArgumentError(ValueError):
 
 class MissingSerializerError(ValidationError):
     pass
+
+
+class WrongRecordSubclass(RecordsError):
+    pass

--- a/tests/integration/records/test_api_authors.py
+++ b/tests/integration/records/test_api_authors.py
@@ -19,7 +19,7 @@ from inspirehep.records.api import AuthorsRecord, InspireRecord
 
 
 def test_authors_create(base_app, db):
-    data = faker.record("lit")
+    data = faker.record("aut")
     record = AuthorsRecord.create(data)
 
     control_number = str(record["control_number"])
@@ -149,3 +149,27 @@ def test_get_record_from_db_depending_on_its_pid_type(base_app, db):
     record = InspireRecord.create(data)
     record_from_db = InspireRecord.get_record(record.id)
     assert type(record_from_db) == AuthorsRecord
+
+
+def test_create_record_from_db_depending_on_its_pid_type(base_app, db):
+    data = faker.record("aut")
+    record = InspireRecord.create(data)
+    assert type(record) == AuthorsRecord
+    assert record.pid_type == "aut"
+
+    record = AuthorsRecord.create(data)
+    assert type(record) == AuthorsRecord
+    assert record.pid_type == "aut"
+
+
+def test_create_or_update_record_from_db_depending_on_its_pid_type(base_app, db):
+    data = faker.record("aut")
+    record = InspireRecord.create_or_update(data)
+    assert type(record) == AuthorsRecord
+    assert record.pid_type == "aut"
+
+    data_update = {"name": {"value": "UPDATED"}}
+    data.update(data_update)
+    record = InspireRecord.create_or_update(data)
+    assert type(record) == AuthorsRecord
+    assert record.pid_type == "aut"

--- a/tests/integration/records/test_api_base.py
+++ b/tests/integration/records/test_api_base.py
@@ -24,7 +24,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from inspirehep.records.api import InspireRecord, LiteratureRecord
 from inspirehep.records.api.base import InspireQueryBuilder
-from inspirehep.records.errors import MissingSerializerError
+from inspirehep.records.errors import MissingSerializerError, WrongRecordSubclass
 from inspirehep.records.fixtures import init_storage_path
 
 
@@ -703,3 +703,9 @@ def test_record_throws_exception_when_serializer_is_not_set(
     record = InspireRecord(record_metadata.json)
     with pytest.raises(MissingSerializerError):
         record.get_serialized_data()
+
+
+def test_create_record_throws_exception_if_wrong_subclass_used(base_app, db):
+    data = faker.record("aut")
+    with pytest.raises(WrongRecordSubclass):
+        LiteratureRecord.create(data)

--- a/tests/integration/records/test_api_conferences.py
+++ b/tests/integration/records/test_api_conferences.py
@@ -137,3 +137,27 @@ def test_get_record_from_db_depending_on_its_pid_type(base_app, db):
     record = InspireRecord.create(data)
     record_from_db = InspireRecord.get_record(record.id)
     assert type(record_from_db) == ConferencesRecord
+
+
+def test_create_record_from_db_depending_on_its_pid_type(base_app, db):
+    data = faker.record("con")
+    record = InspireRecord.create(data)
+    assert type(record) == ConferencesRecord
+    assert record.pid_type == "con"
+
+    record = ConferencesRecord.create(data)
+    assert type(record) == ConferencesRecord
+    assert record.pid_type == "con"
+
+
+def test_create_or_update_record_from_db_depending_on_its_pid_type(base_app, db):
+    data = faker.record("con")
+    record = InspireRecord.create_or_update(data)
+    assert type(record) == ConferencesRecord
+    assert record.pid_type == "con"
+
+    data_update = {"titles": [{"title": "UPDATED"}]}
+    data.update(data_update)
+    record = InspireRecord.create_or_update(data)
+    assert type(record) == ConferencesRecord
+    assert record.pid_type == "con"

--- a/tests/integration/records/test_api_data.py
+++ b/tests/integration/records/test_api_data.py
@@ -137,3 +137,27 @@ def test_get_record_from_db_depending_on_its_pid_type(base_app, db):
     record = InspireRecord.create(data)
     record_from_db = InspireRecord.get_record(record.id)
     assert type(record_from_db) == DataRecord
+
+
+def test_create_record_from_db_depending_on_its_pid_type(base_app, db):
+    data = faker.record("dat")
+    record = InspireRecord.create(data)
+    assert type(record) == DataRecord
+    assert record.pid_type == "dat"
+
+    record = DataRecord.create(data)
+    assert type(record) == DataRecord
+    assert record.pid_type == "dat"
+
+
+def test_create_or_update_record_from_db_depending_on_its_pid_type(base_app, db):
+    data = faker.record("dat")
+    record = InspireRecord.create_or_update(data)
+    assert type(record) == DataRecord
+    assert record.pid_type == "dat"
+
+    data_update = {"deleted": True}
+    data.update(data_update)
+    record = InspireRecord.create_or_update(data)
+    assert type(record) == DataRecord
+    assert record.pid_type == "dat"

--- a/tests/integration/records/test_api_experiments.py
+++ b/tests/integration/records/test_api_experiments.py
@@ -137,3 +137,27 @@ def test_get_record_from_db_depending_on_its_pid_type(base_app, db):
     record = InspireRecord.create(data)
     record_from_db = InspireRecord.get_record(record.id)
     assert type(record_from_db) == ExperimentsRecord
+
+
+def test_create_record_from_db_depending_on_its_pid_type(base_app, db):
+    data = faker.record("exp")
+    record = InspireRecord.create(data)
+    assert type(record) == ExperimentsRecord
+    assert record.pid_type == "exp"
+
+    record = ExperimentsRecord.create(data)
+    assert type(record) == ExperimentsRecord
+    assert record.pid_type == "exp"
+
+
+def test_create_or_update_record_from_db_depending_on_its_pid_type(base_app, db):
+    data = faker.record("exp")
+    record = InspireRecord.create_or_update(data)
+    assert type(record) == ExperimentsRecord
+    assert record.pid_type == "exp"
+
+    data_update = {"deleted": True}
+    data.update(data_update)
+    record = InspireRecord.create_or_update(data)
+    assert type(record) == ExperimentsRecord
+    assert record.pid_type == "exp"

--- a/tests/integration/records/test_api_institutions.py
+++ b/tests/integration/records/test_api_institutions.py
@@ -139,3 +139,27 @@ def test_get_record_from_db_depending_on_its_pid_type(base_app, db):
     record = InspireRecord.create(data)
     record_from_db = InspireRecord.get_record(record.id)
     assert type(record_from_db) == InstitutionsRecord
+
+
+def test_create_record_from_db_depending_on_its_pid_type(base_app, db):
+    data = faker.record("ins")
+    record = InspireRecord.create(data)
+    assert type(record) == InstitutionsRecord
+    assert record.pid_type == "ins"
+
+    record = InstitutionsRecord.create(data)
+    assert type(record) == InstitutionsRecord
+    assert record.pid_type == "ins"
+
+
+def test_create_or_update_record_from_db_depending_on_its_pid_type(base_app, db):
+    data = faker.record("ins")
+    record = InspireRecord.create_or_update(data)
+    assert type(record) == InstitutionsRecord
+    assert record.pid_type == "ins"
+
+    data_update = {"deleted": True}
+    data.update(data_update)
+    record = InspireRecord.create_or_update(data)
+    assert type(record) == InstitutionsRecord
+    assert record.pid_type == "ins"

--- a/tests/integration/records/test_api_jobs.py
+++ b/tests/integration/records/test_api_jobs.py
@@ -137,3 +137,27 @@ def test_get_record_from_db_depending_on_its_pid_type(base_app, db):
     record = InspireRecord.create(data)
     record_from_db = InspireRecord.get_record(record.id)
     assert type(record_from_db) == JobsRecord
+
+
+def test_create_record_from_db_depending_on_its_pid_type(base_app, db):
+    data = faker.record("job")
+    record = InspireRecord.create(data)
+    assert type(record) == JobsRecord
+    assert record.pid_type == "job"
+
+    record = JobsRecord.create(data)
+    assert type(record) == JobsRecord
+    assert record.pid_type == "job"
+
+
+def test_create_or_update_record_from_db_depending_on_its_pid_type(base_app, db):
+    data = faker.record("job")
+    record = InspireRecord.create_or_update(data)
+    assert type(record) == JobsRecord
+    assert record.pid_type == "job"
+
+    data_update = {"description": "Updated"}
+    data.update(data_update)
+    record = InspireRecord.create_or_update(data)
+    assert type(record) == JobsRecord
+    assert record.pid_type == "job"

--- a/tests/integration/records/test_api_journals.py
+++ b/tests/integration/records/test_api_journals.py
@@ -137,3 +137,27 @@ def test_get_record_from_db_depending_on_its_pid_type(base_app, db):
     record = InspireRecord.create(data)
     record_from_db = InspireRecord.get_record(record.id)
     assert type(record_from_db) == JournalsRecord
+
+
+def test_create_record_from_db_depending_on_its_pid_type(base_app, db):
+    data = faker.record("jou")
+    record = InspireRecord.create(data)
+    assert type(record) == JournalsRecord
+    assert record.pid_type == "jou"
+
+    record = JournalsRecord.create(data)
+    assert type(record) == JournalsRecord
+    assert record.pid_type == "jou"
+
+
+def test_create_or_update_record_from_db_depending_on_its_pid_type(base_app, db):
+    data = faker.record("jou")
+    record = InspireRecord.create_or_update(data)
+    assert type(record) == JournalsRecord
+    assert record.pid_type == "jou"
+
+    data_update = {"short_title": "Updated"}
+    data.update(data_update)
+    record = InspireRecord.create_or_update(data)
+    assert type(record) == JournalsRecord
+    assert record.pid_type == "jou"

--- a/tests/integration/records/test_api_literature.py
+++ b/tests/integration/records/test_api_literature.py
@@ -593,3 +593,27 @@ def test_add_and_remove_figs_and_docs_when_files_flag_disabled(
         record["figures"]
 
     assert record["documents"][0]["key"] == expected_doc_filename
+
+
+def test_create_record_from_db_depending_on_its_pid_type(base_app, db):
+    data = faker.record("lit")
+    record = InspireRecord.create(data)
+    assert type(record) == LiteratureRecord
+    assert record.pid_type == "lit"
+
+    record = LiteratureRecord.create(data)
+    assert type(record) == LiteratureRecord
+    assert record.pid_type == "lit"
+
+
+def test_create_or_update_record_from_db_depending_on_its_pid_type(base_app, db):
+    data = faker.record("lit")
+    record = InspireRecord.create_or_update(data)
+    assert type(record) == LiteratureRecord
+    assert record.pid_type == "lit"
+
+    data_update = {"titles": [{"title": "UPDATED"}]}
+    data.update(data_update)
+    record = InspireRecord.create_or_update(data)
+    assert type(record) == LiteratureRecord
+    assert record.pid_type == "lit"


### PR DESCRIPTION
* Check type of record when doing InspireRecord.create / create_or_update and get_record so that we use the proper subclass
* INSPIR-2210