### PR TITLE
Display conference info

### DIFF
--- a/tests/unit/records/marshmallow/literature/common/test_conference_info_item.py
+++ b/tests/unit/records/marshmallow/literature/common/test_conference_info_item.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CERN.
+#
+# inspirehep is free software; you can redistribute it and/or modify it under
+# the terms of the MIT License; see LICENSE file for more details.
+
+import json
+
+from invenio_pidstore.errors import PIDDoesNotExistError
+from mock import patch
+
+from inspirehep.records.marshmallow.literature.common import ConferenceInfoItemSchemaV1
+
+
+def test_returns_empty_if_conference_record_is_missing():
+    schema = ConferenceInfoItemSchemaV1()
+    dump = {"journal_title": "Test JT", "journal_volume": "Test JV"}
+    expected = {}
+
+    result = schema.dumps(dump).data
+
+    assert expected == json.loads(result)
+
+
+@patch("inspirehep.records.api.base.InspireRecord.get_record_by_pid_value")
+def test_returns_non_empty_fields_if_conference_record_found(
+    mock_get_record_by_pid_value
+):
+    mock_get_record_by_pid_value.return_value = {
+        "titles": [{"title": "Conference Title"}],
+        "acronyms": ["Conf"],
+    }
+    schema = ConferenceInfoItemSchemaV1()
+    dump = {
+        "cnum": "C16-07-04.5",
+        "conference_record": {
+            "$ref": "http://labs.inspirehep.net/api/conferences/1423473"
+        },
+        "page_end": "517",
+        "page_start": "512",
+    }
+
+    expected = {
+        "page_start": "512",
+        "titles": [{"title": "Conference Title"}],
+        "acronyms": ["Conf"],
+        "page_end": "517",
+    }
+
+    result = schema.dumps(dump).data
+
+    assert expected == json.loads(result)
+
+
+def side_effect_get_record_by_pid_value(pid_value, pid_type):
+    raise PIDDoesNotExistError(pid_value, pid_type)
+
+
+@patch("inspirehep.records.api.base.InspireRecord.get_record_by_pid_value")
+def test_returns_empty_if_conference_record_not_found(mock_get_record_by_pid_value):
+    mock_get_record_by_pid_value.side_effect = side_effect_get_record_by_pid_value
+    schema = ConferenceInfoItemSchemaV1()
+    dump = {
+        "cnum": "C16-07-04.5",
+        "conference_record": {
+            "$ref": "http://labs.inspirehep.net/api/conferences/1423473"
+        },
+        "page_end": "517",
+        "page_start": "512",
+    }
+
+    expected = {}
+
+    result = schema.dumps(dump).data
+
+    assert expected == json.loads(result)
+
+
+@patch("inspirehep.records.api.base.InspireRecord.get_record_by_pid_value")
+def test_returns_empty_if_titles_is_missing(mock_get_record_by_pid_value):
+    mock_get_record_by_pid_value.return_value = {"_collections": "Conferences"}
+    schema = ConferenceInfoItemSchemaV1()
+    dump = {
+        "cnum": "C16-07-04.5",
+        "conference_record": {
+            "$ref": "http://labs.inspirehep.net/api/conferences/1423473"
+        },
+        "page_end": "517",
+        "page_start": "512",
+    }
+    expected = {}
+
+    result = schema.dumps(dump).data
+
+    assert expected == json.loads(result)

