### PR TITLE
ui: Align numbers for citation summary graph

### DIFF
--- a/ui/src/common/components/CitationSummaryTable/CitationSummaryTable.jsx
+++ b/ui/src/common/components/CitationSummaryTable/CitationSummaryTable.jsx
@@ -11,7 +11,7 @@ import { ErrorPropType } from '../../propTypes';
 
 const CITABLE_HELP_MESSAGE = (
   <span>
-    Published papers are believed to have undergone rigorous peer-review.&nbsp;
+    Published papers are believed to have undergone rigorous peer review.&nbsp;
     <ExternalLink href="http://inspirehep.net/info/faq/general#published">
       Learn More
     </ExternalLink>

--- a/ui/src/common/components/CitationSummaryTable/__tests__/__snapshots__/CitationSummaryTable.test.jsx.snap
+++ b/ui/src/common/components/CitationSummaryTable/__tests__/__snapshots__/CitationSummaryTable.test.jsx.snap
@@ -24,7 +24,7 @@ exports[`CitationSummaryTable renders table without render props 1`] = `
               <LabelWithHelp
                 help={
                   <span>
-                    Published papers are believed to have undergone rigorous peer-review. 
+                    Published papers are believed to have undergone rigorous peer review. 
                     <ExternalLink
                       href="http://inspirehep.net/info/faq/general#published"
                     >

--- a/ui/src/common/components/CitationsByYearGraph/__tests__/CitationsByYearGraph.test.jsx
+++ b/ui/src/common/components/CitationsByYearGraph/__tests__/CitationsByYearGraph.test.jsx
@@ -22,6 +22,43 @@ describe('CitationsByYearGraph', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('renders citations for less than 5 different citation counts with tickValues for the YAxis', () => {
+    const citationsByYear = {
+      '1999': 10,
+      '2000': 10,
+      '2001': 5,
+      '2002': 5,
+    };
+    const wrapper = shallow(
+      <CitationsByYearGraph
+        citationsByYear={citationsByYear}
+        loading={false}
+        error={null}
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders more than 5 different citation counts without explicit tickValues for the YAxis', () => {
+    const citationsByYear = {
+      '1999': 10,
+      '2000': 5,
+      '2001': 50,
+      '2002': 7,
+      '2003': 51,
+      '2004': 56,
+      '2005': 14,
+    };
+    const wrapper = shallow(
+      <CitationsByYearGraph
+        citationsByYear={citationsByYear}
+        loading={false}
+        error={null}
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it('renders citations for less than 3 years with dummy data for previous 1-2 years', () => {
     const citationsByYear = {
       '1999': 10,

--- a/ui/src/common/components/CitationsByYearGraph/__tests__/__snapshots__/CitationsByYearGraph.test.jsx.snap
+++ b/ui/src/common/components/CitationsByYearGraph/__tests__/__snapshots__/CitationsByYearGraph.test.jsx.snap
@@ -34,6 +34,12 @@ exports[`CitationsByYearGraph renders citations for less than 3 years with dummy
             "top": 10,
           }
         }
+        yDomain={
+          Array [
+            0,
+            10,
+          ]
+        }
       >
         <XAxis
           attr="x"
