### PR TITLE
submissions: restrict hidden email access

### DIFF
--- a/inspirehep/accounts/api.py
+++ b/inspirehep/accounts/api.py
@@ -9,6 +9,8 @@ from functools import wraps
 
 from flask import abort
 from flask_login import current_user
+from invenio_oauthclient.models import UserIdentity
+from sqlalchemy.orm.exc import NoResultFound
 
 
 def login_required(func):
@@ -26,3 +28,15 @@ def is_superuser_or_cataloger_logged_in():
         user_roles = {role.name for role in current_user.roles}
         return user_roles & {"superuser", "cataloger"}
     return False
+
+
+def get_current_user_orcid():
+    try:
+        orcid = (
+            UserIdentity.query.filter_by(id_user=current_user.get_id(), method="orcid")
+            .one()
+            .id
+        )
+        return orcid
+    except NoResultFound:
+        return None

--- a/inspirehep/submissions/marshmallow/__init__.py
+++ b/inspirehep/submissions/marshmallow/__init__.py
@@ -8,5 +8,5 @@
 
 """Schemas for submissions"""
 
-from .author import Author
+from .author import Author, SameAuthor
 from .literature import Literature

--- a/inspirehep/submissions/marshmallow/author.py
+++ b/inspirehep/submissions/marshmallow/author.py
@@ -9,6 +9,8 @@ from inspire_schemas.builders.authors import AuthorBuilder
 from inspire_utils.record import get_value, get_values_for_schema
 from marshmallow import Schema, fields, missing, post_load, pre_dump
 
+from inspirehep.records.marshmallow.fields import NonHiddenRaw
+
 
 class Author(Schema):
     alternate_name = fields.Raw()
@@ -16,7 +18,7 @@ class Author(Schema):
     family_name = fields.Raw()
     given_name = fields.Raw()
     native_name = fields.Raw()
-    emails = fields.Raw()
+    emails = NonHiddenRaw()
     orcid = fields.Raw()
 
     status = fields.Raw()
@@ -210,3 +212,7 @@ class Author(Schema):
             )
 
         return author.obj
+
+
+class SameAuthor(Author):
+    emails = fields.Raw()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -238,7 +238,7 @@ def create_user(base_app, db):
             user = create_user()
     """
 
-    def _create_user(role="user"):
-        return UserFactory(role=role)
+    def _create_user(role="user", orcid=None):
+        return UserFactory(role=role, orcid=orcid)
 
     return _create_user

--- a/tests/integration/submissions/test_submissions_views.py
+++ b/tests/integration/submissions/test_submissions_views.py
@@ -160,12 +160,61 @@ def test_get_author_update_data(app, api_client, create_user, create_record_fact
     author_data = {
         "control_number": 123,
         "name": {"value": "John", "preferred_name": "John Doe"},
+        "email_addresses": [
+            {"value": "public@john.ch"},
+            {"value": "private@john.ch", "hidden": True},
+        ],
         "status": "active",
     }
     create_record_factory("aut", data=author_data)
 
     expected_data = {
-        "data": {"given_name": "John", "display_name": "John Doe", "status": "active"}
+        "data": {
+            "given_name": "John",
+            "display_name": "John Doe",
+            "status": "active",
+            "emails": [{"value": "public@john.ch"}],
+        }
+    }
+
+    response = api_client.get(
+        "/submissions/authors/123", headers={"Accept": "application/json"}
+    )
+    response_data = json.loads(response.data)
+
+    assert response_data == expected_data
+
+
+def test_get_author_update_data_of_same_author(
+    app, api_client, create_user, create_record_factory
+):
+    orcid = "0000-0001-5109-3700"
+    user = create_user(orcid=orcid)
+    login_user_via_session(api_client, email=user.email)
+
+    author_data = {
+        "control_number": 123,
+        "name": {"value": "John", "preferred_name": "John Doe"},
+        "ids": [{"schema": "ORCID", "value": orcid}],
+        "email_addresses": [
+            {"value": "public@john.ch"},
+            {"value": "private@john.ch", "hidden": True},
+        ],
+        "status": "active",
+    }
+    create_record_factory("aut", data=author_data)
+
+    expected_data = {
+        "data": {
+            "given_name": "John",
+            "display_name": "John Doe",
+            "status": "active",
+            "orcid": orcid,
+            "emails": [
+                {"value": "public@john.ch"},
+                {"value": "private@john.ch", "hidden": True},
+            ],
+        }
     }
 
     response = api_client.get(

--- a/tests/unit/submissions/test_authors.py
+++ b/tests/unit/submissions/test_authors.py
@@ -7,7 +7,7 @@
 
 from helpers.providers.faker import faker
 
-from inspirehep.submissions.marshmallow.author import Author
+from inspirehep.submissions.marshmallow.author import Author, SameAuthor
 
 DEFAULT_DATA_TO_DUMP = {"name": {"value": "John Doe"}}
 DEFAULT_DATA_DUMP = {"given_name": "John Doe"}
@@ -554,7 +554,7 @@ def test_load_author_project_membership():
     assert result == expected
 
 
-def test_dump_author_emails():
+def test_dump_author_emails_returns_only_public_emails():
     data = {
         **DEFAULT_DATA_TO_DUMP,
         "email_addresses": [
@@ -565,6 +565,22 @@ def test_dump_author_emails():
     record = faker.record("aut", data=data)
 
     result = Author().dump(record).data
+    expected = {**DEFAULT_DATA_DUMP, "emails": [{"value": "public@email.com"}]}
+
+    assert result == expected
+
+
+def test_dump_same_author_emails_returns_all_emails():
+    data = {
+        **DEFAULT_DATA_TO_DUMP,
+        "email_addresses": [
+            {"value": "private@email.com", "hidden": True},
+            {"value": "public@email.com"},
+        ],
+    }
+    record = faker.record("aut", data=data)
+
+    result = SameAuthor().dump(record).data
     expected = {
         **DEFAULT_DATA_DUMP,
         "emails": [


### PR DESCRIPTION
When updating an author profile, it will not display hidden emails
unless logged in user who is updating is the author (matches user.orcid
and author.orcid)