### PR TITLE
ui: Add citation summary graph interactivity

### DIFF
--- a/ui/src/authors/containers/AuthorPublicationsContainer.jsx
+++ b/ui/src/authors/containers/AuthorPublicationsContainer.jsx
@@ -6,7 +6,6 @@ import {
 } from '../../actions/authors';
 import EmbeddedSearch from '../../common/components/EmbeddedSearch';
 import { convertSomeImmutablePropsToJS } from '../../common/immutableToJS';
-import { fetchCitationSummary } from '../../actions/citations';
 
 const stateToProps = state => ({
   aggregations: state.authors.getIn(['publications', 'aggregations']),
@@ -25,7 +24,6 @@ export const dispatchToProps = dispatch => ({
   onQueryChange(queryChange) {
     dispatch(fetchAuthorPublications(queryChange));
     dispatch(fetchAuthorPublicationsFacets(queryChange));
-    dispatch(fetchCitationSummary());
   },
 });
 

--- a/ui/src/authors/containers/NumberOfCiteablePapersContainer.jsx
+++ b/ui/src/authors/containers/NumberOfCiteablePapersContainer.jsx
@@ -5,8 +5,7 @@ import {
   fetchAuthorPublicationsFacets,
 } from '../../actions/authors';
 import LinkLikeButton from '../../common/components/LinkLikeButton';
-
-const CITEABLE_QUERY = { q: 'citeable:true' };
+import { CITEABLE_QUERY } from '../../common/constants';
 
 export const dispatchToProps = dispatch => ({
   onClick() {

--- a/ui/src/authors/containers/NumberOfPublishedPapersContainer.jsx
+++ b/ui/src/authors/containers/NumberOfPublishedPapersContainer.jsx
@@ -5,8 +5,7 @@ import {
   fetchAuthorPublicationsFacets,
 } from '../../actions/authors';
 import LinkLikeButton from '../../common/components/LinkLikeButton';
-
-const PUBLISHED_QUERY = { q: 'citeable:true and refereed:true' };
+import { PUBLISHED_QUERY } from '../../common/constants';
 
 export const dispatchToProps = dispatch => ({
   onClick() {

--- a/ui/src/authors/containers/__tests__/AuthorPublicationsContainer.test.jsx
+++ b/ui/src/authors/containers/__tests__/AuthorPublicationsContainer.test.jsx
@@ -8,7 +8,6 @@ import EmbeddedSearch from '../../../common/components/EmbeddedSearch';
 import {
   AUTHOR_PUBLICATIONS_REQUEST,
   AUTHOR_PUBLICATIONS_FACETS_REQUEST,
-  CITATIONS_SUMMARY_REQUEST,
 } from '../../../actions/actionTypes';
 
 describe('AuthorPublicationsContainer', () => {
@@ -34,7 +33,7 @@ describe('AuthorPublicationsContainer', () => {
   });
 
   // FIXME: avoid also testing that actions merging newQuery and state query
-  it('dispatches fetch author publications and facets, and new citation summary onQueryChange', () => {
+  it('dispatches fetch author publications and facets onQueryChange', () => {
     const existingQuery = { page: 3, size: 10, author: ['Harun'] };
     const queryChange = { sort: 'mostcited' };
     const newQuery = {
@@ -63,9 +62,6 @@ describe('AuthorPublicationsContainer', () => {
       {
         type: AUTHOR_PUBLICATIONS_FACETS_REQUEST,
         payload: newQuery,
-      },
-      {
-        type: CITATIONS_SUMMARY_REQUEST,
       },
     ];
     const actions = store.getActions().slice(0, 3); // slice to assert only REQUEST actions

--- a/ui/src/common/components/CitationSummaryGraph/index.js
+++ b/ui/src/common/components/CitationSummaryGraph/index.js
@@ -1,0 +1,3 @@
+import CitationSummaryGraph from './CitationSummaryGraph';
+
+export default CitationSummaryGraph;

--- a/ui/src/common/components/__tests__/CitationSummaryGraph.test.jsx
+++ b/ui/src/common/components/__tests__/CitationSummaryGraph.test.jsx
@@ -1,79 +1,354 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import CitationSummaryGraph from '../CitationSummaryGraph/CitationSummaryGraph';
+import CitationSummaryGraph, {
+  ORANGE,
+  HOVERED_ORANGE,
+  BLUE,
+  GRAY,
+} from '../CitationSummaryGraph/CitationSummaryGraph';
+import { CITEABLE_BAR_TYPE, PUBLISHED_BAR_TYPE } from '../../constants';
 
+const mockPublishedData = [
+  {
+    key: '0--0',
+    from: 0,
+    to: 1,
+    doc_count: 1,
+  },
+  {
+    key: '1--50',
+    from: 1,
+    to: 50,
+    doc_count: 2,
+  },
+  {
+    key: '50--250',
+    from: 50,
+    to: 250,
+    doc_count: 3,
+  },
+  {
+    key: '250--500',
+    from: 250,
+    to: 500,
+    doc_count: 4,
+  },
+  {
+    key: '--500',
+    from: 500,
+    doc_count: 0,
+  },
+];
+const mockCiteableData = [
+  {
+    key: '0--0',
+    from: 0,
+    to: 1,
+    doc_count: 1,
+  },
+  {
+    key: '1--50',
+    from: 1,
+    to: 50,
+    doc_count: 2,
+  },
+  {
+    key: '50--250',
+    from: 50,
+    to: 250,
+    doc_count: 3,
+  },
+  {
+    key: '250--500',
+    from: 250,
+    to: 500,
+    doc_count: 4,
+  },
+  {
+    key: '500--',
+    from: 500,
+    doc_count: 0,
+  },
+];
 describe('CitationSummaryGraph', () => {
-  it('renders graph with all props given', () => {
-    const publishedData = [
-      {
-        key: '0.0-1.0',
-        from: 0,
-        to: 1,
-        doc_count: 1,
-      },
-      {
-        key: '1.0-50.0',
-        from: 1,
-        to: 50,
-        doc_count: 2,
-      },
-      {
-        key: '50.0-250.0',
-        from: 50,
-        to: 250,
-        doc_count: 3,
-      },
-      {
-        key: '250.0-500.0',
-        from: 250,
-        to: 500,
-        doc_count: 4,
-      },
-      {
-        key: '500.0-*',
-        from: 500,
-        doc_count: 0,
-      },
-    ];
-    const citeableData = [
-      {
-        key: '0.0-1.0',
-        from: 0,
-        to: 1,
-        doc_count: 1,
-      },
-      {
-        key: '1.0-50.0',
-        from: 1,
-        to: 50,
-        doc_count: 2,
-      },
-      {
-        key: '50.0-250.0',
-        from: 50,
-        to: 250,
-        doc_count: 3,
-      },
-      {
-        key: '250.0-500.0',
-        from: 250,
-        to: 500,
-        doc_count: 4,
-      },
-      {
-        key: '500.0-*',
-        from: 500,
-        doc_count: 0,
-      },
-    ];
+  it('renders graph without SelectedBar', () => {
     const wrapper = shallow(
       <CitationSummaryGraph
-        publishedData={publishedData}
-        citeableData={citeableData}
+        publishedData={mockPublishedData}
+        citeableData={mockCiteableData}
         loadingCitationSummary={false}
         error={null}
+        onSelectBarChange={jest.fn()}
       />
     );
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders graph with selectedBar', () => {
+    const wrapper = shallow(
+      <CitationSummaryGraph
+        publishedData={mockPublishedData}
+        citeableData={mockCiteableData}
+        loadingCitationSummary={false}
+        error={null}
+        onSelectBarChange={jest.fn()}
+        selectedBar={{ type: CITEABLE_BAR_TYPE, xValue: '500--' }}
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders with hovered bar', () => {
+    const wrapper = shallow(
+      <CitationSummaryGraph
+        publishedData={mockPublishedData}
+        citeableData={mockCiteableData}
+        loadingCitationSummary={false}
+        error={null}
+        onSelectBarChange={jest.fn()}
+      />
+    );
+    wrapper.setState({
+      hoveredBar: { type: CITEABLE_BAR_TYPE, xValue: '500--' },
+    });
+    expect(wrapper).toMatchSnapshot();
+  });
+  describe('toSeriesData', () => {
+    it('returns series data with correct color', () => {
+      const wrapper = shallow(
+        <CitationSummaryGraph
+          publishedData={mockPublishedData}
+          citeableData={mockCiteableData}
+          loadingCitationSummary={false}
+          error={null}
+          onSelectBarChange={jest.fn()}
+        />
+      );
+      const bucket = {
+        key: '0--0',
+        from: 0,
+        to: 1,
+        doc_count: 10,
+      };
+      const data = wrapper.instance().toSeriesData(bucket, PUBLISHED_BAR_TYPE);
+      const expectedData = {
+        x: '0--0',
+        y: 10,
+        label: '10',
+        color: ORANGE,
+      };
+      expect(data).toEqual(expectedData);
+    });
+    it('returns series data with correct color for hovered bar', () => {
+      const wrapper = shallow(
+        <CitationSummaryGraph
+          publishedData={mockPublishedData}
+          citeableData={mockCiteableData}
+          loadingCitationSummary={false}
+          error={null}
+          onSelectBarChange={jest.fn()}
+        />
+      );
+      wrapper.setState({
+        hoveredBar: { type: PUBLISHED_BAR_TYPE, xValue: '0--0' },
+      });
+      const bucket = {
+        key: '0--0',
+        from: 0,
+        to: 1,
+        doc_count: 10,
+      };
+      const data = wrapper.instance().toSeriesData(bucket, PUBLISHED_BAR_TYPE);
+      const expectedData = {
+        x: '0--0',
+        y: 10,
+        label: '10',
+        color: HOVERED_ORANGE,
+      };
+      expect(data).toEqual(expectedData);
+    });
+    it('returns series data with correct color when selected bar', () => {
+      const wrapper = shallow(
+        <CitationSummaryGraph
+          publishedData={mockPublishedData}
+          citeableData={mockCiteableData}
+          loadingCitationSummary={false}
+          error={null}
+          onSelectBarChange={jest.fn()}
+          selectedBar={{ type: CITEABLE_BAR_TYPE, xValue: '0--0' }}
+        />
+      );
+      const bucketSelectedBar = {
+        key: '0--0',
+        from: 0,
+        to: 1,
+        doc_count: 10,
+      };
+      const dataSelectedBar = wrapper
+        .instance()
+        .toSeriesData(bucketSelectedBar, CITEABLE_BAR_TYPE);
+      const expectedDataSelectedBar = {
+        x: '0--0',
+        y: 10,
+        label: '10',
+        color: BLUE,
+      };
+      expect(dataSelectedBar).toEqual(expectedDataSelectedBar);
+
+      const bucketUnSelectedBar = {
+        key: '10--49',
+        from: 0,
+        to: 1,
+        doc_count: 10,
+      };
+      const dataUnSelectedBar = wrapper
+        .instance()
+        .toSeriesData(bucketUnSelectedBar, CITEABLE_BAR_TYPE);
+      const expectedDataUnSelectedBar = {
+        x: '10--49',
+        y: 10,
+        label: '10',
+        color: GRAY,
+      };
+      expect(dataUnSelectedBar).toEqual(expectedDataUnSelectedBar);
+    });
+  });
+  it('calls onSelectBarChange when citeable bar clicked', () => {
+    const onSelectBarChange = jest.fn();
+    const wrapper = shallow(
+      <CitationSummaryGraph
+        publishedData={mockPublishedData}
+        citeableData={mockCiteableData}
+        loadingCitationSummary={false}
+        error={null}
+        onSelectBarChange={onSelectBarChange}
+      />
+    );
+    const onCiteableBarClick = wrapper
+      .find('[data-test-id="citeable-bar-series"]')
+      .prop('onValueClick');
+    onCiteableBarClick({ x: '0--0' });
+    expect(onSelectBarChange).toHaveBeenCalledWith({
+      type: CITEABLE_BAR_TYPE,
+      xValue: '0--0',
+    });
+  });
+  it('calls onSelectBarChange with null when selected citeable bar clicked', () => {
+    const onSelectBarChange = jest.fn();
+    const wrapper = shallow(
+      <CitationSummaryGraph
+        publishedData={mockPublishedData}
+        citeableData={mockCiteableData}
+        loadingCitationSummary={false}
+        error={null}
+        onSelectBarChange={onSelectBarChange}
+        selectedBar={{ type: CITEABLE_BAR_TYPE, xValue: '0--0' }}
+      />
+    );
+    const onCiteableBarClick = wrapper
+      .find('[data-test-id="citeable-bar-series"]')
+      .prop('onValueClick');
+    onCiteableBarClick({ x: '0--0' });
+    expect(onSelectBarChange).toHaveBeenCalledWith(null);
+  });
+  it('calls onSelectBarChange when published bar clicked', () => {
+    const onSelectBarChange = jest.fn();
+    const wrapper = shallow(
+      <CitationSummaryGraph
+        publishedData={mockPublishedData}
+        citeableData={mockCiteableData}
+        loadingCitationSummary={false}
+        error={null}
+        onSelectBarChange={onSelectBarChange}
+      />
+    );
+    const onPublishedBarClick = wrapper
+      .find('[data-test-id="published-bar-series"]')
+      .prop('onValueClick');
+    onPublishedBarClick({ x: '0--0' });
+    expect(onSelectBarChange).toHaveBeenCalledWith({
+      type: PUBLISHED_BAR_TYPE,
+      xValue: '0--0',
+    });
+  });
+  it('adds hoveredBar to state when citeable bar is hovered', () => {
+    const onSelectBarChange = jest.fn();
+    const wrapper = shallow(
+      <CitationSummaryGraph
+        publishedData={mockPublishedData}
+        citeableData={mockCiteableData}
+        loadingCitationSummary={false}
+        error={null}
+        onSelectBarChange={onSelectBarChange}
+      />
+    );
+    const onCiteableBarHover = wrapper
+      .find('[data-test-id="citeable-bar-series"]')
+      .prop('onValueMouseOver');
+    onCiteableBarHover({ x: '0--0' });
+    expect(wrapper.state('hoveredBar')).toEqual({
+      type: CITEABLE_BAR_TYPE,
+      xValue: '0--0',
+    });
+  });
+  it('adds hoveredBar to state when published bar is hovered', () => {
+    const onSelectBarChange = jest.fn();
+    const wrapper = shallow(
+      <CitationSummaryGraph
+        publishedData={mockPublishedData}
+        citeableData={mockCiteableData}
+        loadingCitationSummary={false}
+        error={null}
+        onSelectBarChange={onSelectBarChange}
+      />
+    );
+    const onPublishedBarHover = wrapper
+      .find('[data-test-id="published-bar-series"]')
+      .prop('onValueMouseOver');
+    onPublishedBarHover({ x: '0--0' });
+    expect(wrapper.state('hoveredBar')).toEqual({
+      type: PUBLISHED_BAR_TYPE,
+      xValue: '0--0',
+    });
+  });
+  it('sets hoveredBar in state to null when published bar is not hovered anymore', () => {
+    const onSelectBarChange = jest.fn();
+    const wrapper = shallow(
+      <CitationSummaryGraph
+        publishedData={mockPublishedData}
+        citeableData={mockCiteableData}
+        loadingCitationSummary={false}
+        error={null}
+        onSelectBarChange={onSelectBarChange}
+      />
+    );
+    wrapper.setState({
+      hoveredBar: { type: PUBLISHED_BAR_TYPE, xValue: '0--0' },
+    });
+    const onPublishedBarUnHover = wrapper
+      .find('[data-test-id="published-bar-series"]')
+      .prop('onValueMouseOut');
+    onPublishedBarUnHover();
+    expect(wrapper.state('hoveredBar')).toEqual(null);
+  });
+  it('sets hoveredBar in state to null when citeable bar is not hovered anymore', () => {
+    const onSelectBarChange = jest.fn();
+    const wrapper = shallow(
+      <CitationSummaryGraph
+        publishedData={mockPublishedData}
+        citeableData={mockCiteableData}
+        loadingCitationSummary={false}
+        error={null}
+        onSelectBarChange={onSelectBarChange}
+      />
+    );
+    wrapper.setState({
+      hoveredBar: { type: CITEABLE_BAR_TYPE, xValue: '0--0' },
+    });
+    const onCiteableBarUnHover = wrapper
+      .find('[data-test-id="citeable-bar-series"]')
+      .prop('onValueMouseOut');
+    onCiteableBarUnHover();
+    expect(wrapper.state('hoveredBar')).toEqual(null);
   });
 });

--- a/ui/src/common/components/__tests__/__snapshots__/CitationSummaryGraph.test.jsx.snap
+++ b/ui/src/common/components/__tests__/__snapshots__/CitationSummaryGraph.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CitationSummaryGraph renders graph with all props given 1`] = `
+exports[`CitationSummaryGraph renders graph with selectedBar 1`] = `
 <div
   className="__CitationSummaryGraph__"
 >
@@ -28,7 +28,6 @@ exports[`CitationSummaryGraph renders graph with all props given 1`] = `
           span={23}
         >
           <FlexibleXYPlot
-            animation={true}
             height={300}
             xType="ordinal"
             yDomain={
@@ -57,36 +56,45 @@ exports[`CitationSummaryGraph renders graph with all props given 1`] = `
             <VerticalBarSeries
               barWidth={0.5}
               className=""
-              color="#1890ff"
+              colorType="literal"
               data={
                 Array [
                   Object {
+                    "color": "#bfbfbf",
                     "label": "1",
-                    "x": "0.0-1.0",
+                    "x": "0--0",
                     "y": 1,
                   },
                   Object {
+                    "color": "#bfbfbf",
                     "label": "2",
-                    "x": "1.0-50.0",
+                    "x": "1--50",
                     "y": 2,
                   },
                   Object {
+                    "color": "#bfbfbf",
                     "label": "3",
-                    "x": "50.0-250.0",
+                    "x": "50--250",
                     "y": 3,
                   },
                   Object {
+                    "color": "#bfbfbf",
                     "label": "4",
-                    "x": "250.0-500.0",
+                    "x": "250--500",
                     "y": 4,
                   },
                   Object {
+                    "color": "#1890ff",
                     "label": null,
-                    "x": "500.0-*",
+                    "x": "500--",
                     "y": 0,
                   },
                 ]
               }
+              data-test-id="citeable-bar-series"
+              onValueClick={[Function]}
+              onValueMouseOut={[Function]}
+              onValueMouseOver={[Function]}
               stack={false}
               style={Object {}}
             />
@@ -96,28 +104,33 @@ exports[`CitationSummaryGraph renders graph with all props given 1`] = `
               data={
                 Array [
                   Object {
+                    "color": "#bfbfbf",
                     "label": "1",
-                    "x": "0.0-1.0",
+                    "x": "0--0",
                     "y": 1,
                   },
                   Object {
+                    "color": "#bfbfbf",
                     "label": "2",
-                    "x": "1.0-50.0",
+                    "x": "1--50",
                     "y": 2,
                   },
                   Object {
+                    "color": "#bfbfbf",
                     "label": "3",
-                    "x": "50.0-250.0",
+                    "x": "50--250",
                     "y": 3,
                   },
                   Object {
+                    "color": "#bfbfbf",
                     "label": "4",
-                    "x": "250.0-500.0",
+                    "x": "250--500",
                     "y": 4,
                   },
                   Object {
+                    "color": "#1890ff",
                     "label": null,
-                    "x": "500.0-*",
+                    "x": "500--",
                     "y": 0,
                   },
                 ]
@@ -132,36 +145,45 @@ exports[`CitationSummaryGraph renders graph with all props given 1`] = `
             <VerticalBarSeries
               barWidth={0.5}
               className=""
-              color="#fa8c16"
+              colorType="literal"
               data={
                 Array [
                   Object {
+                    "color": "#bfbfbf",
                     "label": "1",
-                    "x": "0.0-1.0",
+                    "x": "0--0",
                     "y": 1,
                   },
                   Object {
+                    "color": "#bfbfbf",
                     "label": "2",
-                    "x": "1.0-50.0",
+                    "x": "1--50",
                     "y": 2,
                   },
                   Object {
+                    "color": "#bfbfbf",
                     "label": "3",
-                    "x": "50.0-250.0",
+                    "x": "50--250",
                     "y": 3,
                   },
                   Object {
+                    "color": "#bfbfbf",
                     "label": "4",
-                    "x": "250.0-500.0",
+                    "x": "250--500",
                     "y": 4,
                   },
                   Object {
+                    "color": "#bfbfbf",
                     "label": null,
-                    "x": "500.0-*",
+                    "x": "--500",
                     "y": 0,
                   },
                 ]
               }
+              data-test-id="published-bar-series"
+              onValueClick={[Function]}
+              onValueMouseOut={[Function]}
+              onValueMouseOver={[Function]}
               stack={false}
               style={Object {}}
             />
@@ -171,28 +193,583 @@ exports[`CitationSummaryGraph renders graph with all props given 1`] = `
               data={
                 Array [
                   Object {
+                    "color": "#bfbfbf",
                     "label": "1",
-                    "x": "0.0-1.0",
+                    "x": "0--0",
                     "y": 1,
                   },
                   Object {
+                    "color": "#bfbfbf",
                     "label": "2",
-                    "x": "1.0-50.0",
+                    "x": "1--50",
                     "y": 2,
                   },
                   Object {
+                    "color": "#bfbfbf",
                     "label": "3",
-                    "x": "50.0-250.0",
+                    "x": "50--250",
                     "y": 3,
                   },
                   Object {
+                    "color": "#bfbfbf",
                     "label": "4",
-                    "x": "250.0-500.0",
+                    "x": "250--500",
                     "y": 4,
                   },
                   Object {
+                    "color": "#bfbfbf",
                     "label": null,
-                    "x": "500.0-*",
+                    "x": "--500",
+                    "y": 0,
+                  },
+                ]
+              }
+              getLabel={[Function]}
+              labelAnchorX="start"
+              labelAnchorY="text-after-edge"
+              rotation={0}
+              stack={false}
+              style={Object {}}
+            />
+            <DiscreteColorLegendItem
+              className="legend"
+              colors={
+                Array [
+                  "#12939A",
+                  "#79C7E3",
+                  "#1A3177",
+                  "#FF9833",
+                  "#EF5D28",
+                ]
+              }
+              items={
+                Array [
+                  Object {
+                    "color": "#1890ff",
+                    "title": "Citeable",
+                  },
+                  Object {
+                    "color": "#fa8c16",
+                    "title": "Published",
+                  },
+                ]
+              }
+              orientation="horizontal"
+            />
+          </FlexibleXYPlot>
+        </Col>
+      </Row>
+      <Row
+        gutter={0}
+        justify="center"
+        type="flex"
+      >
+        <div
+          className="axis-label"
+        >
+          Citations
+        </div>
+      </Row>
+    </ErrorAlertOrChildren>
+  </LoadingOrChildren>
+</div>
+`;
+
+exports[`CitationSummaryGraph renders graph without SelectedBar 1`] = `
+<div
+  className="__CitationSummaryGraph__"
+>
+  <LoadingOrChildren
+    loading={false}
+  >
+    <ErrorAlertOrChildren
+      error={null}
+    >
+      <Row
+        align="middle"
+        gutter={0}
+        type="flex"
+      >
+        <Col
+          span={1}
+        >
+          <div
+            className="axis-label y-axis"
+          >
+            Papers
+          </div>
+        </Col>
+        <Col
+          span={23}
+        >
+          <FlexibleXYPlot
+            height={300}
+            xType="ordinal"
+            yDomain={
+              Array [
+                0,
+                5.2,
+              ]
+            }
+          >
+            <HorizontalGridLines
+              attr="y"
+              direction="horizontal"
+            />
+            <XAxis
+              attr="x"
+              attrAxis="y"
+              className="x-axis"
+              orientation="bottom"
+              tickFormat={[Function]}
+            />
+            <YAxis
+              attr="y"
+              attrAxis="x"
+              orientation="left"
+            />
+            <VerticalBarSeries
+              barWidth={0.5}
+              className=""
+              colorType="literal"
+              data={
+                Array [
+                  Object {
+                    "color": "#1890ff",
+                    "label": "1",
+                    "x": "0--0",
+                    "y": 1,
+                  },
+                  Object {
+                    "color": "#1890ff",
+                    "label": "2",
+                    "x": "1--50",
+                    "y": 2,
+                  },
+                  Object {
+                    "color": "#1890ff",
+                    "label": "3",
+                    "x": "50--250",
+                    "y": 3,
+                  },
+                  Object {
+                    "color": "#1890ff",
+                    "label": "4",
+                    "x": "250--500",
+                    "y": 4,
+                  },
+                  Object {
+                    "color": "#1890ff",
+                    "label": null,
+                    "x": "500--",
+                    "y": 0,
+                  },
+                ]
+              }
+              data-test-id="citeable-bar-series"
+              onValueClick={[Function]}
+              onValueMouseOut={[Function]}
+              onValueMouseOver={[Function]}
+              stack={false}
+              style={Object {}}
+            />
+            <LabelSeries
+              animation={false}
+              className=""
+              data={
+                Array [
+                  Object {
+                    "color": "#1890ff",
+                    "label": "1",
+                    "x": "0--0",
+                    "y": 1,
+                  },
+                  Object {
+                    "color": "#1890ff",
+                    "label": "2",
+                    "x": "1--50",
+                    "y": 2,
+                  },
+                  Object {
+                    "color": "#1890ff",
+                    "label": "3",
+                    "x": "50--250",
+                    "y": 3,
+                  },
+                  Object {
+                    "color": "#1890ff",
+                    "label": "4",
+                    "x": "250--500",
+                    "y": 4,
+                  },
+                  Object {
+                    "color": "#1890ff",
+                    "label": null,
+                    "x": "500--",
+                    "y": 0,
+                  },
+                ]
+              }
+              getLabel={[Function]}
+              labelAnchorX="end"
+              labelAnchorY="text-after-edge"
+              rotation={0}
+              stack={false}
+              style={Object {}}
+            />
+            <VerticalBarSeries
+              barWidth={0.5}
+              className=""
+              colorType="literal"
+              data={
+                Array [
+                  Object {
+                    "color": "#fa8c16",
+                    "label": "1",
+                    "x": "0--0",
+                    "y": 1,
+                  },
+                  Object {
+                    "color": "#fa8c16",
+                    "label": "2",
+                    "x": "1--50",
+                    "y": 2,
+                  },
+                  Object {
+                    "color": "#fa8c16",
+                    "label": "3",
+                    "x": "50--250",
+                    "y": 3,
+                  },
+                  Object {
+                    "color": "#fa8c16",
+                    "label": "4",
+                    "x": "250--500",
+                    "y": 4,
+                  },
+                  Object {
+                    "color": "#fa8c16",
+                    "label": null,
+                    "x": "--500",
+                    "y": 0,
+                  },
+                ]
+              }
+              data-test-id="published-bar-series"
+              onValueClick={[Function]}
+              onValueMouseOut={[Function]}
+              onValueMouseOver={[Function]}
+              stack={false}
+              style={Object {}}
+            />
+            <LabelSeries
+              animation={false}
+              className=""
+              data={
+                Array [
+                  Object {
+                    "color": "#fa8c16",
+                    "label": "1",
+                    "x": "0--0",
+                    "y": 1,
+                  },
+                  Object {
+                    "color": "#fa8c16",
+                    "label": "2",
+                    "x": "1--50",
+                    "y": 2,
+                  },
+                  Object {
+                    "color": "#fa8c16",
+                    "label": "3",
+                    "x": "50--250",
+                    "y": 3,
+                  },
+                  Object {
+                    "color": "#fa8c16",
+                    "label": "4",
+                    "x": "250--500",
+                    "y": 4,
+                  },
+                  Object {
+                    "color": "#fa8c16",
+                    "label": null,
+                    "x": "--500",
+                    "y": 0,
+                  },
+                ]
+              }
+              getLabel={[Function]}
+              labelAnchorX="start"
+              labelAnchorY="text-after-edge"
+              rotation={0}
+              stack={false}
+              style={Object {}}
+            />
+            <DiscreteColorLegendItem
+              className="legend"
+              colors={
+                Array [
+                  "#12939A",
+                  "#79C7E3",
+                  "#1A3177",
+                  "#FF9833",
+                  "#EF5D28",
+                ]
+              }
+              items={
+                Array [
+                  Object {
+                    "color": "#1890ff",
+                    "title": "Citeable",
+                  },
+                  Object {
+                    "color": "#fa8c16",
+                    "title": "Published",
+                  },
+                ]
+              }
+              orientation="horizontal"
+            />
+          </FlexibleXYPlot>
+        </Col>
+      </Row>
+      <Row
+        gutter={0}
+        justify="center"
+        type="flex"
+      >
+        <div
+          className="axis-label"
+        >
+          Citations
+        </div>
+      </Row>
+    </ErrorAlertOrChildren>
+  </LoadingOrChildren>
+</div>
+`;
+
+exports[`CitationSummaryGraph renders with hovered bar 1`] = `
+<div
+  className="__CitationSummaryGraph__"
+>
+  <LoadingOrChildren
+    loading={false}
+  >
+    <ErrorAlertOrChildren
+      error={null}
+    >
+      <Row
+        align="middle"
+        gutter={0}
+        type="flex"
+      >
+        <Col
+          span={1}
+        >
+          <div
+            className="axis-label y-axis"
+          >
+            Papers
+          </div>
+        </Col>
+        <Col
+          span={23}
+        >
+          <FlexibleXYPlot
+            height={300}
+            xType="ordinal"
+            yDomain={
+              Array [
+                0,
+                5.2,
+              ]
+            }
+          >
+            <HorizontalGridLines
+              attr="y"
+              direction="horizontal"
+            />
+            <XAxis
+              attr="x"
+              attrAxis="y"
+              className="x-axis"
+              orientation="bottom"
+              tickFormat={[Function]}
+            />
+            <YAxis
+              attr="y"
+              attrAxis="x"
+              orientation="left"
+            />
+            <VerticalBarSeries
+              barWidth={0.5}
+              className=""
+              colorType="literal"
+              data={
+                Array [
+                  Object {
+                    "color": "#1890ff",
+                    "label": "1",
+                    "x": "0--0",
+                    "y": 1,
+                  },
+                  Object {
+                    "color": "#1890ff",
+                    "label": "2",
+                    "x": "1--50",
+                    "y": 2,
+                  },
+                  Object {
+                    "color": "#1890ff",
+                    "label": "3",
+                    "x": "50--250",
+                    "y": 3,
+                  },
+                  Object {
+                    "color": "#1890ff",
+                    "label": "4",
+                    "x": "250--500",
+                    "y": 4,
+                  },
+                  Object {
+                    "color": "#096dd9",
+                    "label": null,
+                    "x": "500--",
+                    "y": 0,
+                  },
+                ]
+              }
+              data-test-id="citeable-bar-series"
+              onValueClick={[Function]}
+              onValueMouseOut={[Function]}
+              onValueMouseOver={[Function]}
+              stack={false}
+              style={Object {}}
+            />
+            <LabelSeries
+              animation={false}
+              className=""
+              data={
+                Array [
+                  Object {
+                    "color": "#1890ff",
+                    "label": "1",
+                    "x": "0--0",
+                    "y": 1,
+                  },
+                  Object {
+                    "color": "#1890ff",
+                    "label": "2",
+                    "x": "1--50",
+                    "y": 2,
+                  },
+                  Object {
+                    "color": "#1890ff",
+                    "label": "3",
+                    "x": "50--250",
+                    "y": 3,
+                  },
+                  Object {
+                    "color": "#1890ff",
+                    "label": "4",
+                    "x": "250--500",
+                    "y": 4,
+                  },
+                  Object {
+                    "color": "#096dd9",
+                    "label": null,
+                    "x": "500--",
+                    "y": 0,
+                  },
+                ]
+              }
+              getLabel={[Function]}
+              labelAnchorX="end"
+              labelAnchorY="text-after-edge"
+              rotation={0}
+              stack={false}
+              style={Object {}}
+            />
+            <VerticalBarSeries
+              barWidth={0.5}
+              className=""
+              colorType="literal"
+              data={
+                Array [
+                  Object {
+                    "color": "#fa8c16",
+                    "label": "1",
+                    "x": "0--0",
+                    "y": 1,
+                  },
+                  Object {
+                    "color": "#fa8c16",
+                    "label": "2",
+                    "x": "1--50",
+                    "y": 2,
+                  },
+                  Object {
+                    "color": "#fa8c16",
+                    "label": "3",
+                    "x": "50--250",
+                    "y": 3,
+                  },
+                  Object {
+                    "color": "#fa8c16",
+                    "label": "4",
+                    "x": "250--500",
+                    "y": 4,
+                  },
+                  Object {
+                    "color": "#fa8c16",
+                    "label": null,
+                    "x": "--500",
+                    "y": 0,
+                  },
+                ]
+              }
+              data-test-id="published-bar-series"
+              onValueClick={[Function]}
+              onValueMouseOut={[Function]}
+              onValueMouseOver={[Function]}
+              stack={false}
+              style={Object {}}
+            />
+            <LabelSeries
+              animation={false}
+              className=""
+              data={
+                Array [
+                  Object {
+                    "color": "#fa8c16",
+                    "label": "1",
+                    "x": "0--0",
+                    "y": 1,
+                  },
+                  Object {
+                    "color": "#fa8c16",
+                    "label": "2",
+                    "x": "1--50",
+                    "y": 2,
+                  },
+                  Object {
+                    "color": "#fa8c16",
+                    "label": "3",
+                    "x": "50--250",
+                    "y": 3,
+                  },
+                  Object {
+                    "color": "#fa8c16",
+                    "label": "4",
+                    "x": "250--500",
+                    "y": 4,
+                  },
+                  Object {
+                    "color": "#fa8c16",
+                    "label": null,
+                    "x": "--500",
                     "y": 0,
                   },
                 ]

--- a/ui/src/common/constants.js
+++ b/ui/src/common/constants.js
@@ -1,0 +1,4 @@
+export const PUBLISHED_QUERY = { citeable: true, refereed: true };
+export const CITEABLE_QUERY = { citeable: true };
+export const PUBLISHED_BAR_TYPE = 'published';
+export const CITEABLE_BAR_TYPE = 'citeable';

--- a/ui/src/common/containers/CitationSummaryGraphContainer.jsx
+++ b/ui/src/common/containers/CitationSummaryGraphContainer.jsx
@@ -1,9 +1,55 @@
 import { connect } from 'react-redux';
-import CitationSummaryGraph from '../components/CitationSummaryGraph/CitationSummaryGraph';
 import { convertAllImmutablePropsToJS } from '../immutableToJS';
+import {
+  fetchAuthorPublications,
+  fetchAuthorPublicationsFacets,
+} from '../../actions/authors';
+import {
+  CITEABLE_QUERY,
+  PUBLISHED_QUERY,
+  CITEABLE_BAR_TYPE,
+  PUBLISHED_BAR_TYPE,
+} from '../constants';
+import CitationSummaryGraph from '../components/CitationSummaryGraph';
+
+const CLEAR_QUERY = {
+  citeable: undefined,
+  refereed: undefined,
+  citation_count: undefined,
+};
+
+function barToQuery(bar) {
+  if (bar == null) {
+    return CLEAR_QUERY;
+  }
+  if (bar.type === CITEABLE_BAR_TYPE) {
+    return {
+      ...CITEABLE_QUERY,
+      citation_count: bar.xValue,
+      refereed: undefined,
+    };
+  }
+  return { ...PUBLISHED_QUERY, citation_count: bar.xValue };
+}
+
+export function queryToBar(query) {
+  if (query.get('citeable') && query.get('citation_count')) {
+    if (query.get('refereed')) {
+      return {
+        type: PUBLISHED_BAR_TYPE,
+        xValue: query.get('citation_count'),
+      };
+    }
+    return {
+      type: CITEABLE_BAR_TYPE,
+      xValue: query.get('citation_count'),
+    };
+  }
+  return null;
+}
 
 const stateToProps = state => ({
-  loadingCitationSummary: state.citations.get('loadingCitationSummary'),
+  loading: state.citations.get('loadingCitationSummary'),
   citeableData: state.citations.getIn([
     'citationSummary',
     'citations',
@@ -21,9 +67,16 @@ const stateToProps = state => ({
     'buckets',
   ]),
   error: state.citations.get('errorCitationSummary'),
+  selectedBar: queryToBar(state.authors.getIn(['publications', 'query'])),
 });
 
-const dispatchToProps = dispatch => ({ dispatch });
+const dispatchToProps = dispatch => ({
+  onSelectBarChange(bar) {
+    const query = barToQuery(bar);
+    dispatch(fetchAuthorPublications(query));
+    dispatch(fetchAuthorPublicationsFacets(query));
+  },
+});
 
 export default connect(stateToProps, dispatchToProps)(
   convertAllImmutablePropsToJS(CitationSummaryGraph)

--- a/ui/src/common/containers/__tests__/CitationSummaryGraphContainer.test.jsx
+++ b/ui/src/common/containers/__tests__/CitationSummaryGraphContainer.test.jsx
@@ -1,114 +1,271 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { fromJS } from 'immutable';
-
 import { getStoreWithState } from '../../../fixtures/store';
 import CitationSummaryGraphContainer from '../CitationSummaryGraphContainer';
+import CitationSummaryGraph from '../../components/CitationSummaryGraph/CitationSummaryGraph';
+import {
+  AUTHOR_PUBLICATIONS_REQUEST,
+  AUTHOR_PUBLICATIONS_FACETS_REQUEST,
+} from '../../../actions/actionTypes';
+import { CITEABLE_BAR_TYPE, PUBLISHED_BAR_TYPE } from '../../constants';
 
 jest.mock('../../../actions/citations');
 
+const mockCitationsStore = fromJS({
+  loadingCitationSummary: false,
+  errorCitationSummary: null,
+  citationSummary: {
+    doc_count: 30,
+    'h-index': {
+      value: {
+        all: 8,
+        published: 9,
+      },
+    },
+    citations: {
+      buckets: {
+        all: {
+          doc_count: 29,
+          citations_count: {
+            value: 2,
+          },
+          citation_buckets: {
+            buckets: [
+              {
+                key: '0.0-1.0',
+                from: 0,
+                to: 1,
+                doc_count: 1,
+              },
+              {
+                key: '1.0-50.0',
+                from: 1,
+                to: 50,
+                doc_count: 2,
+              },
+              {
+                key: '50.0-250.0',
+                from: 50,
+                to: 250,
+                doc_count: 3,
+              },
+              {
+                key: '250.0-500.0',
+                from: 250,
+                to: 500,
+                doc_count: 4,
+              },
+              {
+                key: '500.0-*',
+                from: 500,
+                doc_count: 0,
+              },
+            ],
+          },
+          average_citations: {
+            value: 4.12345,
+          },
+        },
+        published: {
+          doc_count: 0,
+          citations_count: {
+            value: 20,
+          },
+          citation_buckets: {
+            buckets: [
+              {
+                key: '0.0-1.0',
+                from: 0,
+                to: 1,
+                doc_count: 1,
+              },
+              {
+                key: '1.0-50.0',
+                from: 1,
+                to: 50,
+                doc_count: 2,
+              },
+              {
+                key: '50.0-250.0',
+                from: 50,
+                to: 250,
+                doc_count: 3,
+              },
+              {
+                key: '250.0-500.0',
+                from: 250,
+                to: 500,
+                doc_count: 4,
+              },
+              {
+                key: '500.0-*',
+                from: 500,
+                doc_count: 0,
+              },
+            ],
+          },
+          average_citations: {
+            value: 9,
+          },
+        },
+      },
+    },
+  },
+});
 describe('CitationSummaryGraphContainer', () => {
   it('renders with state from store', () => {
     const store = getStoreWithState({
-      citations: fromJS({
-        loadingCitationSummary: false,
-        errorCitationSummary: null,
-        citationSummary: {
-          doc_count: 30,
-          'h-index': {
-            value: {
-              all: 8,
-              published: 9,
-            },
-          },
-          citations: {
-            buckets: {
-              all: {
-                doc_count: 29,
-                citations_count: {
-                  value: 2,
-                },
-                citation_buckets: {
-                  buckets: [
-                    {
-                      key: '0.0-1.0',
-                      from: 0,
-                      to: 1,
-                      doc_count: 1,
-                    },
-                    {
-                      key: '1.0-50.0',
-                      from: 1,
-                      to: 50,
-                      doc_count: 2,
-                    },
-                    {
-                      key: '50.0-250.0',
-                      from: 50,
-                      to: 250,
-                      doc_count: 3,
-                    },
-                    {
-                      key: '250.0-500.0',
-                      from: 250,
-                      to: 500,
-                      doc_count: 4,
-                    },
-                    {
-                      key: '500.0-*',
-                      from: 500,
-                      doc_count: 0,
-                    },
-                  ],
-                },
-                average_citations: {
-                  value: 4.12345,
-                },
-              },
-              published: {
-                doc_count: 0,
-                citations_count: {
-                  value: 20,
-                },
-                citation_buckets: {
-                  buckets: [
-                    {
-                      key: '0.0-1.0',
-                      from: 0,
-                      to: 1,
-                      doc_count: 1,
-                    },
-                    {
-                      key: '1.0-50.0',
-                      from: 1,
-                      to: 50,
-                      doc_count: 2,
-                    },
-                    {
-                      key: '50.0-250.0',
-                      from: 50,
-                      to: 250,
-                      doc_count: 3,
-                    },
-                    {
-                      key: '250.0-500.0',
-                      from: 250,
-                      to: 500,
-                      doc_count: 4,
-                    },
-                    {
-                      key: '500.0-*',
-                      from: 500,
-                      doc_count: 0,
-                    },
-                  ],
-                },
-                average_citations: {
-                  value: 9,
-                },
-              },
-            },
-          },
+      citations: mockCitationsStore,
+    });
+    const wrapper = shallow(
+      <CitationSummaryGraphContainer store={store} />
+    ).dive();
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('dispatches fetch author publications and facets with clean query when onSelectBarChange called with null', () => {
+    const existingQuery = {
+      page: 3,
+      size: 10,
+      author: ['Harun'],
+      citeable: true,
+    };
+    const newQuery = {
+      page: 3,
+      size: 10,
+      author: ['Harun'],
+      citation_count: undefined,
+      citeable: undefined,
+      refereed: undefined,
+    };
+    const store = getStoreWithState({
+      authors: fromJS({
+        publications: {
+          query: existingQuery,
+        },
+      }),
+    });
+    const wrapper = mount(<CitationSummaryGraphContainer store={store} />);
+    wrapper.find(CitationSummaryGraph).prop('onSelectBarChange')(null);
+
+    const expectedActions = [
+      {
+        type: AUTHOR_PUBLICATIONS_REQUEST,
+        payload: newQuery,
+      },
+      {
+        type: AUTHOR_PUBLICATIONS_FACETS_REQUEST,
+        payload: newQuery,
+      },
+    ];
+    const actions = store.getActions().slice(0, 2);
+    expect(actions).toEqual(expectedActions);
+  });
+  it('dispatches fetch author publications and facets with citeable query when onSelectBarChange called with citeable bar', () => {
+    const existingQuery = {
+      page: 3,
+      size: 10,
+      author: ['Harun'],
+      citeable: true,
+    };
+    const newQuery = {
+      page: 3,
+      size: 10,
+      author: ['Harun'],
+      citation_count: '0--0',
+      citeable: true,
+      refereed: undefined,
+    };
+    const store = getStoreWithState({
+      authors: fromJS({
+        publications: {
+          query: existingQuery,
+        },
+      }),
+    });
+    const wrapper = mount(<CitationSummaryGraphContainer store={store} />);
+    wrapper.find(CitationSummaryGraph).prop('onSelectBarChange')({
+      xValue: '0--0',
+      type: CITEABLE_BAR_TYPE,
+    });
+
+    const expectedActions = [
+      {
+        type: AUTHOR_PUBLICATIONS_REQUEST,
+        payload: newQuery,
+      },
+      {
+        type: AUTHOR_PUBLICATIONS_FACETS_REQUEST,
+        payload: newQuery,
+      },
+    ];
+    const actions = store.getActions().slice(0, 2);
+    expect(actions).toEqual(expectedActions);
+  });
+  it('dispatches fetch author publications and facets with published query when onSelectBarChange called with published bar', () => {
+    const existingQuery = {
+      page: 3,
+      size: 10,
+      author: ['Harun'],
+      citeable: true,
+    };
+    const newQuery = {
+      page: 3,
+      size: 10,
+      author: ['Harun'],
+      citation_count: '0--0',
+      citeable: true,
+      refereed: true,
+    };
+    const store = getStoreWithState({
+      authors: fromJS({
+        publications: {
+          query: existingQuery,
+        },
+      }),
+    });
+    const wrapper = mount(<CitationSummaryGraphContainer store={store} />);
+    wrapper.find(CitationSummaryGraph).prop('onSelectBarChange')({
+      xValue: '0--0',
+      type: PUBLISHED_BAR_TYPE,
+    });
+
+    const expectedActions = [
+      {
+        type: AUTHOR_PUBLICATIONS_REQUEST,
+        payload: newQuery,
+      },
+      {
+        type: AUTHOR_PUBLICATIONS_FACETS_REQUEST,
+        payload: newQuery,
+      },
+    ];
+    const actions = store.getActions().slice(0, 2);
+    expect(actions).toEqual(expectedActions);
+  });
+
+  it('renders citeable selected bar', () => {
+    const store = getStoreWithState({
+      citations: mockCitationsStore,
+      authors: fromJS({
+        publications: {
+          query: { citeable: true, citation_count: '0--0' },
+        },
+      }),
+    });
+    const wrapper = shallow(
+      <CitationSummaryGraphContainer store={store} />
+    ).dive();
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders published selected bar', () => {
+    const store = getStoreWithState({
+      citations: mockCitationsStore,
+      authors: fromJS({
+        publications: {
+          query: { citeable: true, citation_count: '0--0', refereed: 'true' },
         },
       }),
     });

--- a/ui/src/common/containers/__tests__/__snapshots__/CitationSummaryGraphContainer.test.jsx.snap
+++ b/ui/src/common/containers/__tests__/__snapshots__/CitationSummaryGraphContainer.test.jsx.snap
@@ -1,5 +1,227 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CitationSummaryGraphContainer renders citeable selected bar 1`] = `
+<CitationSummaryGraph
+  citeableData={
+    Array [
+      Object {
+        "doc_count": 1,
+        "from": 0,
+        "key": "0.0-1.0",
+        "to": 1,
+      },
+      Object {
+        "doc_count": 2,
+        "from": 1,
+        "key": "1.0-50.0",
+        "to": 50,
+      },
+      Object {
+        "doc_count": 3,
+        "from": 50,
+        "key": "50.0-250.0",
+        "to": 250,
+      },
+      Object {
+        "doc_count": 4,
+        "from": 250,
+        "key": "250.0-500.0",
+        "to": 500,
+      },
+      Object {
+        "doc_count": 0,
+        "from": 500,
+        "key": "500.0-*",
+      },
+    ]
+  }
+  error={null}
+  loading={false}
+  onSelectBarChange={[Function]}
+  publishedData={
+    Array [
+      Object {
+        "doc_count": 1,
+        "from": 0,
+        "key": "0.0-1.0",
+        "to": 1,
+      },
+      Object {
+        "doc_count": 2,
+        "from": 1,
+        "key": "1.0-50.0",
+        "to": 50,
+      },
+      Object {
+        "doc_count": 3,
+        "from": 50,
+        "key": "50.0-250.0",
+        "to": 250,
+      },
+      Object {
+        "doc_count": 4,
+        "from": 250,
+        "key": "250.0-500.0",
+        "to": 500,
+      },
+      Object {
+        "doc_count": 0,
+        "from": 500,
+        "key": "500.0-*",
+      },
+    ]
+  }
+  selectedBar={
+    Object {
+      "type": "citeable",
+      "xValue": "0--0",
+    }
+  }
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+  storeSubscription={
+    Subscription {
+      "listeners": Object {
+        "clear": [Function],
+        "get": [Function],
+        "notify": [Function],
+        "subscribe": [Function],
+      },
+      "onStateChange": [Function],
+      "parentSub": undefined,
+      "store": Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      },
+      "unsubscribe": [Function],
+    }
+  }
+/>
+`;
+
+exports[`CitationSummaryGraphContainer renders published selected bar 1`] = `
+<CitationSummaryGraph
+  citeableData={
+    Array [
+      Object {
+        "doc_count": 1,
+        "from": 0,
+        "key": "0.0-1.0",
+        "to": 1,
+      },
+      Object {
+        "doc_count": 2,
+        "from": 1,
+        "key": "1.0-50.0",
+        "to": 50,
+      },
+      Object {
+        "doc_count": 3,
+        "from": 50,
+        "key": "50.0-250.0",
+        "to": 250,
+      },
+      Object {
+        "doc_count": 4,
+        "from": 250,
+        "key": "250.0-500.0",
+        "to": 500,
+      },
+      Object {
+        "doc_count": 0,
+        "from": 500,
+        "key": "500.0-*",
+      },
+    ]
+  }
+  error={null}
+  loading={false}
+  onSelectBarChange={[Function]}
+  publishedData={
+    Array [
+      Object {
+        "doc_count": 1,
+        "from": 0,
+        "key": "0.0-1.0",
+        "to": 1,
+      },
+      Object {
+        "doc_count": 2,
+        "from": 1,
+        "key": "1.0-50.0",
+        "to": 50,
+      },
+      Object {
+        "doc_count": 3,
+        "from": 50,
+        "key": "50.0-250.0",
+        "to": 250,
+      },
+      Object {
+        "doc_count": 4,
+        "from": 250,
+        "key": "250.0-500.0",
+        "to": 500,
+      },
+      Object {
+        "doc_count": 0,
+        "from": 500,
+        "key": "500.0-*",
+      },
+    ]
+  }
+  selectedBar={
+    Object {
+      "type": "published",
+      "xValue": "0--0",
+    }
+  }
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+  storeSubscription={
+    Subscription {
+      "listeners": Object {
+        "clear": [Function],
+        "get": [Function],
+        "notify": [Function],
+        "subscribe": [Function],
+      },
+      "onStateChange": [Function],
+      "parentSub": undefined,
+      "store": Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      },
+      "unsubscribe": [Function],
+    }
+  }
+/>
+`;
+
 exports[`CitationSummaryGraphContainer renders with state from store 1`] = `
 <CitationSummaryGraph
   citeableData={
@@ -35,9 +257,9 @@ exports[`CitationSummaryGraphContainer renders with state from store 1`] = `
       },
     ]
   }
-  dispatch={[Function]}
   error={null}
-  loadingCitationSummary={false}
+  loading={false}
+  onSelectBarChange={[Function]}
   publishedData={
     Array [
       Object {
@@ -71,6 +293,7 @@ exports[`CitationSummaryGraphContainer renders with state from store 1`] = `
       },
     ]
   }
+  selectedBar={null}
   store={
     Object {
       "clearActions": [Function],

--- a/ui/src/styleVariables.js
+++ b/ui/src/styleVariables.js
@@ -22,4 +22,7 @@ module.exports = {
   'border-color-split': 'rgb(232, 232, 232)',
   'card-radius': '2px',
   'orange-6': '#fa8c16',
+  'orange-7': '#d46b08',
+  'blue-7': '#096dd9',
+  'gray-6': '#bfbfbf',
 };


### PR DESCRIPTION
* Added interactivity to the citation summary graph
* On hover, the color darkens a bit. On click, it refetches author publications and facets and the other bars are grayed out
* INSPIR-2388