@@ -53,6 +59,14 @@ exports[`CitationsByYearGraph renders citations for less than 3 years with dummy
           attr="y"
           attrAxis="x"
           orientation="left"
+          tickFormat={[Function]}
+          tickTotal={5}
+          tickValues={
+            Array [
+              0,
+              10,
+            ]
+          }
         />
         <LineSeries
           className=""
@@ -71,6 +85,112 @@ exports[`CitationsByYearGraph renders citations for less than 3 years with dummy
               Object {
                 "x": 1999,
                 "y": 10,
+              },
+            ]
+          }
+          getNull={[Function]}
+          onNearestX={[Function]}
+          opacity={1}
+          stack={false}
+          strokeStyle="solid"
+          style={Object {}}
+        />
+      </FlexibleXYPlot>
+    </Tooltip>
+  </ErrorAlertOrChildren>
+</LoadingOrChildren>
+`;
+
+exports[`CitationsByYearGraph renders citations for less than 5 different citation counts with tickValues for the YAxis 1`] = `
+<LoadingOrChildren
+  loading={false}
+>
+  <ErrorAlertOrChildren
+    error={null}
+  >
+    <Tooltip
+      arrowPointAtCenter={false}
+      autoAdjustOverflow={true}
+      mouseEnterDelay={0.1}
+      mouseLeaveDelay={0.1}
+      placement="bottom"
+      prefixCls="ant-tooltip"
+      title={
+        <span>
+          <strong />
+           citations in
+           
+          <strong />
+        </span>
+      }
+      transitionName="zoom-big-fast"
+    >
+      <FlexibleXYPlot
+        height={250}
+        margin={
+          Object {
+            "bottom": 40,
+            "left": 40,
+            "right": 20,
+            "top": 10,
+          }
+        }
+        yDomain={
+          Array [
+            0,
+            10,
+          ]
+        }
+      >
+        <XAxis
+          attr="x"
+          attrAxis="y"
+          orientation="bottom"
+          tickFormat={[Function]}
+          tickTotal={7}
+          tickValues={
+            Array [
+              1999,
+              2000,
+              2001,
+              2002,
+            ]
+          }
+        />
+        <YAxis
+          attr="y"
+          attrAxis="x"
+          orientation="left"
+          tickFormat={[Function]}
+          tickTotal={5}
+          tickValues={
+            Array [
+              10,
+              5,
+            ]
+          }
+        />
+        <LineSeries
+          className=""
+          color="#1890ff"
+          curve={null}
+          data={
+            Array [
+              Object {
+                "x": 1999,
+                "y": 10,
+              },
+              Object {
+                "x": 2000,
+                "y": 10,
+              },
+              Object {
+                "x": 2001,
+                "y": 5,
+              },
+              Object {
+                "x": 2002,
+                "y": 5,
               },
             ]
           }
