### PR TITLE
search: source based on the Content-Type

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -526,29 +526,13 @@ RECORDS_DEFAULT_FILE_LOCATION_NAME = "records"
 RECORDS_DEFAULT_STORAGE_CLASS = "S"
 """Default storage class for record files."""
 SEARCH_SOURCE_INCLUDES = {
-    "literature": [
-        "$schema",
-        "abstracts.value",
-        "arxiv_eprints.value",
-        "arxiv_eprints.categories",
-        "authors.affiliations",
-        "authors.full_name",
-        "authors.control_number",
-        "collaborations",
-        "control_number",
-        "citation_count",
-        "dois.value",
-        "earliest_date",
-        "inspire_categories",
-        "number_of_references",
-        "publication_info",
-        "report_numbers",
-        "titles.title",
-        # Need these two for the search bibtex serializers
-        "_collections",
-        "document_type",
-        "authors.inspire_roles",
-    ]
+    "literature": {
+        "application/vnd+inspire.record.ui+json": [
+            "_ui_display",
+            # we need this for the record fetcher
+            "control_number",
+        ]
+    }
 }
 
 APP_HEALTH_BLUEPRINT_ENABLED = True

--- a/inspirehep/records/indexer/base.py
+++ b/inspirehep/records/indexer/base.py
@@ -24,7 +24,6 @@ class InspireRecordIndexer(RecordIndexer):
 
     def _prepare_record(self, record, index, doc_type):
         data = record.dumps_for_es()
