### PR TITLE
records: add citation count method and update serializers

### DIFF
--- a/inspirehep/records/api/base.py
+++ b/inspirehep/records/api/base.py
@@ -1038,7 +1038,7 @@ class InspireRecord(Record):
         records_uuids = self.get_records_ids_by_pids(proper_records_pids)
         referenced_records = set()
         references_waiting_for_commit = []
-        citation_date = self.get_earliest_date()
+        citation_date = self.earliest_date
         for reference in records_uuids:
             if reference not in referenced_records:
                 referenced_records.add(reference)
@@ -1055,9 +1055,14 @@ class InspireRecord(Record):
         if references_waiting_for_commit:
             db.session.bulk_save_objects(references_waiting_for_commit)
 
-    def get_earliest_date(self):
+    @property
+    def earliest_date(self):
         """Returns earliest date. If earliest date is missing month or day
-        it's set as 1 as DB does not accept date without day or month"""
+        it's set as 1 as DB does not accept date without day or month
+
+        Returns:
+            str: earliest date represented in a string
+        """
         date_paths = [
             "preprint_date",
             "thesis_info.date",

--- a/inspirehep/records/api/data.py
+++ b/inspirehep/records/api/data.py
@@ -4,12 +4,13 @@
 #
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
+from inspirehep.records.api.mixins import CitationMixin
 
 from ...pidstore.api import PidStoreData
 from .base import InspireRecord
 
 
-class DataRecord(InspireRecord):
+class DataRecord(InspireRecord, CitationMixin):
     """Data Record."""
 
     pid_type = "dat"

--- a/inspirehep/records/api/literature.py
+++ b/inspirehep/records/api/literature.py
@@ -18,6 +18,7 @@ from inspire_schemas.utils import is_arxiv, normalize_arxiv
 from invenio_pidstore.models import PersistentIdentifier
 
 from inspirehep.pidstore.api import PidStoreLiterature
+from inspirehep.records.api.mixins import CitationMixin
 from inspirehep.records.errors import (
     ExistingArticleError,
     ImportArticleError,
@@ -43,7 +44,7 @@ ARXIV_URL = (
 CROSSREF_URL = "https://api.crossref.org/works/<ID>"
 
 
-class LiteratureRecord(InspireRecord):
+class LiteratureRecord(InspireRecord, CitationMixin):
     """Literature Record."""
 
     pid_type = "lit"

--- a/inspirehep/records/api/mixins.py
+++ b/inspirehep/records/api/mixins.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CERN.
+#
+# inspirehep is free software; you can redistribute it and/or modify it under
+# the terms of the MIT License; see LICENSE file for more details.
+
+from inspirehep.records.models import RecordCitations
+
+
+class CitationMixin(object):
+    """Implements methods for citations"""
+
+    def _citation_query(self):
+        """Prepares query with all records which cited this one
+
+        Returns:
+            query: Query containing all citations for this record
+
+        """
+        return RecordCitations.query.filter_by(cited_id=self.id)
+
+    @property
+    def citation_count(self):
+        """Gives citation count number
+
+        Returns:
+            int: Citation count number for this record if it is literature or data
+            record.
+        """
+        return self._citation_query().count()

--- a/inspirehep/records/marshmallow/literature/base.py
+++ b/inspirehep/records/marshmallow/literature/base.py
@@ -213,17 +213,11 @@ class LiteratureESEnhancementV1(LiteratureMetadataRawAdminSchemaV1):
     author_count = fields.Method("get_author_count")
     authors = fields.Nested(AuthorsInfoSchemaForES, dump_only=True, many=True)
     bookautocomplete = fields.Method("get_bookautocomplete")
-    earliest_date = fields.Method("get_earliest_date")
+    earliest_date = fields.Raw(dump_only=True, default=missing)
     facet_inspire_doc_type = fields.Method("get_inspire_document_type")
     facet_author_name = fields.Method("get_facet_author_name")
     id_field = fields.Integer(dump_only=True, dump_to="id", attribute="control_number")
     thesis_info = fields.Nested(ThesisInfoSchemaForESV1, dump_only=True)
-
-    def get_earliest_date(self, record):
-        earliest_date = record.get_earliest_date()
-        if earliest_date:
-            return earliest_date
-        return missing
 
     def get_author_count(self, record):
         """Prepares record for ``author_count`` field."""

--- a/inspirehep/records/marshmallow/literature/latex.py
+++ b/inspirehep/records/marshmallow/literature/latex.py
@@ -17,7 +17,8 @@ from .bibtex import BibTexCommonSchema
 class LatexSchema(Schema):
     arxiv_eprints = fields.Raw()
     authors = fields.Method("get_author_names")
-    citations = fields.Method("get_citations", default=0)
+    # It has to be string, otherwise if result is 0 then it's not rendered in latex
+    citations = fields.String(attribute="citation_count")
     collaborations = fields.Method("get_collaborations")
     dois = fields.Raw()
     publication_info = fields.Method("get_publication_info")
@@ -25,14 +26,6 @@ class LatexSchema(Schema):
     titles = fields.Raw()
     texkeys = fields.Method("get_texkey")
     today = fields.Method("get_current_date")
-
-    def get_citations(self, data):
-        citations = data.get("citation_count")
-
-        if citations is None:
-            return data.get_citations_count()
-
-        return citations
 
     def get_author_names(self, data):
         authors = data.get("authors")

--- a/inspirehep/search/api.py
+++ b/inspirehep/search/api.py
@@ -16,6 +16,8 @@ from flask import current_app
 from invenio_search import current_search_client as es
 from invenio_search.api import DefaultFilter, RecordsSearch
 
+from inspirehep.pidstore.api import PidStoreBase
+
 from .factories import inspire_query_factory
 
 logger = logging.getLogger(__name__)
@@ -72,6 +74,19 @@ class SearchMixin(object):
 
 class InspireSearch(RecordsSearch, SearchMixin):
     """Base Inspire search classs."""
+
+    @staticmethod
+    def get_record_data_from_es(record):
+        """Queries Elastic Search for this record and returns it as dictionary
+
+        Returns:
+            dict:This record in a way it is represented in Elastic Search
+
+        """
+        endpoint = PidStoreBase._get_config_pid_types_to_endpoints()[record.pid_type]
+        search_conf = current_app.config["RECORDS_REST_ENDPOINTS"][endpoint]
+        search_class = search_conf["search_class"]()
+        return search_class.get_source(record.id)
 
     def source_for_content_type(self, content_type):
         return self

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -140,7 +140,6 @@ def create_record(base_app, db, es_clear):
         record = LiteratureRecord.create(record_data)
         record.commit()
         record._indexing = record._index()
-        db.session.commit()
         es_clear.indices.refresh(index)
         return record
 

--- a/tests/integration/records/serializers/test_json.py
+++ b/tests/integration/records/serializers/test_json.py
@@ -182,6 +182,7 @@ def test_literature_application_json_search_without_login(
         "publication_info": [{"pubinfo_freetext": "A public publication info"}],
         "report_numbers": [{"value": "PUBLIC", "hidden": False}],
         "documents": [{"key": "public", "url": "https://url.to/public/document"}],
+        "citation_count": 0,
     }
     expected_result_len = 1
 
@@ -255,6 +256,7 @@ def test_literature_application_json_search_with_cataloger_login(
             },
             {"key": "public", "url": "https://url.to/public/document"},
         ],
+        "citation_count": 0,
     }
     expected_result_len = 1
 

--- a/tests/integration/records/serializers/test_latex.py
+++ b/tests/integration/records/serializers/test_latex.py
@@ -11,7 +11,7 @@ from freezegun import freeze_time
 @freeze_time("1994-12-19")
 def test_latex_eu(api_client, db, create_record_factory):
     headers = {"Accept": "application/vnd+inspire.latex.eu+x-latex"}
-    data = {"control_number": 637275237, "titles": [{"title": "This is a title."}]}
+    data = {"control_number": 637_275_237, "titles": [{"title": "This is a title."}]}
 
     record = create_record_factory("lit", data=data, with_indexing=True)
     record_control_number = record.json["control_number"]
@@ -22,11 +22,9 @@ def test_latex_eu(api_client, db, create_record_factory):
         "%\\cite{637275237}\n"
         "\\bibitem{637275237}\n"
         "%``This is a title.,''\n"
-        "% citations counted in INSPIRE as of 19 Dec 1994"
+        "%0 citations counted in INSPIRE as of 19 Dec 1994"
     )
-    response = api_client.get(
-        "/literature/{}".format(record_control_number), headers=headers
-    )
+    response = api_client.get(f"/literature/{record_control_number}", headers=headers)
 
     response_status_code = response.status_code
     etag = response.headers.get("Etag")
@@ -42,7 +40,7 @@ def test_latex_eu(api_client, db, create_record_factory):
 @freeze_time("1994-12-19")
 def test_latex_us(api_client, db, create_record_factory):
     headers = {"Accept": "application/vnd+inspire.latex.us+x-latex"}
-    data = {"control_number": 637275237, "titles": [{"title": "This is a title."}]}
+    data = {"control_number": 637_275_237, "titles": [{"title": "This is a title."}]}
 
     record = create_record_factory("lit", data=data, with_indexing=True)
     record_control_number = record.json["control_number"]
@@ -53,11 +51,9 @@ def test_latex_us(api_client, db, create_record_factory):
         "%\\cite{637275237}\n"
         "\\bibitem{637275237}\n"
         "%``This is a title.,''\n"
-        "% citations counted in INSPIRE as of 19 Dec 1994"
+        "%0 citations counted in INSPIRE as of 19 Dec 1994"
     )
-    response = api_client.get(
-        "/literature/{}".format(record_control_number), headers=headers
-    )
+    response = api_client.get(f"/literature/{record_control_number}", headers=headers)
 
     response_status_code = response.status_code
     etag = response.headers.get("Etag")

--- a/tests/integration/records/test_api_base.py
+++ b/tests/integration/records/test_api_base.py
@@ -730,8 +730,8 @@ def test_create_record_throws_exception_if_wrong_subclass_used(base_app, db):
         LiteratureRecord.create(data)
 
 
-def test_get_earliest_date(base_app, db, datadir, create_record_factory, disable_files):
+def test_earliest_date(base_app, db, datadir, create_record_factory, disable_files):
     data = json.loads((datadir / "1366189.json").read_text())
     record = LiteratureRecord.create(data=data)
 
-    assert record.get_earliest_date() == "2015-05-05"
+    assert record.earliest_date == "2015-05-05"

--- a/tests/integration/records/test_api_conferences.py
+++ b/tests/integration/records/test_api_conferences.py
@@ -161,3 +161,11 @@ def test_create_or_update_record_from_db_depending_on_its_pid_type(base_app, db)
     record = InspireRecord.create_or_update(data)
     assert type(record) == ConferencesRecord
     assert record.pid_type == "con"
+
+
+def test_aut_citation_count_property_blows_up_on_wrong_pid_type(base_app, db):
+    data = faker.record("con")
+    record = ConferencesRecord.create(data)
+
+    with pytest.raises(AttributeError):
+        record.citation_count

--- a/tests/integration/records/test_api_data.py
+++ b/tests/integration/records/test_api_data.py
@@ -176,3 +176,14 @@ def test_create_record_update_citation_table_for_literature_citation(base_app, d
     assert len(record2.model.citations) == 0
     assert len(record2.model.references) == 1
     assert len(RecordCitations.query.all()) == 1
+
+
+def test_data_citation_count_property(base_app, db):
+    data = faker.record("dat")
+    record = InspireRecord.create(data)
+
+    data2 = faker.record("lit", data_citations=[record["control_number"]])
+    record2 = InspireRecord.create(data2)
+
+    assert record.citation_count == 1
+    assert record2.citation_count == 0

--- a/tests/integration/records/test_api_experiments.py
+++ b/tests/integration/records/test_api_experiments.py
@@ -161,3 +161,11 @@ def test_create_or_update_record_from_db_depending_on_its_pid_type(base_app, db)
     record = InspireRecord.create_or_update(data)
     assert type(record) == ExperimentsRecord
     assert record.pid_type == "exp"
+
+
+def test_aut_citation_count_property_blows_up_on_wrong_pid_type(base_app, db):
+    data = faker.record("exp")
+    record = ExperimentsRecord.create(data)
+
+    with pytest.raises(AttributeError):
+        record.citation_count

--- a/tests/integration/records/test_api_institutions.py
+++ b/tests/integration/records/test_api_institutions.py
@@ -163,3 +163,11 @@ def test_create_or_update_record_from_db_depending_on_its_pid_type(base_app, db)
     record = InspireRecord.create_or_update(data)
     assert type(record) == InstitutionsRecord
     assert record.pid_type == "ins"
+
+
+def test_aut_citation_count_property_blows_up_on_wrong_pid_type(base_app, db):
+    data = faker.record("ins")
+    record = InstitutionsRecord.create(data)
+
+    with pytest.raises(AttributeError):
+        record.citation_count

--- a/tests/integration/records/test_api_jobs.py
+++ b/tests/integration/records/test_api_jobs.py
@@ -161,3 +161,11 @@ def test_create_or_update_record_from_db_depending_on_its_pid_type(base_app, db)
     record = InspireRecord.create_or_update(data)
     assert type(record) == JobsRecord
     assert record.pid_type == "job"
+
+
+def test_aut_citation_count_property_blows_up_on_wrong_pid_type(base_app, db):
+    data = faker.record("job")
+    record = JobsRecord.create(data)
+
+    with pytest.raises(AttributeError):
+        record.citation_count

--- a/tests/integration/records/test_api_journals.py
+++ b/tests/integration/records/test_api_journals.py
@@ -161,3 +161,11 @@ def test_create_or_update_record_from_db_depending_on_its_pid_type(base_app, db)
     record = InspireRecord.create_or_update(data)
     assert type(record) == JournalsRecord
     assert record.pid_type == "jou"
+
+
+def test_aut_citation_count_property_blows_up_on_wrong_pid_type(base_app, db):
+    data = faker.record("jou")
+    record = JournalsRecord.create(data)
+
+    with pytest.raises(AttributeError):
+        record.citation_count

--- a/tests/integration/records/test_api_literature.py
+++ b/tests/integration/records/test_api_literature.py
@@ -789,3 +789,14 @@ def test_literature_is_not_cited_by_deleted_records(
     assert len(record.model.citations) == 0
     assert len(record.model.references) == 0
     assert len(RecordCitations.query.all()) == 0
+
+
+def test_literature_citation_count_property(base_app, db):
+    data = faker.record("lit")
+    record = InspireRecord.create(data)
+
+    data2 = faker.record("lit", literature_citations=[record["control_number"]])
+    record2 = LiteratureRecord.create(data2)
+
+    assert record.citation_count == 1
+    assert record2.citation_count == 0


### PR DESCRIPTION
* Add: get_citations_count method
* Add: citations_count property

* Fix: Latex serializer which were using get_citation_count method which was not in InspireRecord at all.

* INSPIR-2314
* INSPIR-2214