### PR TITLE
search: server-side sort options

### DIFF
--- a/data/records/literature/1721418.json
+++ b/data/records/literature/1721418.json
@@ -21,7 +21,7 @@
     "submission_number": "1465450"
   },
   "arxiv_eprints": [
-    { "categories": ["gr-qc", "hep-th", "math.DG"], "value": "1902.07899" }
+    { "categories": ["gr-qc", "hep-th", "math.DG"], "value": "1902.17899" }
   ],
   "authors": [
     {
@@ -71,7 +71,7 @@
   "documents": [
     {
       "fulltext": true,
-      "key": "1902.07899.pdf",
+      "key": "1902.17899.pdf",
       "source": "arxiv",
       "url":
         "file:///afs/cern.ch/project/inspire/PROD/var/data/files/g184/3697965/content.pdf%3B1"

--- a/docker-compose.services.yml
+++ b/docker-compose.services.yml
@@ -8,6 +8,7 @@
 version: '2.1'
 services:
   app:
+    restart: "always"
     build:
       context: ./
       args:

--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -399,7 +399,9 @@ CONFERENCES.update(
                     "acronyms",
                     "titles",
                     "address",
-                    "opening_date" "cnum" "control_number",
+                    "opening_date",
+                    "cnum",
+                    "control_number",
                     "self",
                 ],
                 "completion": {"field": "conferenceautocomplete"},
@@ -541,13 +543,13 @@ RECORDS_REST_FACETS = {
 RECORDS_REST_SORT_OPTIONS = {
     "records-hep": {
         "mostrecent": {
-            "title": "Most recent",
+            "title": "Most Recent",
             "fields": ["-earliest_date"],
             "default_order": "asc",  # Used for invenio-search-js config
             "order": 1,
         },
         "mostcited": {
-            "title": "Most cited",
+            "title": "Most Cited",
             "fields": ["-citation_count"],
             "default_order": "asc",  # Used for invenio-search-js config
             "order": 2,

--- a/inspirehep/records/serializers/json.py
+++ b/inspirehep/records/serializers/json.py
@@ -7,12 +7,11 @@
 
 import json
 
-from invenio_records_rest.serializers.json import JSONSerializer
 from invenio_records_rest.serializers.response import search_responsify
 from marshmallow import Schema
 
 from inspirehep.accounts.api import is_superuser_or_cataloger_logged_in
-from inspirehep.serializers import ConditionalMultiSchemaJSONSerializer
+from inspirehep.serializers import ConditionalMultiSchemaJSONSerializer, JSONSerializer
 
 from ..marshmallow.authors import (
     AuthorsOnlyControlNumberSchemaV1,
@@ -61,7 +60,9 @@ literature_json_v1_response_search = search_responsify(
 )
 
 literature_json_ui_v1 = JSONSerializer(LiteratureUISchemaV1)
-literature_json_ui_v1_search = JSONSerializer(LiteratureSearchUISchemaV1)
+literature_json_ui_v1_search = JSONSerializer(
+    LiteratureSearchUISchemaV1, index_name="records-hep"
+)
 
 literature_json_ui_v1_response = record_responsify(
     literature_json_ui_v1, "application/vnd+inspire.record.ui+json"

--- a/tests/integration/records/serializers/test_json.py
+++ b/tests/integration/records/serializers/test_json.py
@@ -314,6 +314,28 @@ def test_literature_json_ui_v1_response_search(api_client, db, create_record):
     assert expected_result == expected_data_hits
 
 
+def test_literature_json_ui_v1_response_search_has_sort_options(
+    api_client, db, create_record
+):
+    headers = {"Accept": "application/vnd+inspire.record.ui+json"}
+    record = create_record("lit")
+
+    expected_status_code = 200
+    expected_sort_options = [
+        {"value": "mostrecent", "display": "Most Recent"},
+        {"value": "mostcited", "display": "Most Cited"},
+        {"value": "bestmatch", "display": "Best Match"},
+    ]
+    response = api_client.get("/literature", headers=headers)
+
+    response_status_code = response.status_code
+    response_data = json.loads(response.data)
+    sort_options = response_data["sort_options"]
+
+    assert expected_status_code == response_status_code
+    assert expected_sort_options == sort_options
+
+
 def test_literature_application_json_authors(api_client, db, create_record):
     headers = {"Accept": "application/json"}
     full_name_1 = faker.name()
@@ -620,6 +642,24 @@ def test_authors_default_json_v1_response_search(
 
     assert expected_status_code == response_status_code
     assert expected_result == response_data_hits_metadata
+
+
+def test_authors_json_v1_response_search_does_not_have_sort_options(
+    api_client, db, create_record
+):
+    headers = {"Accept": "application/json"}
+    record = create_record("aut")
+
+    expected_status_code = 200
+    expected_sort_options = None
+    response = api_client.get("/authors", headers=headers)
+
+    response_status_code = response.status_code
+    response_data = json.loads(response.data)
+    sort_options = response_data["sort_options"]
+
+    assert expected_status_code == response_status_code
+    assert expected_sort_options == sort_options
 
 
 def test_authors_application_json_v1_response_search_with_logged_in_cataloger(

--- a/ui/src/authors/containers/AuthorPublicationsContainer.jsx
+++ b/ui/src/authors/containers/AuthorPublicationsContainer.jsx
@@ -15,6 +15,7 @@ const stateToProps = state => ({
   ]),
   query: state.authors.getIn(['publications', 'query']),
   results: state.authors.getIn(['publications', 'results']),
+  sortOptions: state.authors.getIn(['publications', 'sortOptions']),
   loadingResults: state.authors.getIn(['publications', 'loadingResults']),
   numberOfResults: state.authors.getIn(['publications', 'total']),
   error: state.authors.getIn(['publications', 'error']),
@@ -28,5 +29,5 @@ export const dispatchToProps = dispatch => ({
 });
 
 export default connect(stateToProps, dispatchToProps)(
-  convertSomeImmutablePropsToJS(EmbeddedSearch, ['query'])
+  convertSomeImmutablePropsToJS(EmbeddedSearch, ['query', 'sortOptions'])
 );

--- a/ui/src/authors/containers/__tests__/AuthorPublicationsContainer.test.jsx
+++ b/ui/src/authors/containers/__tests__/AuthorPublicationsContainer.test.jsx
@@ -15,9 +15,10 @@ describe('AuthorPublicationsContainer', () => {
     const store = getStoreWithState({
       authors: fromJS({
         publications: {
-          query: { size: 10, page: 2, q: 'dude' },
+          query: { size: 10, page: 2, q: 'dude', sort: 'mostrecent' },
           results: [{ control_number: 1 }, { control_number: 2 }],
           aggregations: { agg1: { foo: 'bar' } },
+          sortOptions: [{ value: 'mostrecent', display: 'Most Recent' }],
           loadingResults: true,
           loadingAggregations: true,
           numberOfResults: 50,
@@ -34,7 +35,12 @@ describe('AuthorPublicationsContainer', () => {
 
   // FIXME: avoid also testing that actions merging newQuery and state query
   it('dispatches fetch author publications and facets onQueryChange', () => {
-    const existingQuery = { page: 3, size: 10, author: ['Harun'] };
+    const existingQuery = {
+      page: 3,
+      size: 10,
+      author: ['Harun'],
+      sort: 'mostrecent',
+    };
     const queryChange = { sort: 'mostcited' };
     const newQuery = {
       page: 3,

--- a/ui/src/authors/containers/__tests__/__snapshots__/AuthorPublicationsContainer.test.jsx.snap
+++ b/ui/src/authors/containers/__tests__/__snapshots__/AuthorPublicationsContainer.test.jsx.snap
@@ -23,6 +23,7 @@ exports[`AuthorPublicationsContainer passes all props to embedded search 1`] = `
       "page": 2,
       "q": "dude",
       "size": 10,
+      "sort": "mostrecent",
     }
   }
   renderResultItem={[MockFunction]}
@@ -33,6 +34,14 @@ exports[`AuthorPublicationsContainer passes all props to embedded search 1`] = `
       },
       Immutable.Map {
         "control_number": 2,
+      },
+    ]
+  }
+  sortOptions={
+    Array [
+      Object {
+        "display": "Most Recent",
+        "value": "mostrecent",
       },
     ]
   }

--- a/ui/src/common/components/EmbeddedSearch.jsx
+++ b/ui/src/common/components/EmbeddedSearch.jsx
@@ -11,6 +11,7 @@ import SearchResults from './SearchResults';
 import SearchPagination from './SearchPagination';
 import ResponsiveView from './ResponsiveView';
 import DrawerHandle from './DrawerHandle';
+import { SelectOptionsPropType } from '../propTypes';
 
 class EmbeddedSearch extends Component {
   constructor(props) {
@@ -67,6 +68,7 @@ class EmbeddedSearch extends Component {
       error,
       numberOfResults,
       loadingResults,
+      sortOptions,
     } = this.props;
     return (
       !error && (
@@ -100,7 +102,11 @@ class EmbeddedSearch extends Component {
                   )}
                 />
                 <Col>
-                  <SortBy onSortChange={this.onSortChange} sort={query.sort} />
+                  <SortBy
+                    onSortChange={this.onSortChange}
+                    sort={query.sort}
+                    sortOptions={sortOptions}
+                  />
                 </Col>
               </Row>
               <Row>
@@ -133,6 +139,7 @@ EmbeddedSearch.propTypes = {
   onQueryChange: PropTypes.func,
   results: PropTypes.instanceOf(List),
   aggregations: PropTypes.instanceOf(Map),
+  sortOptions: SelectOptionsPropType,
   numberOfResults: PropTypes.number,
   loadingResults: PropTypes.bool,
   loadingAggregations: PropTypes.bool,
@@ -142,6 +149,7 @@ EmbeddedSearch.propTypes = {
 EmbeddedSearch.defaultProps = {
   error: null,
   onQueryChange: null,
+  sortOptions: null,
   results: List(),
   aggregations: Map(),
   numberOfResults: 0,

--- a/ui/src/common/components/SelectBox.jsx
+++ b/ui/src/common/components/SelectBox.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import { Select } from 'antd';
+import { SelectOptionsPropType } from '../propTypes';
 
 class SelectBox extends Component {
   render() {
@@ -25,12 +25,7 @@ class SelectBox extends Component {
 }
 
 SelectBox.propTypes = {
-  options: PropTypes.arrayOf(
-    PropTypes.shape({
-      value: PropTypes.string.isRequired,
-      display: PropTypes.string,
-    })
-  ).isRequired,
+  options: SelectOptionsPropType.isRequired,
   ...Select.propTypes,
 };
 

--- a/ui/src/common/components/SortBy.jsx
+++ b/ui/src/common/components/SortBy.jsx
@@ -2,38 +2,30 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import SelectBox from './SelectBox';
-
-const SORT_BY_OPTIONS = [
-  {
-    display: 'Most Recent',
-    value: 'mostrecent',
-  },
-  {
-    display: 'Most Cited',
-    value: 'mostcited',
-  },
-];
+import { SelectOptionsPropType } from '../propTypes';
 
 class SortBy extends Component {
   render() {
-    const { sort, onSortChange } = this.props;
+    const { sort, onSortChange, sortOptions } = this.props;
     return (
-      <SelectBox
-        onChange={onSortChange}
-        defaultValue={sort}
-        options={SORT_BY_OPTIONS}
-      />
+      sortOptions && (
+        <SelectBox
+          onChange={onSortChange}
+          defaultValue={sort}
+          options={sortOptions}
+        />
+      )
     );
   }
 }
 
 SortBy.propTypes = {
   onSortChange: PropTypes.func.isRequired,
-  sort: PropTypes.string,
+  sortOptions: SelectOptionsPropType,
+  sort: PropTypes.string.isRequired,
 };
 
 SortBy.defaultProps = {
-  sort: SORT_BY_OPTIONS[0].value,
+  sortOptions: null,
 };
-
 export default SortBy;

--- a/ui/src/common/components/__tests__/EmbeddedSearch.test.jsx
+++ b/ui/src/common/components/__tests__/EmbeddedSearch.test.jsx
@@ -13,7 +13,7 @@ describe('EmbeddedSearch', () => {
     const renderResultItem = jest.fn();
     const wrapper = shallow(
       <EmbeddedSearch
-        query={{ size: 2, page: 2 }}
+        query={{ size: 2, page: 2, sort: 'mostrecent' }}
         renderResultItem={renderResultItem}
       />
     );
@@ -28,7 +28,7 @@ describe('EmbeddedSearch', () => {
     const renderResultItem = jest.fn();
     const wrapper = shallow(
       <EmbeddedSearch
-        query={{ size: 2, page: 2 }}
+        query={{ size: 2, page: 2, sort: 'mostrecent' }}
         renderResultItem={renderResultItem}
         error={fromJS({ message: 'error' })}
       />
@@ -41,10 +41,11 @@ describe('EmbeddedSearch', () => {
       <EmbeddedSearch
         renderResultItem={jest.fn()}
         onQueryChange={jest.fn()}
-        query={{ doc_type: 'article', size: 2, page: 2 }}
+        query={{ doc_type: 'article', size: 2, page: 2, sort: 'mostrecent' }}
         aggregations={fromJS({
           agg1: { foo: 'bar' },
         })}
+        sortOptions={[{ value: 'mostrecent', display: 'Most Recent' }]}
         results={fromJS([{ value: '1' }, { value: '2' }])}
         numberOfResults={5}
         loadingAggregations
@@ -58,7 +59,7 @@ describe('EmbeddedSearch', () => {
     const onQueryChange = jest.fn();
     const wrapper = shallow(
       <EmbeddedSearch
-        query={{ size: 2, page: 2 }}
+        query={{ size: 2, page: 2, sort: 'mostrecent' }}
         renderResultItem={jest.fn()}
         onQueryChange={onQueryChange}
       />
@@ -74,7 +75,7 @@ describe('EmbeddedSearch', () => {
     const onQueryChange = jest.fn();
     const wrapper = shallow(
       <EmbeddedSearch
-        query={{ size: 2, page: 2 }}
+        query={{ size: 2, page: 2, sort: 'mostrecent' }}
         renderResultItem={jest.fn()}
         onQueryChange={onQueryChange}
       />
@@ -89,7 +90,7 @@ describe('EmbeddedSearch', () => {
     const onQueryChange = jest.fn();
     const wrapper = shallow(
       <EmbeddedSearch
-        query={{ size: 2, page: 2 }}
+        query={{ size: 2, page: 2, sort: 'mostrecent' }}
         renderResultItem={jest.fn()}
         onQueryChange={onQueryChange}
       />

--- a/ui/src/common/components/__tests__/SortBy.test.jsx
+++ b/ui/src/common/components/__tests__/SortBy.test.jsx
@@ -7,6 +7,17 @@ import SelectBox from '../SelectBox';
 describe('SortBy', () => {
   it('renders with all props set', () => {
     const wrapper = shallow(
+      <SortBy
+        sort="mostrecent"
+        onSortChange={jest.fn()}
+        sortOptions={[{ value: 'mostrecent', display: 'Most Recent' }]}
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('does not render if sortOptions missing', () => {
+    const wrapper = shallow(
       <SortBy sort="mostrecent" onSortChange={jest.fn()} />
     );
     expect(wrapper).toMatchSnapshot();
@@ -15,7 +26,11 @@ describe('SortBy', () => {
   it('calls onSortChange when select box change', () => {
     const onSortChange = jest.fn();
     const wrapper = shallow(
-      <SortBy sort="mostrecent" onSortChange={onSortChange} />
+      <SortBy
+        sort="mostrecent"
+        onSortChange={onSortChange}
+        sortOptions={[{ value: 'mostrecent', display: 'Most Recent' }]}
+      />
     );
     const onSelectBoxChange = wrapper.find(SelectBox).prop('onChange');
     const sort = 'mostcited';

--- a/ui/src/common/components/__tests__/__snapshots__/EmbeddedSearch.test.jsx.snap
+++ b/ui/src/common/components/__tests__/__snapshots__/EmbeddedSearch.test.jsx.snap
@@ -44,6 +44,14 @@ exports[`EmbeddedSearch renders with all props set except error 1`] = `
           <SortBy
             onSortChange={[Function]}
             sort="mostrecent"
+            sortOptions={
+              Array [
+                Object {
+                  "display": "Most Recent",
+                  "value": "mostrecent",
+                },
+              ]
+            }
           />
         </Col>
       </Row>
@@ -125,6 +133,7 @@ exports[`EmbeddedSearch renders with only required props 1`] = `
           <SortBy
             onSortChange={[Function]}
             sort="mostrecent"
+            sortOptions={null}
           />
         </Col>
       </Row>

--- a/ui/src/common/components/__tests__/__snapshots__/SortBy.test.jsx.snap
+++ b/ui/src/common/components/__tests__/__snapshots__/SortBy.test.jsx.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SortBy does not render if sortOptions missing 1`] = `""`;
+
 exports[`SortBy renders with all props set 1`] = `
 <SelectBox
   defaultValue="mostrecent"
@@ -9,10 +11,6 @@ exports[`SortBy renders with all props set 1`] = `
       Object {
         "display": "Most Recent",
         "value": "mostrecent",
-      },
-      Object {
-        "display": "Most Cited",
-        "value": "mostcited",
       },
     ]
   }

--- a/ui/src/common/containers/SortByContainer.jsx
+++ b/ui/src/common/containers/SortByContainer.jsx
@@ -2,9 +2,13 @@ import { connect } from 'react-redux';
 import { pushQueryToLocation } from '../../actions/search';
 
 import SortBy from '../components/SortBy';
+import { convertAllImmutablePropsToJS } from '../immutableToJS';
 
 const stateToProps = state => ({
-  sort: state.router.location.query.sort,
+  sort:
+    state.router.location.query.sort ||
+    state.search.getIn(['scope', 'query', 'sort']),
+  sortOptions: state.search.get('sortOptions'),
 });
 
 export const dispatchToProps = dispatch => ({
@@ -13,4 +17,9 @@ export const dispatchToProps = dispatch => ({
   },
 });
 
-export default connect(stateToProps, dispatchToProps)(SortBy);
+const SortByContainer = connect(stateToProps, dispatchToProps)(
+  convertAllImmutablePropsToJS(SortBy)
+);
+SortByContainer.displayName = 'SortByContainer';
+
+export default SortByContainer;

--- a/ui/src/common/layouts/SearchLayout/SearchLayout.jsx
+++ b/ui/src/common/layouts/SearchLayout/SearchLayout.jsx
@@ -24,12 +24,7 @@ class SearchLayout extends Component {
   }
 
   render() {
-    const {
-      renderResultItem,
-      loading,
-      withoutSort,
-      withoutAggregations,
-    } = this.props;
+    const { renderResultItem, loading, withoutAggregations } = this.props;
     return (
       <Row className="__SearchLayout__" gutter={32} type="flex" justify="start">
         <Col xs={0} lg={8} xl={7} xxl={5}>
@@ -58,7 +53,7 @@ class SearchLayout extends Component {
                 />
               </Col>
               <Col className="tr" span={12}>
-                {!withoutSort && <SortByContainer />}
+                <SortByContainer />
               </Col>
             </Row>
             <Row>
@@ -77,14 +72,12 @@ class SearchLayout extends Component {
 SearchLayout.propTypes = {
   renderResultItem: PropTypes.func.isRequired,
   withoutAggregations: PropTypes.bool,
-  withoutSort: PropTypes.bool,
   loading: PropTypes.bool.isRequired,
   loadingAggregations: PropTypes.bool.isRequired,
 };
 
 SearchLayout.defaultProps = {
   withoutAggregations: false,
-  withoutSort: false,
 };
 
 const stateToProps = state => ({

--- a/ui/src/common/layouts/SearchLayout/__tests__/SearchLayout.test.jsx
+++ b/ui/src/common/layouts/SearchLayout/__tests__/SearchLayout.test.jsx
@@ -29,7 +29,7 @@ describe('SearchLayout', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('renders without aggregations and sort', () => {
+  it('renders without aggregations', () => {
     const store = getStore();
     const wrapper = shallow(
       <SearchLayout

--- a/ui/src/common/layouts/SearchLayout/__tests__/__snapshots__/SearchLayout.test.jsx.snap
+++ b/ui/src/common/layouts/SearchLayout/__tests__/__snapshots__/SearchLayout.test.jsx.snap
@@ -52,7 +52,7 @@ exports[`SearchLayout renders with initial state 1`] = `
           className="tr"
           span={12}
         >
-          <Connect(SortBy) />
+          <SortByContainer />
         </Col>
       </Row>
       <Row
@@ -124,7 +124,7 @@ exports[`SearchLayout renders with loading states true 1`] = `
           className="tr"
           span={12}
         >
-          <Connect(SortBy) />
+          <SortByContainer />
         </Col>
       </Row>
       <Row
@@ -144,7 +144,7 @@ exports[`SearchLayout renders with loading states true 1`] = `
 </Row>
 `;
 
-exports[`SearchLayout renders without aggregations and sort 1`] = `
+exports[`SearchLayout renders without aggregations 1`] = `
 <Row
   className="__SearchLayout__"
   gutter={32}
@@ -190,7 +190,9 @@ exports[`SearchLayout renders without aggregations and sort 1`] = `
         <Col
           className="tr"
           span={12}
-        />
+        >
+          <SortByContainer />
+        </Col>
       </Row>
       <Row
         gutter={0}

--- a/ui/src/common/propTypes.js
+++ b/ui/src/common/propTypes.js
@@ -6,3 +6,10 @@ export const ErrorPropType = PropTypes.oneOfType([
   NullPropType,
   PropTypes.instanceOf(Map),
 ]);
+
+export const SelectOptionsPropType = PropTypes.arrayOf(
+  PropTypes.shape({
+    value: PropTypes.string.isRequired,
+    display: PropTypes.string,
+  })
+);

--- a/ui/src/reducers/__tests__/authors.test.js
+++ b/ui/src/reducers/__tests__/authors.test.js
@@ -102,6 +102,7 @@ describe('authors reducer', () => {
         ],
         total: 5,
       },
+      sort_options: [{ value: 'mostrecent', display: 'Most Recent' }],
     };
     const state = reducer(Map(), {
       type: AUTHOR_PUBLICATIONS_SUCCESS,
@@ -111,6 +112,7 @@ describe('authors reducer', () => {
       publications: {
         results: payload.hits.hits,
         total: payload.hits.total,
+        sortOptions: payload.sort_options,
         error: initialState.getIn(['publications', 'error']),
         loadingResults: false,
       },
@@ -127,6 +129,7 @@ describe('authors reducer', () => {
       publications: {
         results: initialState.getIn(['publications', 'results']),
         total: initialState.getIn(['publications', 'total']),
+        sortOptions: initialState.getIn(['publications', 'sortOptions']),
         error: { message: 'error' },
         loadingResults: false,
       },

--- a/ui/src/reducers/__tests__/search.test.js
+++ b/ui/src/reducers/__tests__/search.test.js
@@ -7,24 +7,7 @@ import * as types from '../../actions/actionTypes';
 describe('search reducer', () => {
   it('default', () => {
     const state = reducer(undefined, {});
-    const expected = fromJS({
-      loading: false,
-      total: 0,
-      scope: {
-        name: 'literature',
-        pathname: 'literature',
-        query: {
-          sort: 'mostrecent',
-          size: '25',
-          page: '1',
-        },
-      },
-      error: null,
-      aggregations: Map(),
-      loadingAggregations: false,
-      aggregationsError: null,
-    });
-    expect(state).toEqual(expected);
+    expect(state).toEqual(initialState);
   });
 
   it('LOCATION_CHANGE authors', () => {
@@ -72,12 +55,14 @@ describe('search reducer', () => {
         hits: ['found'],
         total: 1,
       },
+      sort_options: [{ value: 'mostrecent', display: 'Most Recent' }],
     };
     const state = reducer(Map(), { type: types.SEARCH_SUCCESS, payload });
     const expected = fromJS({
       loading: false,
       total: payload.hits.total,
       results: payload.hits.hits,
+      sortOptions: payload.sort_options,
       error: initialState.get('error'),
     });
     expect(state).toEqual(expected);

--- a/ui/src/reducers/authors.js
+++ b/ui/src/reducers/authors.js
@@ -20,6 +20,7 @@ export const initialState = fromJS({
   publications: {
     loadingResults: false,
     total: 0,
+    sortOptions: null,
     query: {
       page: 1,
       size: 10,
@@ -60,6 +61,10 @@ const authorsReducer = (state = initialState, action) => {
       return state
         .setIn(['publications', 'loadingResults'], false)
         .setIn(['publications', 'total'], fromJS(action.payload.hits.total))
+        .setIn(
+          ['publications', 'sortOptions'],
+          fromJS(action.payload.sort_options)
+        )
         .setIn(['publications', 'results'], fromJS(action.payload.hits.hits))
         .setIn(
           ['publications', 'error'],
@@ -72,6 +77,10 @@ const authorsReducer = (state = initialState, action) => {
         .setIn(
           ['publications', 'total'],
           initialState.getIn(['publications', 'total'])
+        )
+        .setIn(
+          ['publications', 'sortOptions'],
+          initialState.getIn(['publications', 'sortOptions'])
         )
         .setIn(
           ['publications', 'results'],

--- a/ui/src/reducers/search.js
+++ b/ui/src/reducers/search.js
@@ -35,6 +35,7 @@ export const initialState = fromJS({
   total: 0,
   scope: searchScopes.get('literature'),
   error: null,
+  sortOptions: null,
   aggregations: {},
   loadingAggregations: false,
   aggregationsError: null,
@@ -55,6 +56,7 @@ const searchReducer = (state = initialState, action) => {
       return state
         .set('loading', false)
         .set('total', fromJS(action.payload.hits.total))
+        .set('sortOptions', fromJS(action.payload.sort_options))
         .set('results', fromJS(action.payload.hits.hits))
         .set('error', initialState.get('error'));
     case SEARCH_ERROR:


### PR DESCRIPTION
* Sort option now comes with search results and rendered on the UI
dynamically, so that we can avoid hardcoding them on the UI and
creating different SortBy for each collections since sort options
change by collection.

* Makes [web] and [worker] services "restart: always" to avoid crashing
due to syntax errors during development

* Fixes literature record in `data/records` which had duplicate pid
(arxiv)