-
         before_record_index.send(
             current_app._get_current_object(),
             json=data,

--- a/inspirehep/search/factories/search.py
+++ b/inspirehep/search/factories/search.py
@@ -16,13 +16,17 @@ from .filter import inspire_filter_factory
 
 def get_search_with_source(search):
     source = current_app.config.get("SEARCH_SOURCE_INCLUDES")
-    if not source:
+    has_accept_mimetypes = len(request.accept_mimetypes) > 0
+
+    if not source or not has_accept_mimetypes:
         return search
 
     if isinstance(search, LiteratureSearch):
-        source_literature = source.get("literature")
-        if source_literature:
-            search = search.source(includes=source_literature)
+        source_literature = source.get("literature", {})
+        accept_type = next(request.accept_mimetypes.values())
+        source_literature_mimetype = source_literature.get(accept_type)
+        if source_literature_mimetype:
+            search = search.source(includes=source_literature_mimetype)
     return search
 
 

--- a/tests/helpers/compare.py
+++ b/tests/helpers/compare.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CERN.
+#
+# inspirehep is free software; you can redistribute it and/or modify it under
+# the terms of the MIT License; see LICENSE file for more details.
+
+import json
+
+
+def compare_data_with_ui_display_field(expected, result):
+    """Comparing results with ``ui_display``.
+
+    Note:
+        `_ui_display` is being stringify (`json.dumps`), hence the order is
+        never the same.
+    """
+    expected_ui_display = expected.pop("_ui_display")
+    result_ui_display = json.loads(result.pop("_ui_display"))
+
+    assert expected_ui_display == result_ui_display
+    assert expected == result

--- a/tests/integration/pidstore/minters/test_minters_arxiv.py
+++ b/tests/integration/pidstore/minters/test_minters_arxiv.py
@@ -15,11 +15,11 @@ from inspirehep.pidstore.errors import MissingSchema
 from inspirehep.pidstore.minters.arxiv import ArxivMinter
 
 
-def test_minter_arxiv_eprints(base_app, db, create_record):
+def test_minter_arxiv_eprints(base_app, db, create_record_factory):
     arxiv_value_1 = faker.arxiv()
     arxiv_value_2 = faker.arxiv()
     data = {"arxiv_eprints": [{"value": arxiv_value_1}, {"value": arxiv_value_2}]}
-    record = create_record("lit", data=data)
+    record = create_record_factory("lit", data=data)
     data = record.json
 
     ArxivMinter.mint(record.id, data)
@@ -43,8 +43,8 @@ def test_minter_arxiv_eprints(base_app, db, create_record):
         assert pid.pid_value in epxected_pids_values
 
 
-def test_minter_arxiv_eprints_empty(base_app, db, create_record):
-    record = create_record("lit")
+def test_minter_arxiv_eprints_empty(base_app, db, create_record_factory):
+    record = create_record_factory("lit")
     data = record.json
 
     ArxivMinter.mint(record.id, data)
@@ -59,22 +59,22 @@ def test_minter_arxiv_eprints_empty(base_app, db, create_record):
     assert expected_pids_len == result_pids_len
 
 
-def test_mitner_arxiv_eprints_already_existing(base_app, db, create_record):
+def test_mitner_arxiv_eprints_already_existing(base_app, db, create_record_factory):
     arxiv_value = faker.arxiv()
     data = {"arxiv_eprints": [{"value": arxiv_value}]}
 
-    record_with_arxiv = create_record("lit", data=data)
+    record_with_arxiv = create_record_factory("lit", data=data)
     ArxivMinter.mint(record_with_arxiv.id, record_with_arxiv.json)
 
-    record_with_existing_arxiv = create_record("lit", data)
+    record_with_existing_arxiv = create_record_factory("lit", data)
     with pytest.raises(PIDAlreadyExists):
         ArxivMinter.mint(record_with_existing_arxiv.id, record_with_existing_arxiv.json)
 
 
-def test_mitner_arxiv_eprints_missing_schema(base_app, db, create_record):
+def test_mitner_arxiv_eprints_missing_schema(base_app, db, create_record_factory):
     arxiv_value = faker.arxiv()
     data = {"arxiv_eprints": [{"value": arxiv_value}]}
-    record = create_record("lit", data=data)
+    record = create_record_factory("lit", data=data)
 
     record_data = record.json
     record_id = record.id

--- a/tests/integration/pidstore/minters/test_minters_control_number.py
+++ b/tests/integration/pidstore/minters/test_minters_control_number.py
@@ -20,8 +20,10 @@ from inspirehep.pidstore.minters.control_number import (
 )
 
 
-def test_control_number_literature_without_control_number(base_app, db, create_record):
-    record = create_record("lit", with_pid=False)
+def test_control_number_literature_without_control_number(
+    base_app, db, create_record_factory
+):
+    record = create_record_factory("lit", with_pid=False)
     data = record.json
 
     LiteratureMinter.mint(record.id, data)
@@ -37,9 +39,11 @@ def test_control_number_literature_without_control_number(base_app, db, create_r
     assert expected_pid_object_uuid == result_pid.object_uuid
 
 
-def test_control_number_literature_with_control_number(base_app, db, create_record):
+def test_control_number_literature_with_control_number(
+    base_app, db, create_record_factory
+):
     data = {"control_number": 1}
-    record = create_record("lit", data=data, with_pid=False)
+    record = create_record_factory("lit", data=data, with_pid=False)
     data = record.json
 
     LiteratureMinter.mint(record.id, data)
@@ -54,8 +58,10 @@ def test_control_number_literature_with_control_number(base_app, db, create_reco
     assert expected_pid_object_uuid == result_pid.object_uuid
 
 
-def test_control_number_authors_without_control_number(base_app, db, create_record):
-    record = create_record("aut", with_pid=False)
+def test_control_number_authors_without_control_number(
+    base_app, db, create_record_factory
+):
+    record = create_record_factory("aut", with_pid=False)
     data = record.json
 
     AuthorsMinter.mint(record.id, data)
@@ -71,9 +77,11 @@ def test_control_number_authors_without_control_number(base_app, db, create_reco
     assert expected_pid_object_uuid == result_pid.object_uuid
 
 
-def test_control_number_authors_with_control_number(base_app, db, create_record):
+def test_control_number_authors_with_control_number(
+    base_app, db, create_record_factory
+):
     data = {"control_number": 1}
-    record = create_record("aut", data=data, with_pid=False)
+    record = create_record_factory("aut", data=data, with_pid=False)
     data = record.json
 
     AuthorsMinter.mint(record.id, data)
@@ -88,9 +96,9 @@ def test_control_number_authors_with_control_number(base_app, db, create_record)
     assert expected_pid_object_uuid == result_pid.object_uuid
 
 
-def test_control_number_jobs_with_control_number(base_app, db, create_record):
+def test_control_number_jobs_with_control_number(base_app, db, create_record_factory):
     data = {"control_number": 1}
-    record = create_record("job", data=data, with_pid=False)
+    record = create_record_factory("job", data=data, with_pid=False)
     data = record.json
 
     JobsMinter.mint(record.id, data)
@@ -105,8 +113,10 @@ def test_control_number_jobs_with_control_number(base_app, db, create_record):
     assert expected_pid_object_uuid == result_pid.object_uuid
 
 
-def test_control_number_jobs_without_control_number(base_app, db, create_record):
-    record = create_record("job", with_pid=False)
+def test_control_number_jobs_without_control_number(
+    base_app, db, create_record_factory
+):
+    record = create_record_factory("job", with_pid=False)
     data = record.json
 
     JobsMinter.mint(record.id, data)
@@ -122,9 +132,11 @@ def test_control_number_jobs_without_control_number(base_app, db, create_record)
     assert expected_pid_object_uuid == result_pid.object_uuid
 
 
-def test_control_number_journals_with_control_number(base_app, db, create_record):
+def test_control_number_journals_with_control_number(
+    base_app, db, create_record_factory
+):
     data = {"control_number": 1}
-    record = create_record("jou", data=data, with_pid=False)
+    record = create_record_factory("jou", data=data, with_pid=False)
     data = record.json
 
     JournalsMinter.mint(record.id, data)
@@ -139,8 +151,10 @@ def test_control_number_journals_with_control_number(base_app, db, create_record
     assert expected_pid_object_uuid == result_pid.object_uuid
 
 
-def test_control_number_journals_without_control_number(base_app, db, create_record):
-    record = create_record("jou", with_pid=False)
+def test_control_number_journals_without_control_number(
+    base_app, db, create_record_factory
+):
+    record = create_record_factory("jou", with_pid=False)
     data = record.json
 
     JournalsMinter.mint(record.id, data)
@@ -156,9 +170,11 @@ def test_control_number_journals_without_control_number(base_app, db, create_rec
     assert expected_pid_object_uuid == result_pid.object_uuid
 
 
-def test_control_number_experiments_with_control_number(base_app, db, create_record):
+def test_control_number_experiments_with_control_number(
+    base_app, db, create_record_factory
+):
     data = {"control_number": 1}
-    record = create_record("exp", data=data, with_pid=False)
+    record = create_record_factory("exp", data=data, with_pid=False)
     data = record.json
 
     ExperimentsMinter.mint(record.id, data)
@@ -173,8 +189,10 @@ def test_control_number_experiments_with_control_number(base_app, db, create_rec
     assert expected_pid_object_uuid == result_pid.object_uuid
 
 
-def test_control_number_experiments_without_control_number(base_app, db, create_record):
-    record = create_record("exp", with_pid=False)
+def test_control_number_experiments_without_control_number(
+    base_app, db, create_record_factory
+):
+    record = create_record_factory("exp", with_pid=False)
     data = record.json
 
     ExperimentsMinter.mint(record.id, data)
@@ -190,9 +208,11 @@ def test_control_number_experiments_without_control_number(base_app, db, create_
     assert expected_pid_object_uuid == result_pid.object_uuid
 
 
-def test_control_number_conferences_with_control_number(base_app, db, create_record):
+def test_control_number_conferences_with_control_number(
+    base_app, db, create_record_factory
+):
     data = {"control_number": 1}
-    record = create_record("con", data=data, with_pid=False)
+    record = create_record_factory("con", data=data, with_pid=False)
     data = record.json
 
     ConferencesMinter.mint(record.id, data)
@@ -207,8 +227,10 @@ def test_control_number_conferences_with_control_number(base_app, db, create_rec
     assert expected_pid_object_uuid == result_pid.object_uuid
 
 
-def test_control_number_conferences_without_control_number(base_app, db, create_record):
-    record = create_record("con", with_pid=False)
+def test_control_number_conferences_without_control_number(
+    base_app, db, create_record_factory
+):
+    record = create_record_factory("con", with_pid=False)
     data = record.json
 
     ConferencesMinter.mint(record.id, data)
@@ -224,9 +246,9 @@ def test_control_number_conferences_without_control_number(base_app, db, create_
     assert expected_pid_object_uuid == result_pid.object_uuid
 
 
-def test_control_number_data_with_control_number(base_app, db, create_record):
+def test_control_number_data_with_control_number(base_app, db, create_record_factory):
     data = {"control_number": 1}
-    record = create_record("dat", data=data, with_pid=False)
+    record = create_record_factory("dat", data=data, with_pid=False)
     data = record.json
 
     DataMinter.mint(record.id, data)
@@ -241,8 +263,10 @@ def test_control_number_data_with_control_number(base_app, db, create_record):
     assert expected_pid_object_uuid == result_pid.object_uuid
 
 
-def test_control_number_data_without_control_number(base_app, db, create_record):
-    record = create_record("dat", with_pid=False)
+def test_control_number_data_without_control_number(
+    base_app, db, create_record_factory
+):
+    record = create_record_factory("dat", with_pid=False)
     data = record.json
 
     DataMinter.mint(record.id, data)
@@ -258,9 +282,11 @@ def test_control_number_data_without_control_number(base_app, db, create_record)
     assert expected_pid_object_uuid == result_pid.object_uuid
 
 
-def test_control_number_institutions_with_control_number(base_app, db, create_record):
+def test_control_number_institutions_with_control_number(
+    base_app, db, create_record_factory
+):
     data = {"control_number": 1}
-    record = create_record("ins", data=data, with_pid=False)
+    record = create_record_factory("ins", data=data, with_pid=False)
     data = record.json
 
     InstitutionsMinter.mint(record.id, data)
@@ -276,9 +302,9 @@ def test_control_number_institutions_with_control_number(base_app, db, create_re
 
 
 def test_control_number_institutions_without_control_number(
-    base_app, db, create_record
+    base_app, db, create_record_factory
 ):
-    record = create_record("ins", with_pid=False)
+    record = create_record_factory("ins", with_pid=False)
     data = record.json
 
     InstitutionsMinter.mint(record.id, data)

--- a/tests/integration/pidstore/minters/test_minters_doi.py
+++ b/tests/integration/pidstore/minters/test_minters_doi.py
@@ -15,11 +15,11 @@ from inspirehep.pidstore.errors import MissingSchema
 from inspirehep.pidstore.minters.doi import DoiMinter
 
 
-def test_minter_dois(base_app, db, create_record):
+def test_minter_dois(base_app, db, create_record_factory):
     doi_value_1 = faker.doi()
     doi_value_2 = faker.doi()
     data = {"dois": [{"value": doi_value_1}, {"value": doi_value_2}]}
-    record = create_record("lit", data=data)
+    record = create_record_factory("lit", data=data)
     data = record.json
 
     DoiMinter.mint(record.id, data)
@@ -43,8 +43,8 @@ def test_minter_dois(base_app, db, create_record):
         assert pid.pid_value in epxected_pids_values
 
 
-def test_minter_dois_empty(base_app, db, create_record):
-    record = create_record("lit")
+def test_minter_dois_empty(base_app, db, create_record_factory):
+    record = create_record_factory("lit")
     data = record.json
 
     DoiMinter.mint(record.id, data)
@@ -59,22 +59,22 @@ def test_minter_dois_empty(base_app, db, create_record):
     assert expected_pids_len == result_pids_len
 
 
-def test_mitner_dois_already_existing(base_app, db, create_record):
+def test_mitner_dois_already_existing(base_app, db, create_record_factory):
     doi_value = faker.doi()
     data = {"dois": [{"value": doi_value}]}
 
-    record_with_doi = create_record("lit", data=data)
+    record_with_doi = create_record_factory("lit", data=data)
     DoiMinter.mint(record_with_doi.id, record_with_doi.json)
 
-    record_with_existing_doi = create_record("lit", data)
+    record_with_existing_doi = create_record_factory("lit", data)
     with pytest.raises(PIDAlreadyExists):
         DoiMinter.mint(record_with_existing_doi.id, record_with_existing_doi.json)
 
 
-def test_mitner_dois_missing_schema(base_app, db, create_record):
+def test_mitner_dois_missing_schema(base_app, db, create_record_factory):
     doi_value = faker.doi()
     data = {"dois": [{"value": doi_value}]}
-    record = create_record("lit", data=data)
+    record = create_record_factory("lit", data=data)
 
     record_data = record.json
     record_id = record.id

--- a/tests/integration/pidstore/minters/test_minters_orcid.py
+++ b/tests/integration/pidstore/minters/test_minters_orcid.py
@@ -15,7 +15,7 @@ from inspirehep.pidstore.errors import MissingSchema
 from inspirehep.pidstore.minters.orcid import OrcidMinter
 
 
-def test_minter_orcid(base_app, db, create_record):
+def test_minter_orcid(base_app, db, create_record_factory):
     orcid_value = faker.orcid()
     data = {
         "ids": [
@@ -23,7 +23,7 @@ def test_minter_orcid(base_app, db, create_record):
             {"schema": "ORCID", "value": orcid_value},
         ]
     }
-    record = create_record("aut", data=data)
+    record = create_record_factory("aut", data=data)
     data = record.json
 
     OrcidMinter.mint(record.id, data)
@@ -48,8 +48,8 @@ def test_minter_orcid(base_app, db, create_record):
     assert pid.pid_value in epxected_pids_values
 
 
-def test_minter_orcid_empty(base_app, db, create_record):
-    record = create_record("aut")
+def test_minter_orcid_empty(base_app, db, create_record_factory):
+    record = create_record_factory("aut")
     data = record.json
 
     OrcidMinter.mint(record.id, data)
@@ -64,22 +64,22 @@ def test_minter_orcid_empty(base_app, db, create_record):
     assert expected_pids_len == result_pids_len
 
 
-def test_minter_orcid_already_existing(base_app, db, create_record):
+def test_minter_orcid_already_existing(base_app, db, create_record_factory):
     orcid_value = faker.orcid()
     data = {"ids": [{"value": orcid_value, "schema": "ORCID"}]}
 
-    record_with_orcid = create_record("aut", data=data)
+    record_with_orcid = create_record_factory("aut", data=data)
     OrcidMinter.mint(record_with_orcid.id, record_with_orcid.json)
 
-    record_with_existing_orcid = create_record("aut", data)
+    record_with_existing_orcid = create_record_factory("aut", data)
     with pytest.raises(PIDAlreadyExists):
         OrcidMinter.mint(record_with_existing_orcid.id, record_with_existing_orcid.json)
 
 
-def test_minter_orcid_missing_schema(base_app, db, create_record):
+def test_minter_orcid_missing_schema(base_app, db, create_record_factory):
     orcid_value = faker.orcid()
     data = {"ids": [{"value": orcid_value, "schema": "ORCID"}]}
-    record = create_record("aut", data=data)
+    record = create_record_factory("aut", data=data)
 
     record_data = record.json
     record_id = record.id

--- a/tests/integration/records/serializers/test_bibtex.py
+++ b/tests/integration/records/serializers/test_bibtex.py
@@ -6,10 +6,10 @@
 # the terms of the MIT License; see LICENSE file for more details.
 
 
-def test_bibtex(api_client, db, create_record):
+def test_bibtex(api_client, db, create_record_factory):
     headers = {"Accept": "application/x-bibtex"}
     data = {"control_number": 637275237, "titles": [{"title": "This is a title."}]}
-    record = create_record("lit", data=data, with_indexing=True)
+    record = create_record_factory("lit", data=data, with_indexing=True)
     record_control_number = record.json["control_number"]
 
     expected_status_code = 200
@@ -29,12 +29,12 @@ def test_bibtex(api_client, db, create_record):
     assert expected_result == response_data
 
 
-def test_bibtex_search(api_client, db, create_record):
+def test_bibtex_search(api_client, db, create_record_factory):
     headers = {"Accept": "application/x-bibtex"}
     data_1 = {"control_number": 637275237, "titles": [{"title": "This is a title."}]}
     data_2 = {"control_number": 637275232, "titles": [{"title": "Yet another title."}]}
-    record_1 = create_record("lit", data=data_1, with_indexing=True)
-    record_2 = create_record("lit", data=data_2, with_indexing=True)
+    record_1 = create_record_factory("lit", data=data_1, with_indexing=True)
+    record_2 = create_record_factory("lit", data=data_2, with_indexing=True)
 
     expected_status_code = 200
     expected_result_1 = "@article{637275237,\n" '    title = "This is a title."\n' "}\n"

--- a/tests/integration/records/serializers/test_latex.py
+++ b/tests/integration/records/serializers/test_latex.py
@@ -9,11 +9,11 @@ from freezegun import freeze_time
 
 
 @freeze_time("1994-12-19")
-def test_latex_eu(api_client, db, create_record):
+def test_latex_eu(api_client, db, create_record_factory):
     headers = {"Accept": "application/vnd+inspire.latex.eu+x-latex"}
     data = {"control_number": 637275237, "titles": [{"title": "This is a title."}]}
 
-    record = create_record("lit", data=data, with_indexing=True)
+    record = create_record_factory("lit", data=data, with_indexing=True)
     record_control_number = record.json["control_number"]
 
     expected_status_code = 200
@@ -40,11 +40,11 @@ def test_latex_eu(api_client, db, create_record):
 
 
 @freeze_time("1994-12-19")
-def test_latex_us(api_client, db, create_record):
+def test_latex_us(api_client, db, create_record_factory):
     headers = {"Accept": "application/vnd+inspire.latex.us+x-latex"}
     data = {"control_number": 637275237, "titles": [{"title": "This is a title."}]}
 
-    record = create_record("lit", data=data, with_indexing=True)
+    record = create_record_factory("lit", data=data, with_indexing=True)
     record_control_number = record.json["control_number"]
 
     expected_status_code = 200

--- a/tests/integration/records/test_indexer.py
+++ b/tests/integration/records/test_indexer.py
@@ -10,9 +10,9 @@ from copy import deepcopy
 from invenio_search import current_search_client as es
 
 
-def test_index_experiment_record(es_clear, db, datadir, create_record):
+def test_index_experiment_record(es_clear, db, datadir, create_record_factory):
     data = json.loads((datadir / "1108541.json").read_text())
-    record = create_record("exp", data=data, with_indexing=True)
+    record = create_record_factory("exp", data=data, with_indexing=True)
     response = es.search("records-experiments")
     expected_count = 1
     expected_metadata = deepcopy(record.json)
@@ -20,9 +20,9 @@ def test_index_experiment_record(es_clear, db, datadir, create_record):
     assert response["hits"]["hits"][0]["_source"] == expected_metadata
 
 
-def test_index_conference_record(es_clear, db, datadir, create_record):
+def test_index_conference_record(es_clear, db, datadir, create_record_factory):
     data = json.loads((datadir / "1203206.json").read_text())
-    record = create_record("con", data=data, with_indexing=True)
+    record = create_record_factory("con", data=data, with_indexing=True)
 
     response = es.search("records-conferences")
     expected_count = 1
@@ -31,9 +31,9 @@ def test_index_conference_record(es_clear, db, datadir, create_record):
     assert response["hits"]["hits"][0]["_source"] == expected_metadata
 
 
-def test_index_literature_record(es_clear, db, datadir, create_record):
+def test_index_literature_record(es_clear, db, datadir, create_record_factory):
     data = json.loads((datadir / "1630825.json").read_text())
-    record = create_record("lit", data=data, with_indexing=True)
+    record = create_record_factory("lit", data=data, with_indexing=True)
 
     response = es.search("records-hep")
     expected_count = 1

--- a/tests/integration/search/test_factories_search.py
+++ b/tests/integration/search/test_factories_search.py
@@ -17,9 +17,20 @@ from inspirehep.search.factories.search import (
 )
 
 
-def test_get_search_with_source_with_LiteratureSearch_instance(base_app):
-    config = {"SEARCH_SOURCE_INCLUDES": {"literature": ["title", "description"]}}
-    with patch.dict(base_app.config, config), base_app.test_request_context():
+def test_get_search_with_source_with_LiteratureSearch_instance_with_defined_headers(
+    base_app
+):
+    config = {
+        "SEARCH_SOURCE_INCLUDES": {
+            "literature": {
+                "application/vnd+inspire.record.ui+json": ["title", "description"]
+            }
+        }
+    }
+    headers = {"Accept": "application/vnd+inspire.record.ui+json"}
+    with patch.dict(base_app.config, config), base_app.test_request_context(
+        headers=headers
+    ):
         search = LiteratureSearch()
         search = get_search_with_source(search)
 
@@ -31,9 +42,20 @@ def test_get_search_with_source_with_LiteratureSearch_instance(base_app):
         assert expected_source_includes == search_source_includes
 
 
-def test_get_search_with_source_with_LiteratureSearch_instance_without_config(base_app):
-    config = {"SEARCH_SOURCE_INCLUDES": {"something_else": ["title", "description"]}}
-    with patch.dict(base_app.config, config), base_app.test_request_context():
+def test_get_search_with_source_with_LiteratureSearch_instance_with_not_defined_headers(
+    base_app
+):
+    config = {
+        "SEARCH_SOURCE_INCLUDES": {
+            "literature": {
+                "application/vnd+inspire.record.ui+json": ["title", "description"]
+            }
+        }
+    }
+    headers = {"Accept": "application/json"}
+    with patch.dict(base_app.config, config), base_app.test_request_context(
+        headers=headers
+    ):
         search = LiteratureSearch()
         search = get_search_with_source(search)
 
@@ -41,10 +63,10 @@ def test_get_search_with_source_with_LiteratureSearch_instance_without_config(ba
         assert "_source" not in search_to_dict
 
 
-def test_get_search_with_source_with_other_search_instance(base_app):
-    config = {"SEARCH_SOURCE_INCLUDES": {"literature": ["title", "description"]}}
+def test_get_search_with_source_with_LiteratureSearch_instance_without_config(base_app):
+    config = {"SEARCH_SOURCE_INCLUDES": None}
     with patch.dict(base_app.config, config), base_app.test_request_context():
-        search = InspireSearch()
+        search = LiteratureSearch()
         search = get_search_with_source(search)
 
         search_to_dict = search.to_dict()

--- a/tests/integration/submissions/test_submissions_views.py
+++ b/tests/integration/submissions/test_submissions_views.py
@@ -152,7 +152,7 @@ def test_new_author_submit_works_with_session_login(
     assert response.status_code == 200
 
 
-def test_get_author_update_data(app, api_client, create_user, create_record):
+def test_get_author_update_data(app, api_client, create_user, create_record_factory):
     user = create_user()
     login_user_via_session(api_client, email=user.email)
 
@@ -161,7 +161,7 @@ def test_get_author_update_data(app, api_client, create_user, create_record):
         "name": {"value": "John", "preferred_name": "John Doe"},
         "status": "active",
     }
-    create_record("aut", data=author_data)
+    create_record_factory("aut", data=author_data)
 
     expected_data = {
         "data": {"given_name": "John", "display_name": "John Doe", "status": "active"}


### PR DESCRIPTION
* BREAKING: Renames ``create_record`` fixture factory to ``create_record_factory``.

* Creates ``create_record`` fixture to create records from the application level.

* Adds elastic search source based on the ``Content-Type``.

Signed-off-by: Harris Tzovanakis <me@drjova.com>