@@ -121,6 +241,12 @@ exports[`CitationsByYearGraph renders citations for more than 3 less than 8 year
             "top": 10,
           }
         }
+        yDomain={
+          Array [
+            0,
+            56,
+          ]
+        }
       >
         <XAxis
           attr="x"
@@ -141,6 +267,16 @@ exports[`CitationsByYearGraph renders citations for more than 3 less than 8 year
           attr="y"
           attrAxis="x"
           orientation="left"
+          tickFormat={[Function]}
+          tickTotal={5}
+          tickValues={
+            Array [
+              10,
+              5,
+              56,
+              33,
+            ]
+          }
         />
         <LineSeries
           className=""
@@ -213,6 +349,12 @@ exports[`CitationsByYearGraph renders filling missing years with 0 1`] = `
             "top": 10,
           }
         }
+        yDomain={
+          Array [
+            0,
+            43,
+          ]
+        }
       >
         <XAxis
           attr="x"
@@ -226,6 +368,16 @@ exports[`CitationsByYearGraph renders filling missing years with 0 1`] = `
           attr="y"
           attrAxis="x"
           orientation="left"
+          tickFormat={[Function]}
+          tickTotal={5}
+          tickValues={
+            Array [
+              10,
+              0,
+              43,
+              5,
+            ]
+          }
         />
         <LineSeries
           className=""
@@ -350,6 +502,12 @@ exports[`CitationsByYearGraph renders hovered info in a tooltip on line series h
             "top": 10,
           }
         }
+        yDomain={
+          Array [
+            0,
+            56,
+          ]
+        }
       >
         <XAxis
           attr="x"
@@ -369,6 +527,15 @@ exports[`CitationsByYearGraph renders hovered info in a tooltip on line series h
           attr="y"
           attrAxis="x"
           orientation="left"
+          tickFormat={[Function]}
+          tickTotal={5}
+          tickValues={
+            Array [
+              10,
+              5,
+              56,
+            ]
+          }
         />
         <LineSeries
           className=""
@@ -387,6 +554,112 @@ exports[`CitationsByYearGraph renders hovered info in a tooltip on line series h
               Object {
                 "x": 2001,
                 "y": 56,
+              },
+            ]
+          }
+          getNull={[Function]}
+          onNearestX={[Function]}
+          opacity={1}
+          stack={false}
+          strokeStyle="solid"
+          style={Object {}}
+        />
+      </FlexibleXYPlot>
+    </Tooltip>
+  </ErrorAlertOrChildren>
+</LoadingOrChildren>
+`;
+
+exports[`CitationsByYearGraph renders more than 5 different citation counts without explicit tickValues for the YAxis 1`] = `
+<LoadingOrChildren
+  loading={false}
+>
+  <ErrorAlertOrChildren
+    error={null}
+  >
+    <Tooltip
+      arrowPointAtCenter={false}
+      autoAdjustOverflow={true}
+      mouseEnterDelay={0.1}
+      mouseLeaveDelay={0.1}
+      placement="bottom"
+      prefixCls="ant-tooltip"
+      title={
+        <span>
+          <strong />
+           citations in
+           
+          <strong />
+        </span>
+      }
+      transitionName="zoom-big-fast"
+    >
+      <FlexibleXYPlot
+        height={250}
+        margin={
+          Object {
+            "bottom": 40,
+            "left": 40,
+            "right": 20,
+            "top": 10,
+          }
+        }
+        yDomain={
+          Array [
+            0,
+            56,
+          ]
+        }
+      >
+        <XAxis
+          attr="x"
+          attrAxis="y"
+          orientation="bottom"
+          tickFormat={[Function]}
+          tickTotal={7}
+          tickValues={null}
+        />
+        <YAxis
+          attr="y"
+          attrAxis="x"
+          orientation="left"
+          tickFormat={[Function]}
+          tickTotal={5}
+          tickValues={null}
+        />
+        <LineSeries
+          className=""
+          color="#1890ff"
+          curve={null}
+          data={
+            Array [
+              Object {
+                "x": 1999,
+                "y": 10,
+              },
+              Object {
+                "x": 2000,
+                "y": 5,
+              },
+              Object {
+                "x": 2001,
+                "y": 50,
+              },
+              Object {
+                "x": 2002,
+                "y": 7,
+              },
+              Object {
+                "x": 2003,
+                "y": 51,
+              },
+              Object {
+                "x": 2004,
+                "y": 56,
+              },
+              Object {
+                "x": 2005,
+                "y": 14,
               },
             ]
           }
@@ -437,6 +710,12 @@ exports[`CitationsByYearGraph renders more than 8 years without explicit tickVal
             "top": 10,
           }
         }
+        yDomain={
+          Array [
+            0,
+            123,
+          ]
+        }
       >
         <XAxis
           attr="x"
@@ -450,6 +729,9 @@ exports[`CitationsByYearGraph renders more than 8 years without explicit tickVal
           attr="y"
           attrAxis="x"
           orientation="left"
+          tickFormat={[Function]}
+          tickTotal={5}
+          tickValues={null}
         />
         <LineSeries
           className=""
@@ -574,6 +856,12 @@ exports[`CitationsByYearGraph renders without citations 1`] = `
             "top": 10,
           }
         }
+        yDomain={
+          Array [
+            0,
+            0,
+          ]
+        }
       >
         <XAxis
           attr="x"
@@ -587,6 +875,9 @@ exports[`CitationsByYearGraph renders without citations 1`] = `
           attr="y"
           attrAxis="x"
           orientation="left"
+          tickFormat={[Function]}
+          tickTotal={5}
+          tickValues={Array []}
         />
         <LineSeries
           className=""

--- a/ui/src/common/components/__tests__/__snapshots__/CitationSummaryGraph.test.jsx.snap
+++ b/ui/src/common/components/__tests__/__snapshots__/CitationSummaryGraph.test.jsx.snap
@@ -32,7 +32,7 @@ exports[`CitationSummaryGraph renders graph with selectedBar 1`] = `
             yDomain={
               Array [
                 0,
-                5.2,
+                5.6,
               ]
             }
           >
