### PR TITLE
alembic: add alembic to inspirehep

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ These commands allow you to spin up a contenarized environment that reproduces t
 $ ./scripts/bootstrap
 $ ./docker-inspire up -d
 $ ./docker-inspire run --rm web ./scripts/setup
-$ ./docker-inspire run --rm web-next scripts/setup_inspire_next
 $ firefox localhost:8081
 ```
 

--- a/inspirehep/alembic/7be4c8b5c5e8_inspirehep_new_migrations.py
+++ b/inspirehep/alembic/7be4c8b5c5e8_inspirehep_new_migrations.py
@@ -1,0 +1,323 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CERN.
+#
+# inspirehep is free software; you can redistribute it and/or modify it under
+# the terms of the MIT License; see LICENSE file for more details.
+
+"""Inspirehep initial revision of migrations
+which makes db identical like in inspire-next"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "7be4c8b5c5e8"
+down_revision = None
+branch_labels = ("inspirehep_new",)
+depends_on = "dbdbc1b19cf2"
+
+
+def upgrade():
+    # """Upgrade database."""
+    op.create_table(
+        "workflows_workflow",
+        sa.Column("uuid", postgresql.UUID(), autoincrement=False, nullable=False),
+        sa.Column("name", sa.VARCHAR(length=255), autoincrement=False, nullable=False),
+        sa.Column(
+            "created", postgresql.TIMESTAMP(), autoincrement=False, nullable=False
+        ),
+        sa.Column(
+            "modified", postgresql.TIMESTAMP(), autoincrement=False, nullable=False
+        ),
+        sa.Column("id_user", sa.INTEGER(), autoincrement=False, nullable=False),
+        sa.Column(
+            "extra_data",
+            postgresql.JSON(astext_type=sa.Text()),
+            autoincrement=False,
+            nullable=False,
+        ),
+        sa.Column("status", sa.INTEGER(), autoincrement=False, nullable=False),
+        sa.PrimaryKeyConstraint("uuid", name="pk_workflows_workflow"),
+    )
+    op.create_table(
+        "workflows_object",
+        sa.Column(
+            "id",
+            sa.INTEGER(),
+            server_default=sa.text("nextval('workflows_object_id_seq'::regclass)"),
+            autoincrement=True,
+            nullable=False,
+        ),
+        sa.Column(
+            "data",
+            postgresql.JSON(astext_type=sa.Text()),
+            autoincrement=False,
+            nullable=False,
+        ),
+        sa.Column(
+            "extra_data",
+            postgresql.JSON(astext_type=sa.Text()),
+            autoincrement=False,
+            nullable=False,
+        ),
+        sa.Column("id_workflow", postgresql.UUID(), autoincrement=False, nullable=True),
+        sa.Column("status", sa.INTEGER(), autoincrement=False, nullable=False),
+        sa.Column("id_parent", sa.INTEGER(), autoincrement=False, nullable=True),
+        sa.Column("id_user", sa.INTEGER(), autoincrement=False, nullable=False),
+        sa.Column(
+            "created", postgresql.TIMESTAMP(), autoincrement=False, nullable=False
+        ),
+        sa.Column(
+            "modified", postgresql.TIMESTAMP(), autoincrement=False, nullable=False
+        ),
+        sa.Column(
+            "data_type", sa.VARCHAR(length=150), autoincrement=False, nullable=True
+        ),
+        sa.Column(
+            "callback_pos",
+            postgresql.JSON(astext_type=sa.Text()),
+            autoincrement=False,
+            nullable=True,
+        ),
+        sa.ForeignKeyConstraint(
+            ["id_parent"],
+            ["workflows_object.id"],
+            name="fk_workflows_object_id_parent_workflows_object",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["id_workflow"],
+            ["workflows_workflow.uuid"],
+            name="fk_workflows_object_id_workflow_workflows_workflow",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_workflows_object"),
+        postgresql_ignore_search_path=False,
+    )
+    op.create_index(
+        "ix_workflows_object_status", "workflows_object", ["status"], unique=False
+    )
+    op.create_index(
+        "ix_workflows_object_id_workflow",
+        "workflows_object",
+        ["id_workflow"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_workflows_object_id_parent", "workflows_object", ["id_parent"], unique=False
+    )
+    op.create_index(
+        "ix_workflows_object_data_type", "workflows_object", ["data_type"], unique=False
+    )
+    op.create_table(
+        "workflows_buckets",
+        sa.Column(
+            "workflow_object_id", sa.INTEGER(), autoincrement=False, nullable=False
+        ),
+        sa.Column("bucket_id", postgresql.UUID(), autoincrement=False, nullable=False),
+        sa.ForeignKeyConstraint(
+            ["bucket_id"],
+            ["files_bucket.id"],
+            name="fk_workflows_buckets_bucket_id_files_bucket",
+            onupdate="CASCADE",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["workflow_object_id"],
+            ["workflows_object.id"],
+            name="fk_workflows_buckets_workflow_object_id_workflows_object",
+            onupdate="CASCADE",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint(
+            "workflow_object_id", "bucket_id", name="pk_workflows_buckets"
+        ),
+    )
+    op.create_table(
+        "legacy_records_mirror",
+        sa.Column("recid", sa.INTEGER(), autoincrement=True, nullable=False),
+        sa.Column(
+            "last_updated", postgresql.TIMESTAMP(), autoincrement=False, nullable=False
+        ),
+        sa.Column("marcxml", postgresql.BYTEA(), autoincrement=False, nullable=False),
+        sa.Column("valid", sa.BOOLEAN(), autoincrement=False, nullable=True),
+        sa.Column("errors", sa.TEXT(), autoincrement=False, nullable=True),
+        sa.Column("collection", sa.TEXT(), autoincrement=False, nullable=True),
+        sa.PrimaryKeyConstraint("recid", name="pk_legacy_records_mirror"),
+    )
+    op.create_index(
+        "ix_legacy_records_mirror_valid_collection",
+        "legacy_records_mirror",
+        ["valid", "collection"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_legacy_records_mirror_last_updated",
+        "legacy_records_mirror",
+        ["last_updated"],
+        unique=False,
+    )
+    op.create_table(
+        "workflows_audit_logging",
+        sa.Column("id", sa.INTEGER(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.INTEGER(), autoincrement=False, nullable=True),
+        sa.Column(
+            "score",
+            postgresql.DOUBLE_PRECISION(precision=53),
+            autoincrement=False,
+            nullable=False,
+        ),
+        sa.Column("user_action", sa.TEXT(), autoincrement=False, nullable=False),
+        sa.Column("decision", sa.TEXT(), autoincrement=False, nullable=False),
+        sa.Column("source", sa.TEXT(), autoincrement=False, nullable=False),
+        sa.Column("action", sa.TEXT(), autoincrement=False, nullable=False),
+        sa.Column(
+            "created", postgresql.TIMESTAMP(), autoincrement=False, nullable=False
+        ),
+        sa.Column("object_id", sa.INTEGER(), autoincrement=False, nullable=False),
+        sa.ForeignKeyConstraint(
+            ["object_id"],
+            ["workflows_object.id"],
+            name="fk_workflows_audit_logging_object_id_workflows_object",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["accounts_user.id"],
+            name="fk_workflows_audit_logging_user_id_accounts_user",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_workflows_audit_logging"),
+    )
+    op.create_index(
+        "ix_workflows_audit_logging_user_id",
+        "workflows_audit_logging",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_workflows_audit_logging_object_id",
+        "workflows_audit_logging",
+        ["object_id"],
+        unique=False,
+    )
+    op.create_table(
+        "crawler_job",
+        sa.Column("id", sa.INTEGER(), autoincrement=True, nullable=False),
+        sa.Column("job_id", postgresql.UUID(), autoincrement=False, nullable=True),
+        sa.Column("spider", sa.VARCHAR(length=255), autoincrement=False, nullable=True),
+        sa.Column(
+            "workflow", sa.VARCHAR(length=255), autoincrement=False, nullable=True
+        ),
+        sa.Column("results", sa.TEXT(), autoincrement=False, nullable=True),
+        sa.Column("status", sa.VARCHAR(length=10), autoincrement=False, nullable=False),
+        sa.Column("logs", sa.TEXT(), autoincrement=False, nullable=True),
+        sa.Column(
+            "scheduled", postgresql.TIMESTAMP(), autoincrement=False, nullable=False
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_crawler_job"),
+    )
+    op.create_index(
+        "ix_crawler_job_workflow", "crawler_job", ["workflow"], unique=False
+    )
+    op.create_index("ix_crawler_job_spider", "crawler_job", ["spider"], unique=False)
+    op.create_index(
+        "ix_crawler_job_scheduled", "crawler_job", ["scheduled"], unique=False
+    )
+    op.create_index("ix_crawler_job_job_id", "crawler_job", ["job_id"], unique=False)
+    op.create_table(
+        "crawler_workflows_object",
+        sa.Column("job_id", postgresql.UUID(), autoincrement=False, nullable=False),
+        sa.Column("object_id", sa.INTEGER(), autoincrement=False, nullable=False),
+        sa.ForeignKeyConstraint(
+            ["object_id"],
+            ["workflows_object.id"],
+            name="fk_crawler_workflows_object_object_id_workflows_object",
+            onupdate="CASCADE",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint(
+            "job_id", "object_id", name="pk_crawler_workflows_object"
+        ),
+    )
+    op.create_table(
+        "workflows_pending_record",
+        sa.Column("workflow_id", sa.INTEGER(), autoincrement=False, nullable=False),
+        sa.Column("record_id", sa.INTEGER(), autoincrement=False, nullable=False),
+        sa.ForeignKeyConstraint(
+            ["workflow_id"],
+            ["workflows_object.id"],
+            name="fk_workflows_pending_record_workflow_id_workflows_object",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("workflow_id", name="pk_workflows_pending_record"),
+    )
+    op.create_table(
+        "workflows_record_sources",
+        sa.Column(
+            "source",
+            postgresql.ENUM("arxiv", "submitter", "publisher", name="source_enum"),
+            autoincrement=False,
+            nullable=False,
+        ),
+        sa.Column(
+            "record_uuid", postgresql.UUID(), autoincrement=False, nullable=False
+        ),
+        sa.Column(
+            "json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            autoincrement=False,
+            nullable=True,
+        ),
+        sa.Column(
+            "created", postgresql.TIMESTAMP(), autoincrement=False, nullable=True
+        ),
+        sa.Column(
+            "updated", postgresql.TIMESTAMP(), autoincrement=False, nullable=True
+        ),
+        sa.ForeignKeyConstraint(
+            ["record_uuid"],
+            ["records_metadata.id"],
+            name="fk_workflows_record_sources_record_uuid_records_metadata",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint(
+            "record_uuid", "source", name="pk_workflows_record_sources"
+        ),
+    )
+
+
+def downgrade():
+    # """Downgrade database."""
+    op.drop_table("workflows_record_sources")
+    op.drop_table("workflows_pending_record")
+    op.drop_table("crawler_workflows_object")
+    op.drop_index("ix_crawler_job_job_id", table_name="crawler_job")
+    op.drop_index("ix_crawler_job_scheduled", table_name="crawler_job")
+    op.drop_index("ix_crawler_job_spider", table_name="crawler_job")
+    op.drop_index("ix_crawler_job_workflow", table_name="crawler_job")
+    op.drop_table("crawler_job")
+    op.drop_index(
+        "ix_workflows_audit_logging_object_id", table_name="workflows_audit_logging"
+    )
+    op.drop_index(
+        "ix_workflows_audit_logging_user_id", table_name="workflows_audit_logging"
+    )
+    op.drop_table("workflows_audit_logging")
+    op.drop_index(
+        "ix_legacy_records_mirror_last_updated", table_name="legacy_records_mirror"
+    )
+    op.drop_index(
+        "ix_legacy_records_mirror_valid_collection", table_name="legacy_records_mirror"
+    )
+    op.drop_table("legacy_records_mirror")
+    op.drop_table("workflows_buckets")
+    op.drop_index("ix_workflows_object_data_type", table_name="workflows_object")
+    op.drop_index("ix_workflows_object_id_parent", table_name="workflows_object")
+    op.drop_index("ix_workflows_object_id_workflow", table_name="workflows_object")
+    op.drop_index("ix_workflows_object_status", table_name="workflows_object")
+    op.drop_table("workflows_object")
+    op.drop_table("workflows_workflow")
+    op.execute("DROP TYPE IF EXISTS source_enum")

--- a/inspirehep/alembic_helper/db.py
+++ b/inspirehep/alembic_helper/db.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CERN.
+#
+# inspirehep is free software; you can redistribute it and/or modify it under
+# the terms of the MIT License; see LICENSE file for more details.
+
+from flask import current_app
+from flask_alembic import Alembic
+
+
+def clean_db(db):
+    db.session.close()
+    db.reflect()
+    db.drop_all()
+    db.engine.execute(
+        """
+        DROP SEQUENCE IF EXISTS transaction_id_seq;
+        DROP TYPE IF EXISTS source_enum;
+        """
+    )
+    db.session.close()
+
+
+def setup_db():
+    alembic = Alembic(current_app)
+    alembic.upgrade()

--- a/inspirehep/alembic_helper/db.py
+++ b/inspirehep/alembic_helper/db.py
@@ -5,7 +5,6 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-from flask import current_app
 from flask_alembic import Alembic
 
 
@@ -22,6 +21,6 @@ def clean_db(db):
     db.session.close()
 
 
-def setup_db():
-    alembic = Alembic(current_app)
+def setup_db(app):
+    alembic = Alembic(app)
     alembic.upgrade()

--- a/inspirehep/alembic_helper/table_check.py
+++ b/inspirehep/alembic_helper/table_check.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CERN.
+#
+# inspirehep is free software; you can redistribute it and/or modify it under
+# the terms of the MIT License; see LICENSE file for more details.
+from flask import current_app
+
+
+def include_table_check(object, name, type_, *args, **kwargs):
+    if type == "table" and name in current_app.config.get("ALEMBIC_SKIP_TABLES"):
+        return False
+    return True

--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -22,6 +22,8 @@ from invenio_indexer.api import RecordIndexer
 from invenio_records_rest.facets import range_filter
 from invenio_records_rest.utils import allow_all, deny_all
 
+from inspirehep.alembic_helper.table_check import include_table_check
+
 from .search.api import LiteratureSearch
 from .search.facets import (
     hep_author_publications,
@@ -553,3 +555,25 @@ CELERY_IMPORTS = ["inspirehep.records.indexer.tasks"]
 # =============
 
 FEATURE_FLAG_ENABLE_FILES = False
+
+
+ALEMBIC_CONTEXT = {
+    "version_table": "inspirehep_alembic_version",
+    "include_object": include_table_check,
+}
+
+
+ALEMBIC_SKIP_TABLES = [
+    "workflows_record_sources",
+    "workflows_pending_record",
+    "crawler_workflows_object",
+    "crawler_job",
+    "workflows_audit_logging",
+    "legacy_records_mirror",
+    "workflows_buckets",
+    "workflows_object",
+    "workflows_workflow",
+    "records_metadata_version",
+    "transaction",
+    "alembic_version",
+]

--- a/scripts/setup
+++ b/scripts/setup
@@ -11,7 +11,8 @@ set -e
 # Clean redis
 poetry run inspirehep shell --no-term-title -c "import redis; redis.StrictRedis.from_url(app.config['CACHE_REDIS_URL']).flushall(); print('Cache cleared')"
 poetry run inspirehep db destroy --yes-i-know
-poetry run inspirehep db init create
+poetry run inspirehep db init
+poetry run inspirehep alembic upgrade
 poetry run inspirehep index destroy --force --yes-i-know
 poetry run inspirehep index init --force
 poetry run inspirehep index queue init purge

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
         "invenio_jsonschemas.schemas": ["inspire_records_schemas = inspire_schemas"],
         "invenio_search.mappings": ["records = inspirehep.search.mappings"],
         "invenio_celery.tasks": ["invenio_indexer = inspirehep.records.indexer.tasks"],
+        "invenio_db.alembic": ["inspirehep_new = inspirehep:alembic"],
     },
     classifiers=[
         "Environment :: Web Environment",

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         "invenio_jsonschemas.schemas": ["inspire_records_schemas = inspire_schemas"],
         "invenio_search.mappings": ["records = inspirehep.search.mappings"],
         "invenio_celery.tasks": ["invenio_indexer = inspirehep.records.indexer.tasks"],
-        "invenio_db.alembic": ["inspirehep_new = inspirehep:alembic"],
+        "invenio_db.alembic": ["inspirehep = inspirehep:alembic"],
     },
     classifiers=[
         "Environment :: Web Environment",

--- a/tests/integration-async/records/conftest.py
+++ b/tests/integration-async/records/conftest.py
@@ -34,7 +34,8 @@ logger = logging.getLogger(__name__)
 def app():
     app = invenio_create_app()
     app_config = {}
-    app_config["DEBUG"] = True
+    # Due to flask error it has to be False otherwise Alembic __init__ will fail.
+    app_config["DEBUG"] = False
     app_config["CELERY_BROKER_URL"] = "pyamqp://guest:guest@localhost:5672"
     app_config["CELERY_RESULT_BACKEND"] = "redis://localhost:6379/1"
     app_config["CELERY_CACHE_BACKEND"] = "memory"
@@ -51,7 +52,7 @@ def app():
 def clear_environment(app):
     with app.app_context():
         clean_db(db)
-        setup_db()
+        setup_db(app)
         _es = app.extensions["invenio-search"]
         list(_es.delete(ignore=[404]))
         list(_es.create(ignore=[400]))

--- a/tests/integration-async/records/conftest.py
+++ b/tests/integration-async/records/conftest.py
@@ -20,6 +20,7 @@ from invenio_app.factory import create_api as invenio_create_app
 from invenio_db import db
 from invenio_search import current_search_client as es
 
+from inspirehep.alembic_helper.db import clean_db, setup_db
 from inspirehep.records.api import LiteratureRecord
 from inspirehep.records.fixtures import (
     init_default_storage_path,
@@ -49,10 +50,8 @@ def app():
 @pytest.fixture(scope="function", autouse=True)
 def clear_environment(app):
     with app.app_context():
-        db.session.close()
-        db.drop_all()
-        db.init_app(app)
-        db.create_all()
+        clean_db(db)
+        setup_db()
         _es = app.extensions["invenio-search"]
         list(_es.delete(ignore=[404]))
         list(_es.create(ignore=[400]))

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -17,6 +17,7 @@ from helpers.factories.models.user_access_token import AccessTokenFactory, UserF
 from helpers.providers.faker import faker
 from invenio_app.factory import create_api as invenio_create_app
 
+from inspirehep.alembic_helper.db import clean_db, setup_db
 from inspirehep.records.api import LiteratureRecord
 
 
@@ -46,6 +47,25 @@ def disable_files(base_app):
 @pytest.fixture(scope="module")
 def create_app():
     return invenio_create_app
+
+
+@pytest.fixture(scope="module")
+def database(appctx):
+    """Setup database.
+    Scope: module
+    Normally, tests should use the function-scoped :py:data:`db` fixture
+    instead. This fixture takes care of creating the database/tables and
+    removing the tables once tests are done.
+    """
+    from invenio_db import db as db_
+
+    clean_db(db_)
+    setup_db()
+
+    yield db_
+
+    db_.session.remove()
+    clean_db(db_)
 
 
 @pytest.fixture(scope="function")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -26,6 +26,9 @@ def app_config(app_config):
     # add extra global config if you would like to customize the config
     # for a specific test you can chagne create fixture per-directory
     # using ``conftest.py`` or per-file.
+
+    # Due to flask error it has to be False otherwise Alembic __init__ will fail.
+    app_config["DEBUG"] = False
     app_config["JSONSCHEMAS_HOST"] = "localhost:5000"
     app_config["SEARCH_ELASTIC_HOSTS"] = "localhost:9200"
     app_config[
@@ -60,7 +63,7 @@ def database(appctx):
     from invenio_db import db as db_
 
     clean_db(db_)
-    setup_db()
+    setup_db(appctx)
 
     yield db_
 

--- a/tests/integration/test_alembic.py
+++ b/tests/integration/test_alembic.py
@@ -1,0 +1,109 @@
+from flask_alembic import Alembic
+from sqlalchemy import text
+
+from inspirehep.alembic_helper.db import clean_db
+
+
+def test_downgrade(app, db):
+    alembic = Alembic(app)
+
+    # test 7be4c8b5c5e8
+    alembic.downgrade(1)
+
+    assert "workflows_record_sources" not in _get_table_names(db)
+    assert "workflows_pending_record" not in _get_table_names(db)
+    assert "crawler_workflows_object" not in _get_table_names(db)
+    assert "crawler_job" not in _get_table_names(db)
+    assert "workflows_audit_logging" not in _get_table_names(db)
+    assert "legacy_records_mirror" not in _get_table_names(db)
+    assert "workflows_buckets" not in _get_table_names(db)
+    assert "workflows_object" not in _get_table_names(db)
+    assert "workflows_workflow" not in _get_table_names(db)
+
+    assert "ix_crawler_job_job_id" not in _get_indexes("crawler_job", db)
+    assert "ix_crawler_job_scheduled" not in _get_indexes("crawler_job", db)
+    assert "ix_crawler_job_spider" not in _get_indexes("crawler_job", db)
+    assert "ix_crawler_job_workflow" not in _get_indexes("crawler_job", db)
+    assert "ix_workflows_audit_logging_object_id" not in _get_indexes(
+        "workflows_audit_logging", db
+    )
+    assert "ix_workflows_audit_logging_user_id" not in _get_indexes(
+        "workflows_audit_logging", db
+    )
+    assert "ix_legacy_records_mirror_last_updated" not in _get_indexes(
+        "legacy_records_mirror", db
+    )
+    assert "ix_legacy_records_mirror_valid_collection" not in _get_indexes(
+        "legacy_records_mirror", db
+    )
+    assert "ix_workflows_object_data_type" not in _get_indexes("workflows_object", db)
+    assert "ix_workflows_object_id_parent" not in _get_indexes("workflows_object", db)
+    assert "ix_workflows_object_id_workflow" not in _get_indexes("workflows_object", db)
+    assert "ix_workflows_object_status" not in _get_indexes("workflows_object", db)
+
+
+def test_upgrade(app, db):
+    alembic = Alembic(app)
+    # go down before first migration
+    alembic.downgrade(target="7be4c8b5c5e8")
+    # test 7be4c8b5c5e8
+    alembic.upgrade(target="7be4c8b5c5e8")
+
+    assert "workflows_record_sources" in _get_table_names(db)
+    assert "workflows_pending_record" in _get_table_names(db)
+    assert "crawler_workflows_object" in _get_table_names(db)
+    assert "crawler_job" in _get_table_names(db)
+    assert "workflows_audit_logging" in _get_table_names(db)
+    assert "legacy_records_mirror" in _get_table_names(db)
+    assert "workflows_buckets" in _get_table_names(db)
+    assert "workflows_object" in _get_table_names(db)
+    assert "workflows_workflow" in _get_table_names(db)
+
+    assert "ix_crawler_job_job_id" in _get_indexes("crawler_job", db)
+    assert "ix_crawler_job_scheduled" in _get_indexes("crawler_job", db)
+    assert "ix_crawler_job_spider" in _get_indexes("crawler_job", db)
+    assert "ix_crawler_job_workflow" in _get_indexes("crawler_job", db)
+    assert "ix_workflows_audit_logging_object_id" in _get_indexes(
+        "workflows_audit_logging", db
+    )
+    assert "ix_workflows_audit_logging_user_id" in _get_indexes(
+        "workflows_audit_logging", db
+    )
+    assert "ix_legacy_records_mirror_last_updated" in _get_indexes(
+        "legacy_records_mirror", db
+    )
+    assert "ix_legacy_records_mirror_valid_collection" in _get_indexes(
+        "legacy_records_mirror", db
+    )
+    assert "ix_workflows_object_data_type" in _get_indexes("workflows_object", db)
+    assert "ix_workflows_object_id_parent" in _get_indexes("workflows_object", db)
+    assert "ix_workflows_object_id_workflow" in _get_indexes("workflows_object", db)
+    assert "ix_workflows_object_status" in _get_indexes("workflows_object", db)
+
+
+def _get_indexes(tablename, db):
+    query = text(
+        """
+        SELECT indexname
+        FROM pg_indexes
+        WHERE tablename=:tablename
+    """
+    ).bindparams(tablename=tablename)
+
+    return [el.indexname for el in db.session.execute(query)]
+
+
+def _get_sequences(db):
+    query = text(
+        """
+        SELECT relname
+        FROM pg_class
+        WHERE relkind='S'
+    """
+    )
+
+    return [el.relname for el in db.session.execute(query)]
+
+
+def _get_table_names(db):
+    return db.engine.table_names()


### PR DESCRIPTION
* ADD: Adds alembic to the project with all migrations which will bring all tables for inspirehep and tables for inspire-next because it's not possible to run migrations form inspirehep and inspire-next in the same db, ad both projects are using same modules and tables and this migrations won't work together.

* INSPIR-2213