--- a/ui/src/common/components/PublicationInfo.jsx
+++ b/ui/src/common/components/PublicationInfo.jsx
@@ -1,17 +1,14 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Map } from 'immutable';
+import { getPageDisplay } from '../../literature/utils';
 
 class PublicationInfo extends Component {
   getPageOrArtidDisplay() {
     const { info } = this.props;
 
-    if (info.has('page_start') && info.has('page_end')) {
-      return `${info.get('page_start')}-${info.get('page_end')}`;
-    }
-
-    if (info.has('page_start')) {
-      return info.get('page_start');
+    if (getPageDisplay(info)) {
+      return getPageDisplay(info);
     }
 
     if (info.has('artid')) {

--- a/ui/src/literature/components/ConferenceInfo.jsx
+++ b/ui/src/literature/components/ConferenceInfo.jsx
@@ -1,0 +1,40 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Map, List } from 'immutable';
+import InlineList from '../../common/components/InlineList';
+import { getPageDisplay } from '../utils';
+
+class ConferenceInfo extends Component {
+  renderAcronyms() {
+    const { conferenceInfo } = this.props;
+    return (
+      <InlineList
+        wrapperClassName="di"
+        separateItemsClassName="separate-items-with-and"
+        items={conferenceInfo.get('acronyms')}
+        renderItem={acronym => <span>{acronym}</span>}
+      />
+    );
+  }
+
+  render() {
+    const { conferenceInfo } = this.props;
+    const title = conferenceInfo.getIn(['titles', 0, 'title']);
+    const acronyms = conferenceInfo.get('acronyms', List());
+
+    return (
+      <span>
+        {acronyms.size > 0 ? this.renderAcronyms() : title}
+        {getPageDisplay(conferenceInfo) && (
+          <span>, {getPageDisplay(conferenceInfo)}</span>
+        )}
+      </span>
+    );
+  }
+}
+
+ConferenceInfo.propTypes = {
+  conferenceInfo: PropTypes.instanceOf(Map).isRequired,
+};
+
+export default ConferenceInfo;

--- a/ui/src/literature/components/ConferenceInfoList.jsx
+++ b/ui/src/literature/components/ConferenceInfoList.jsx
@@ -3,20 +3,17 @@ import PropTypes from 'prop-types';
 import { List } from 'immutable';
 
 import InlineList from '../../common/components/InlineList';
+import ConferenceInfo from './ConferenceInfo';
 
 class ConferenceInfoList extends Component {
-  static getConferenceTitle(info) {
-    return info.getIn(['titles', 0, 'title']);
-  }
-
   render() {
     const { conferenceInfo } = this.props;
     return (
       <InlineList
         label="Contribution to"
         items={conferenceInfo}
-        extractKey={ConferenceInfoList.getConferenceTitle}
-        renderItem={ConferenceInfoList.getConferenceTitle}
+        extractKey={info => info.get('control_number')}
+        renderItem={info => <ConferenceInfo conferenceInfo={info} />}
       />
     );
   }

--- a/ui/src/literature/components/LiteratureItem.jsx
+++ b/ui/src/literature/components/LiteratureItem.jsx
@@ -18,6 +18,7 @@ import EventTracker from '../../common/components/EventTracker';
 import LiteratureTitle from '../../common/components/LiteratureTitle';
 import ResponsiveView from '../../common/components/ResponsiveView';
 import CiteModalActionContainer from '../containers/CiteModalActionContainer';
+import ConferenceInfoList from './ConferenceInfoList';
 
 class LiteratureItem extends Component {
   renderBulletIfPublicationInfoAndEprintsNotEmpty() {
@@ -38,6 +39,7 @@ class LiteratureItem extends Component {
     const recordId = metadata.get('control_number');
     const citationCount = metadata.get('citation_count', 0);
     const authorCount = metadata.get('number_of_authors');
+    const conferenceInfo = metadata.get('conference_info');
 
     const date = metadata.get('date');
     const publicationInfo = metadata.get('publication_info');
@@ -101,6 +103,7 @@ class LiteratureItem extends Component {
           />
           {this.renderBulletIfPublicationInfoAndEprintsNotEmpty()}
           <ArxivEprintList wrapperClassName="di" eprints={eprints} />
+          <ConferenceInfoList conferenceInfo={conferenceInfo} />
         </div>
       </ResultItem>
     );

--- a/ui/src/literature/components/__tests__/ConferenceInfo.test.jsx
+++ b/ui/src/literature/components/__tests__/ConferenceInfo.test.jsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { fromJS } from 'immutable';
+
+import ConferenceInfo from '../ConferenceInfo';
+
+describe('ConferenceInfo', () => {
+  it('renders without acronyms present', () => {
+    const info = fromJS({
+      control_number: 1639582,
+      titles: [
+        {
+          title:
+            '15th Marcel Grossmann Meeting on Recent Developments in Theoretical and Experimental General Relativity, Astrophysics, and Relativistic Field Theories',
+        },
+      ],
+    });
+    const wrapper = shallow(<ConferenceInfo conferenceInfo={info} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders with acronyms', () => {
+    const info = fromJS({
+      acronyms: ['MG15', 'SAP16'],
+      control_number: 1639582,
+      titles: [
+        {
+          title:
+            '15th Marcel Grossmann Meeting on Recent Developments in Theoretical and Experimental General Relativity, Astrophysics, and Relativistic Field Theories',
+        },
+      ],
+    });
+    const wrapper = shallow(<ConferenceInfo conferenceInfo={info} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders with acronyms and start and end page', () => {
+    const info = fromJS({
+      acronyms: ['MG15'],
+      control_number: 1639582,
+      titles: [
+        {
+          title:
+            '15th Marcel Grossmann Meeting on Recent Developments in Theoretical and Experimental General Relativity, Astrophysics, and Relativistic Field Theories',
+        },
+      ],
+      page_start: 1,
+      page_end: 20,
+    });
+    const wrapper = shallow(<ConferenceInfo conferenceInfo={info} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders with only page start', () => {
+    const info = fromJS({
+      acronyms: ['MG15'],
+      control_number: 1639582,
+      titles: [
+        {
+          title:
+            '15th Marcel Grossmann Meeting on Recent Developments in Theoretical and Experimental General Relativity, Astrophysics, and Relativistic Field Theories',
+        },
+      ],
+      page_start: 1,
+    });
+    const wrapper = shallow(<ConferenceInfo conferenceInfo={info} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders with only page end', () => {
+    const info = fromJS({
+      acronyms: ['MG15'],
+      control_number: 1639582,
+      titles: [
+        {
+          title:
+            '15th Marcel Grossmann Meeting on Recent Developments in Theoretical and Experimental General Relativity, Astrophysics, and Relativistic Field Theories',
+        },
+      ],
+      page_end: 20,
+    });
+    const wrapper = shallow(<ConferenceInfo conferenceInfo={info} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/ui/src/literature/components/__tests__/ConferenceInfoList.test.jsx
+++ b/ui/src/literature/components/__tests__/ConferenceInfoList.test.jsx
@@ -11,17 +11,17 @@ describe('ConferenceInfoList', () => {
         titles: [
           {
             title: 'Test Conferece 2',
-            control_number: 111111,
           },
         ],
+        control_number: 111111,
       },
       {
         titles: [
           {
             title: 'Test Conferece 2',
-            control_number: 222222,
           },
         ],
+        control_number: 222222,
       },
     ]);
     const wrapper = shallow(<ConferenceInfoList conferenceInfo={info} />);

--- a/ui/src/literature/components/__tests__/LiteratureItem.test.jsx
+++ b/ui/src/literature/components/__tests__/LiteratureItem.test.jsx
@@ -16,6 +16,17 @@ describe('LiteratureItem', () => {
       publication_info: [{ journal_title: 'Test Jornal' }],
       collaborations: [{ value: 'CMS' }],
       collaborations_with_suffix: [{ value: 'CMS Group' }],
+      conference_info: [
+        {
+          acronyms: ['MG15', 'SAP16'],
+          titles: [
+            {
+              title:
+                '15th Marcel Grossmann Meeting on Recent Developments in Theoretical and Experimental General Relativity, Astrophysics, and Relativistic Field Theories',
+            },
+          ],
+        },
+      ],
     });
     const wrapper = shallow(
       <LiteratureItem metadata={metadata} searchRank={2} />

--- a/ui/src/literature/components/__tests__/__snapshots__/ConferenceInfo.test.jsx.snap
+++ b/ui/src/literature/components/__tests__/__snapshots__/ConferenceInfo.test.jsx.snap
@@ -1,0 +1,92 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConferenceInfo renders with acronyms 1`] = `
+<span>
+  <InlineList
+    extractKey={[Function]}
+    items={
+      Immutable.List [
+        "MG15",
+        "SAP16",
+      ]
+    }
+    label={null}
+    renderItem={[Function]}
+    separateItems={true}
+    separateItemsClassName="separate-items-with-and"
+    suffix={null}
+    wrapperClassName="di"
+  />
+</span>
+`;
+
+exports[`ConferenceInfo renders with acronyms and start and end page 1`] = `
+<span>
+  <InlineList
+    extractKey={[Function]}
+    items={
+      Immutable.List [
+        "MG15",
+      ]
+    }
+    label={null}
+    renderItem={[Function]}
+    separateItems={true}
+    separateItemsClassName="separate-items-with-and"
+    suffix={null}
+    wrapperClassName="di"
+  />
+  <span>
+    , 
+    1-20
+  </span>
+</span>
+`;
+
+exports[`ConferenceInfo renders with only page end 1`] = `
+<span>
+  <InlineList
+    extractKey={[Function]}
+    items={
+      Immutable.List [
+        "MG15",
+      ]
+    }
+    label={null}
+    renderItem={[Function]}
+    separateItems={true}
+    separateItemsClassName="separate-items-with-and"
+    suffix={null}
+    wrapperClassName="di"
+  />
+</span>
+`;
+
+exports[`ConferenceInfo renders with only page start 1`] = `
+<span>
+  <InlineList
+    extractKey={[Function]}
+    items={
+      Immutable.List [
+        "MG15",
+      ]
+    }
+    label={null}
+    renderItem={[Function]}
+    separateItems={true}
+    separateItemsClassName="separate-items-with-and"
+    suffix={null}
+    wrapperClassName="di"
+  />
+  <span>
+    , 
+    1
+  </span>
+</span>
+`;
+
+exports[`ConferenceInfo renders without acronyms present 1`] = `
+<span>
+  15th Marcel Grossmann Meeting on Recent Developments in Theoretical and Experimental General Relativity, Astrophysics, and Relativistic Field Theories
+</span>
+`;

--- a/ui/src/literature/components/__tests__/__snapshots__/ConferenceInfoList.test.jsx.snap
+++ b/ui/src/literature/components/__tests__/__snapshots__/ConferenceInfoList.test.jsx.snap
@@ -12,14 +12,36 @@ exports[`ConferenceInfoList renders conference link 1`] = `
     className="separate-items-with-comma"
   >
     <li
-      key="Test Conferece 2"
+      key="111111"
     >
-      Test Conferece 2
+      <ConferenceInfo
+        conferenceInfo={
+          Immutable.Map {
+            "titles": Immutable.List [
+              Immutable.Map {
+                "title": "Test Conferece 2",
+              },
+            ],
+            "control_number": 111111,
+          }
+        }
+      />
     </li>
     <li
-      key="Test Conferece 2"
+      key="222222"
     >
-      Test Conferece 2
+      <ConferenceInfo
+        conferenceInfo={
+          Immutable.Map {
+            "titles": Immutable.List [
+              Immutable.Map {
+                "title": "Test Conferece 2",
+              },
+            ],
+            "control_number": 222222,
+          }
+        }
+      />
     </li>
   </ul>
 </div>

--- a/ui/src/literature/components/__tests__/__snapshots__/LiteratureItem.test.jsx.snap
+++ b/ui/src/literature/components/__tests__/__snapshots__/LiteratureItem.test.jsx.snap
@@ -86,6 +86,9 @@ exports[`LiteratureItem does not arxiv pdf download action if there is no eprint
       eprints={null}
       wrapperClassName="di"
     />
+    <ConferenceInfoList
+      conferenceInfo={null}
+    />
   </div>
 </ResultItem>
 `;
@@ -175,6 +178,9 @@ exports[`LiteratureItem renders 0 citations if it does not exist 1`] = `
     <ArxivEprintList
       eprints={null}
       wrapperClassName="di"
+    />
+    <ConferenceInfoList
+      conferenceInfo={null}
     />
   </div>
 </ResultItem>
@@ -301,6 +307,23 @@ exports[`LiteratureItem renders with all props set, including sub props 1`] = `
         ]
       }
       wrapperClassName="di"
+    />
+    <ConferenceInfoList
+      conferenceInfo={
+        Immutable.List [
+          Immutable.Map {
+            "acronyms": Immutable.List [
+              "MG15",
+              "SAP16",
+            ],
+            "titles": Immutable.List [
+              Immutable.Map {
+                "title": "15th Marcel Grossmann Meeting on Recent Developments in Theoretical and Experimental General Relativity, Astrophysics, and Relativistic Field Theories",
+              },
+            ],
+          },
+        ]
+      }
     />
   </div>
 </ResultItem>

--- a/ui/src/literature/components/__tests__/utils.test.js
+++ b/ui/src/literature/components/__tests__/utils.test.js
@@ -1,0 +1,34 @@
+import { fromJS } from 'immutable';
+import { getPageDisplay } from '../../utils';
+
+describe('utils', () => {
+  describe('getPageDisplay', () => {
+    it('returns both page_start and page_end if both passed', () => {
+      const pagesInfo = fromJS({
+        page_start: '1',
+        page_end: '2',
+      });
+      const expected = '1-2';
+      const currentPositions = getPageDisplay(pagesInfo);
+      expect(currentPositions).toEqual(expected);
+    });
+
+    it('returns null if only page_end passed', () => {
+      const pagesInfo = fromJS({
+        page_end: '2',
+      });
+      const expected = null;
+      const currentPositions = getPageDisplay(pagesInfo);
+      expect(currentPositions).toEqual(expected);
+    });
+
+    it('returns page_start if only page_start passed', () => {
+      const pagesInfo = fromJS({
+        page_start: '2',
+      });
+      const expected = '2';
+      const currentPositions = getPageDisplay(pagesInfo);
+      expect(currentPositions).toEqual(expected);
+    });
+  });
+});

--- a/ui/src/literature/utils.js
+++ b/ui/src/literature/utils.js
@@ -1,0 +1,12 @@
+// eslint-disable-next-line import/prefer-default-export
+export function getPageDisplay(pagesInfo) {
+  if (pagesInfo.has('page_start') && pagesInfo.has('page_end')) {
+    return `${pagesInfo.get('page_start')}-${pagesInfo.get('page_end')}`;
+  }
+
+  if (pagesInfo.has('page_start')) {
+    return pagesInfo.get('page_start');
+  }
+
+  return null;
+}


### PR DESCRIPTION
* Fixed the conference info serializer to retrieve the conference record properly and return correct data
* Added page_start, page_end and acronyms to the serializer
* Added ConferenceInfo component to display conference as Contribution to {acronyms or title}, {start_page - end_page}