@@ -60,30 +60,35 @@ exports[`CitationSummaryGraph renders graph with selectedBar 1`] = `
                     "color": "#bfbfbf",
                     "label": "1",
                     "x": "0--0",
+                    "xOffset": -0,
                     "y": 1,
                   },
                   Object {
                     "color": "#bfbfbf",
                     "label": "2",
                     "x": "1--50",
+                    "xOffset": -0,
                     "y": 2,
                   },
                   Object {
                     "color": "#bfbfbf",
                     "label": "3",
                     "x": "50--250",
+                    "xOffset": -0,
                     "y": 3,
                   },
                   Object {
                     "color": "#bfbfbf",
                     "label": "4",
                     "x": "250--500",
+                    "xOffset": -0,
                     "y": 4,
                   },
                   Object {
                     "color": "#1890ff",
                     "label": null,
                     "x": "500--",
+                    "xOffset": -0,
                     "y": 0,
                   },
                 ]
@@ -104,36 +109,41 @@ exports[`CitationSummaryGraph renders graph with selectedBar 1`] = `
                     "color": "#bfbfbf",
                     "label": "1",
                     "x": "0--0",
+                    "xOffset": -0,
                     "y": 1,
                   },
                   Object {
                     "color": "#bfbfbf",
                     "label": "2",
                     "x": "1--50",
+                    "xOffset": -0,
                     "y": 2,
                   },
                   Object {
                     "color": "#bfbfbf",
                     "label": "3",
                     "x": "50--250",
+                    "xOffset": -0,
                     "y": 3,
                   },
                   Object {
                     "color": "#bfbfbf",
                     "label": "4",
                     "x": "250--500",
+                    "xOffset": -0,
                     "y": 4,
                   },
                   Object {
                     "color": "#1890ff",
                     "label": null,
                     "x": "500--",
+                    "xOffset": -0,
                     "y": 0,
                   },
                 ]
               }
               getLabel={[Function]}
-              labelAnchorX="end"
+              labelAnchorX="middle"
               labelAnchorY="text-after-edge"
               rotation={0}
               stack={false}
@@ -149,30 +159,35 @@ exports[`CitationSummaryGraph renders graph with selectedBar 1`] = `
                     "color": "#bfbfbf",
                     "label": "1",
                     "x": "0--0",
+                    "xOffset": 0,
                     "y": 1,
                   },
                   Object {
                     "color": "#bfbfbf",
                     "label": "2",
                     "x": "1--50",
+                    "xOffset": 0,
                     "y": 2,
                   },
                   Object {
                     "color": "#bfbfbf",
                     "label": "3",
                     "x": "50--250",
+                    "xOffset": 0,
                     "y": 3,
                   },
                   Object {
                     "color": "#bfbfbf",
                     "label": "4",
                     "x": "250--500",
+                    "xOffset": 0,
                     "y": 4,
                   },
                   Object {
                     "color": "#bfbfbf",
                     "label": null,
                     "x": "--500",
+                    "xOffset": 0,
                     "y": 0,
                   },
                 ]
@@ -193,36 +208,41 @@ exports[`CitationSummaryGraph renders graph with selectedBar 1`] = `
                     "color": "#bfbfbf",
                     "label": "1",
                     "x": "0--0",
+                    "xOffset": 0,
                     "y": 1,
                   },
                   Object {
                     "color": "#bfbfbf",
                     "label": "2",
                     "x": "1--50",
+                    "xOffset": 0,
                     "y": 2,
                   },
                   Object {
                     "color": "#bfbfbf",
                     "label": "3",
                     "x": "50--250",
+                    "xOffset": 0,
                     "y": 3,
                   },
                   Object {
                     "color": "#bfbfbf",
                     "label": "4",
                     "x": "250--500",
+                    "xOffset": 0,
                     "y": 4,
                   },
                   Object {
                     "color": "#bfbfbf",
                     "label": null,
                     "x": "--500",
+                    "xOffset": 0,
                     "y": 0,
                   },
                 ]
               }
               getLabel={[Function]}
-              labelAnchorX="start"
+              labelAnchorX="middle"
               labelAnchorY="text-after-edge"
               rotation={0}
               stack={false}
@@ -293,7 +313,7 @@ exports[`CitationSummaryGraph renders graph without SelectedBar 1`] = `
             yDomain={
               Array [
                 0,
-                5.2,
+                5.6,
               ]
             }
           >
@@ -321,30 +341,35 @@ exports[`CitationSummaryGraph renders graph without SelectedBar 1`] = `
                     "color": "#1890ff",
                     "label": "1",
                     "x": "0--0",
+                    "xOffset": -0,
                     "y": 1,
                   },
                   Object {
                     "color": "#1890ff",
                     "label": "2",
                     "x": "1--50",
+                    "xOffset": -0,
                     "y": 2,
                   },
                   Object {
                     "color": "#1890ff",
                     "label": "3",
                     "x": "50--250",
+                    "xOffset": -0,
                     "y": 3,
                   },
                   Object {
                     "color": "#1890ff",
                     "label": "4",
                     "x": "250--500",
+                    "xOffset": -0,
                     "y": 4,
                   },
                   Object {
                     "color": "#1890ff",
                     "label": null,
                     "x": "500--",
+                    "xOffset": -0,
                     "y": 0,
                   },
                 ]
@@ -365,36 +390,41 @@ exports[`CitationSummaryGraph renders graph without SelectedBar 1`] = `
                     "color": "#1890ff",
                     "label": "1",
                     "x": "0--0",
+                    "xOffset": -0,
                     "y": 1,
                   },
                   Object {
                     "color": "#1890ff",
                     "label": "2",
                     "x": "1--50",
+                    "xOffset": -0,
                     "y": 2,
                   },
                   Object {
                     "color": "#1890ff",
                     "label": "3",
                     "x": "50--250",
+                    "xOffset": -0,
                     "y": 3,
                   },
                   Object {
                     "color": "#1890ff",
                     "label": "4",
                     "x": "250--500",
+                    "xOffset": -0,
                     "y": 4,
                   },
                   Object {
                     "color": "#1890ff",
                     "label": null,
                     "x": "500--",
+                    "xOffset": -0,
                     "y": 0,
                   },
                 ]
               }
               getLabel={[Function]}
-              labelAnchorX="end"
+              labelAnchorX="middle"
               labelAnchorY="text-after-edge"
               rotation={0}
               stack={false}
@@ -410,30 +440,35 @@ exports[`CitationSummaryGraph renders graph without SelectedBar 1`] = `
                     "color": "#fa8c16",
                     "label": "1",
                     "x": "0--0",
+                    "xOffset": 0,
                     "y": 1,
                   },
                   Object {
                     "color": "#fa8c16",
                     "label": "2",
                     "x": "1--50",
+                    "xOffset": 0,
                     "y": 2,
                   },
                   Object {
                     "color": "#fa8c16",
                     "label": "3",
                     "x": "50--250",
+                    "xOffset": 0,
                     "y": 3,
                   },
                   Object {
                     "color": "#fa8c16",
                     "label": "4",
                     "x": "250--500",
+                    "xOffset": 0,
                     "y": 4,
                   },
                   Object {
                     "color": "#fa8c16",
                     "label": null,
                     "x": "--500",
+                    "xOffset": 0,
                     "y": 0,
                   },
                 ]
@@ -454,36 +489,41 @@ exports[`CitationSummaryGraph renders graph without SelectedBar 1`] = `
                     "color": "#fa8c16",
                     "label": "1",
                     "x": "0--0",
+                    "xOffset": 0,
                     "y": 1,
                   },
                   Object {
                     "color": "#fa8c16",
                     "label": "2",
                     "x": "1--50",
+                    "xOffset": 0,
                     "y": 2,
                   },
                   Object {
                     "color": "#fa8c16",
                     "label": "3",
                     "x": "50--250",
+                    "xOffset": 0,
                     "y": 3,
                   },
                   Object {
                     "color": "#fa8c16",
                     "label": "4",
                     "x": "250--500",
+                    "xOffset": 0,
                     "y": 4,
                   },
                   Object {
                     "color": "#fa8c16",
                     "label": null,
                     "x": "--500",
+                    "xOffset": 0,
                     "y": 0,
                   },
                 ]
               }
               getLabel={[Function]}
-              labelAnchorX="start"
+              labelAnchorX="middle"
               labelAnchorY="text-after-edge"
               rotation={0}
               stack={false}
@@ -554,7 +594,7 @@ exports[`CitationSummaryGraph renders with hovered bar 1`] = `
             yDomain={
               Array [
                 0,
-                5.2,
+                5.6,
               ]
             }
           >
@@ -582,30 +622,35 @@ exports[`CitationSummaryGraph renders with hovered bar 1`] = `
                     "color": "#1890ff",
                     "label": "1",
                     "x": "0--0",
+                    "xOffset": -0,
                     "y": 1,
                   },
                   Object {
                     "color": "#1890ff",
                     "label": "2",
                     "x": "1--50",
+                    "xOffset": -0,
                     "y": 2,
                   },
                   Object {
                     "color": "#1890ff",
                     "label": "3",
                     "x": "50--250",
+                    "xOffset": -0,
                     "y": 3,
                   },
                   Object {
                     "color": "#1890ff",
                     "label": "4",
                     "x": "250--500",
+                    "xOffset": -0,
                     "y": 4,
                   },
                   Object {
                     "color": "#096dd9",
                     "label": null,
                     "x": "500--",
+                    "xOffset": -0,
                     "y": 0,
                   },
                 ]
@@ -626,36 +671,41 @@ exports[`CitationSummaryGraph renders with hovered bar 1`] = `
                     "color": "#1890ff",
                     "label": "1",
                     "x": "0--0",
+                    "xOffset": -0,
                     "y": 1,
                   },
                   Object {
                     "color": "#1890ff",
                     "label": "2",
                     "x": "1--50",
+                    "xOffset": -0,
                     "y": 2,
                   },
                   Object {
                     "color": "#1890ff",
                     "label": "3",
                     "x": "50--250",
+                    "xOffset": -0,
                     "y": 3,
                   },
                   Object {
                     "color": "#1890ff",
                     "label": "4",
                     "x": "250--500",
+                    "xOffset": -0,
                     "y": 4,
                   },
                   Object {
                     "color": "#096dd9",
                     "label": null,
                     "x": "500--",
+                    "xOffset": -0,
                     "y": 0,
                   },
                 ]
               }
               getLabel={[Function]}
-              labelAnchorX="end"
+              labelAnchorX="middle"
               labelAnchorY="text-after-edge"
               rotation={0}
               stack={false}
@@ -671,30 +721,35 @@ exports[`CitationSummaryGraph renders with hovered bar 1`] = `
                     "color": "#fa8c16",
                     "label": "1",
                     "x": "0--0",
+                    "xOffset": 0,
                     "y": 1,
                   },
                   Object {
                     "color": "#fa8c16",
                     "label": "2",
                     "x": "1--50",
+                    "xOffset": 0,
                     "y": 2,
                   },
                   Object {
                     "color": "#fa8c16",
                     "label": "3",
                     "x": "50--250",
+                    "xOffset": 0,
                     "y": 3,
                   },
                   Object {
                     "color": "#fa8c16",
                     "label": "4",
                     "x": "250--500",
+                    "xOffset": 0,
                     "y": 4,
                   },
                   Object {
                     "color": "#fa8c16",
                     "label": null,
                     "x": "--500",
+                    "xOffset": 0,
                     "y": 0,
                   },
                 ]
@@ -715,36 +770,41 @@ exports[`CitationSummaryGraph renders with hovered bar 1`] = `
                     "color": "#fa8c16",
                     "label": "1",
                     "x": "0--0",
+                    "xOffset": 0,
                     "y": 1,
                   },
                   Object {
                     "color": "#fa8c16",
                     "label": "2",
                     "x": "1--50",
+                    "xOffset": 0,
                     "y": 2,
                   },
                   Object {
                     "color": "#fa8c16",
                     "label": "3",
                     "x": "50--250",
+                    "xOffset": 0,
                     "y": 3,
                   },
                   Object {
                     "color": "#fa8c16",
                     "label": "4",
                     "x": "250--500",
+                    "xOffset": 0,
                     "y": 4,
                   },
                   Object {
                     "color": "#fa8c16",
                     "label": null,
                     "x": "--500",
+                    "xOffset": 0,
                     "y": 0,
                   },
                 ]
               }
               getLabel={[Function]}
-              labelAnchorX="start"
+              labelAnchorX="middle"
               labelAnchorY="text-after-edge"
               rotation={0}
               stack={false}


### PR DESCRIPTION
* Aligned the numbers for the citation summary graph based on the width of the container INSPIR-2441
* Changed the yAxis domain for the citation by year graph to start from 0
* Changed the yAxis for the citation by year graph to not have non-integer ticks
* Changed peer-review to peer review in the citation summary table INSPIR-2421
