### PR TITLE
Dropdown menus should stay unchanged for jobs page

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -39,6 +39,7 @@
     "lodash.isplainobject": "^4.0.6",
     "lodash.maxby": "^4.6.0",
     "lodash.mergewith": "^4.6.1",
+    "lodash.omit": "^4.5.0",
     "lodash.transform": "^4.6.0",
     "math-interval-2": "^1.1.0",
     "moment": "^2.24.0",

--- a/ui/src/actions/search.js
+++ b/ui/src/actions/search.js
@@ -94,7 +94,9 @@ function searchAggregationsError(error) {
   };
 }
 
-export function fetchSearchAggregationsForCurrentLocation() {
+export function fetchSearchAggregationsForCurrentLocation(
+  useLocationQuery = true
+) {
   return async (dispatch, getState, http) => {
     dispatch(fetchingSearchAggregations());
 
@@ -103,7 +105,9 @@ export function fetchSearchAggregationsForCurrentLocation() {
     const {
       router: { location },
     } = state;
-    const url = `${location.pathname}/facets?${searchQueryString}`;
+    const url = `${location.pathname}/facets${
+      useLocationQuery ? `?${searchQueryString}` : ''
+    }`;
     try {
       const response = await http.get(url);
       dispatch(searchAggregationsSuccess(response.data));

--- a/ui/src/common/components/AggregationFilters.jsx
+++ b/ui/src/common/components/AggregationFilters.jsx
@@ -20,10 +20,11 @@ class AggregationFilters extends Component {
       query,
       onAggregationChange,
       inline,
+      displayWhenNoResults,
     } = this.props;
     return (
       aggregations &&
-      numberOfResults > 0 && (
+      (numberOfResults > 0 || displayWhenNoResults) && (
         <Row className="bg-white pa3" type="flex" justify="space-between">
           {aggregations
             .entrySeq()
@@ -65,10 +66,12 @@ AggregationFilters.propTypes = {
   aggregations: PropTypes.instanceOf(Immutable.Map).isRequired,
   query: PropTypes.objectOf(PropTypes.any).isRequired,
   numberOfResults: PropTypes.number.isRequired,
+  displayWhenNoResults: PropTypes.bool,
 };
 
 AggregationFilters.defaultProps = {
   inline: false,
+  displayWhenNoResults: false,
 };
 
 export default AggregationFilters;

--- a/ui/src/common/components/__tests__/AggregationFilters.test.jsx
+++ b/ui/src/common/components/__tests__/AggregationFilters.test.jsx
@@ -155,4 +155,33 @@ describe('AggregationFilters', () => {
     onAggregationFilterChange(['foo', 'bar']);
     expect(onAggregationChange).toBeCalledWith('agg', ['foo', 'bar']);
   });
+
+  it('renders aggregations when numberOfResults is 0 and displayWhenNoResults is true', () => {
+    const aggregations = fromJS({
+      agg: {
+        buckets: [
+          {
+            key: 'foo',
+            doc_count: 0,
+          },
+        ],
+        meta: {
+          title: 'Jessica Jones',
+          order: 1,
+          type: 'checkbox',
+        },
+      },
+    });
+    const query = {};
+    const wrapper = shallow(
+      <AggregationFilters
+        query={query}
+        aggregations={aggregations}
+        numberOfResults={0}
+        onAggregationChange={jest.fn()}
+        displayWhenNoResults
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/ui/src/common/components/__tests__/__snapshots__/AggregationFilters.test.jsx.snap
+++ b/ui/src/common/components/__tests__/__snapshots__/AggregationFilters.test.jsx.snap
@@ -35,6 +35,42 @@ exports[`AggregationFilters does not render aggregations with empty buckets 1`] 
 </Row>
 `;
 
+exports[`AggregationFilters renders aggregations when numberOfResults is 0 and displayWhenNoResults is true 1`] = `
+<Row
+  className="bg-white pa3"
+  gutter={0}
+  justify="space-between"
+  type="flex"
+>
+  <Col
+    gutter={32}
+    key="agg"
+    lg={24}
+    xs={24}
+  >
+    <EventTracker
+      eventId="Facet-Jessica Jones"
+      eventPropName="onChange"
+      extractEventArgsToForward={null}
+    >
+      <AggregationFilter
+        aggregationType="checkbox"
+        buckets={
+          Immutable.List [
+            Immutable.Map {
+              "key": "foo",
+              "doc_count": 0,
+            },
+          ]
+        }
+        name="Jessica Jones"
+        onChange={[Function]}
+      />
+    </EventTracker>
+  </Col>
+</Row>
+`;
+
 exports[`AggregationFilters renders with all props set 1`] = `
 <Row
   className="bg-white pa3"

--- a/ui/src/jobs/containers/SearchLayout.jsx
+++ b/ui/src/jobs/containers/SearchLayout.jsx
@@ -33,7 +33,7 @@ class SearchLayout extends Component {
     const { loadingAggregations } = this.props;
     return (
       <LoadingOrChildren loading={loadingAggregations}>
-        <AggregationFiltersContainer inline />
+        <AggregationFiltersContainer inline displayWhenNoResults />
       </LoadingOrChildren>
     );
   }
@@ -43,7 +43,7 @@ class SearchLayout extends Component {
     return (
       <DrawerHandle className="mt2" handleText="Filter" drawerTitle="Filter">
         <LoadingOrChildren loading={loadingAggregations}>
-          <AggregationFiltersContainer inline />
+          <AggregationFiltersContainer inline displayWhenNoResults />
         </LoadingOrChildren>
       </DrawerHandle>
     );

--- a/ui/src/middlewares/__tests__/searchDispatcher.test.js
+++ b/ui/src/middlewares/__tests__/searchDispatcher.test.js
@@ -2,7 +2,7 @@ import { LOCATION_CHANGE } from 'react-router-redux';
 
 import middleware from '../searchDispatcher';
 import * as search from '../../actions/search';
-import { SUBMISSIONS } from '../../common/routes';
+import { SUBMISSIONS, LITERATURE, AUTHORS, JOBS } from '../../common/routes';
 
 jest.mock('../../actions/search');
 
@@ -30,7 +30,6 @@ describe('searchDispatcher middleware', () => {
     };
     dispatch(action);
     expect(mockSearchForCurrentLocation).toHaveBeenCalled();
-    expect(mockFetchSearchAggregationsForCurrentLocation).toHaveBeenCalled();
   });
 
   it('calls searchForCurrentLocation when LOCATION_CHANGE and search is present in action payload [different searches]', () => {
@@ -56,7 +55,6 @@ describe('searchDispatcher middleware', () => {
     };
     dispatch(action);
     expect(mockSearchForCurrentLocation).toHaveBeenCalled();
-    expect(mockFetchSearchAggregationsForCurrentLocation).toHaveBeenCalled();
   });
 
   it('does not call searchForCurrentLocation when LOCATION_CHANGE if it is a submission [different searches and pathname]', () => {
@@ -82,9 +80,178 @@ describe('searchDispatcher middleware', () => {
     };
     dispatch(action);
     expect(mockSearchForCurrentLocation).not.toHaveBeenCalled();
+  });
+
+  it('does not call aggregation fetch when LOCATION_CHANGE if it is for author page', () => {
+    const router = {
+      location: {
+        pathname: `${LITERATURE}`,
+        search: '?filter=value1',
+      },
+    };
+    const getState = () => ({ router });
+    const next = jest.fn();
+    const dispatch = middleware({ getState, dispatch: jest.fn() })(next);
+    const mockSearchForCurrentLocation = jest.fn();
+    const mockFetchSearchAggregationsForCurrentLocation = jest.fn();
+    search.searchForCurrentLocation = mockSearchForCurrentLocation;
+    search.fetchSearchAggregationsForCurrentLocation = mockFetchSearchAggregationsForCurrentLocation;
+    const action = {
+      type: LOCATION_CHANGE,
+      payload: {
+        pathname: `${AUTHORS}`,
+        search: '?filter=value2',
+      },
+    };
+    dispatch(action);
+    expect(mockSearchForCurrentLocation).toHaveBeenCalled();
     expect(
       mockFetchSearchAggregationsForCurrentLocation
     ).not.toHaveBeenCalled();
+  });
+
+  it('does not call aggregation fetch when LOCATION_CHANGE if location remains in jobs page', () => {
+    const router = {
+      location: {
+        pathname: `${JOBS}`,
+        search: '?filter=value1',
+      },
+    };
+    const getState = () => ({ router });
+    const next = jest.fn();
+    const dispatch = middleware({ getState, dispatch: jest.fn() })(next);
+    const mockSearchForCurrentLocation = jest.fn();
+    const mockFetchSearchAggregationsForCurrentLocation = jest.fn();
+    search.searchForCurrentLocation = mockSearchForCurrentLocation;
+    search.fetchSearchAggregationsForCurrentLocation = mockFetchSearchAggregationsForCurrentLocation;
+    const action = {
+      type: LOCATION_CHANGE,
+      payload: {
+        pathname: `${JOBS}`,
+        search: '?filter=value2',
+      },
+    };
+    dispatch(action);
+    expect(mockSearchForCurrentLocation).toHaveBeenCalled();
+    expect(
+      mockFetchSearchAggregationsForCurrentLocation
+    ).not.toHaveBeenCalled();
+  });
+
+  it('calls aggregation fetch with useLocationQuery false when LOCATION_CHANGE if location just changed to jobs page', () => {
+    const router = {
+      location: {
+        pathname: `${LITERATURE}`,
+        search: '?filter=value1',
+      },
+    };
+    const getState = () => ({ router });
+    const next = jest.fn();
+    const dispatch = middleware({ getState, dispatch: jest.fn() })(next);
+    const mockSearchForCurrentLocation = jest.fn();
+    const mockFetchSearchAggregationsForCurrentLocation = jest.fn();
+    search.searchForCurrentLocation = mockSearchForCurrentLocation;
+    search.fetchSearchAggregationsForCurrentLocation = mockFetchSearchAggregationsForCurrentLocation;
+    const action = {
+      type: LOCATION_CHANGE,
+      payload: {
+        pathname: `${JOBS}`,
+        search: '?filter=value2',
+      },
+    };
+    dispatch(action);
+    expect(mockSearchForCurrentLocation).toHaveBeenCalled();
+    expect(mockFetchSearchAggregationsForCurrentLocation).toHaveBeenCalledWith(
+      false
+    );
+  });
+
+  it('does not call aggregation fetch if only sort changed', () => {
+    const router = {
+      location: {
+        pathname: `${LITERATURE}`,
+        search: '?filter=value1&sort=mostcited',
+        query: { sort: 'mostcited', filter: 'value1' },
+      },
+    };
+    const getState = () => ({ router });
+    const next = jest.fn();
+    const dispatch = middleware({ getState, dispatch: jest.fn() })(next);
+    const mockSearchForCurrentLocation = jest.fn();
+    const mockFetchSearchAggregationsForCurrentLocation = jest.fn();
+    search.searchForCurrentLocation = mockSearchForCurrentLocation;
+    search.fetchSearchAggregationsForCurrentLocation = mockFetchSearchAggregationsForCurrentLocation;
+    const action = {
+      type: LOCATION_CHANGE,
+      payload: {
+        pathname: `${LITERATURE}`,
+        search: '?filter=value1&sort=deadline',
+        query: { sort: 'deadline', filter: 'value1' },
+      },
+    };
+    dispatch(action);
+    expect(mockSearchForCurrentLocation).toHaveBeenCalled();
+    expect(
+      mockFetchSearchAggregationsForCurrentLocation
+    ).not.toHaveBeenCalled();
+  });
+
+  it('does not call aggregation fetch if only page changed', () => {
+    const router = {
+      location: {
+        pathname: `${LITERATURE}`,
+        search: '?filter=value1&page=1',
+        query: { page: '1', filter: 'value1' },
+      },
+    };
+    const getState = () => ({ router });
+    const next = jest.fn();
+    const dispatch = middleware({ getState, dispatch: jest.fn() })(next);
+    const mockSearchForCurrentLocation = jest.fn();
+    const mockFetchSearchAggregationsForCurrentLocation = jest.fn();
+    search.searchForCurrentLocation = mockSearchForCurrentLocation;
+    search.fetchSearchAggregationsForCurrentLocation = mockFetchSearchAggregationsForCurrentLocation;
+    const action = {
+      type: LOCATION_CHANGE,
+      payload: {
+        pathname: `${LITERATURE}`,
+        search: '?filter=value1&page=2',
+        query: { page: '2', filter: 'value1' },
+      },
+    };
+    dispatch(action);
+    expect(mockSearchForCurrentLocation).toHaveBeenCalled();
+    expect(
+      mockFetchSearchAggregationsForCurrentLocation
+    ).not.toHaveBeenCalled();
+  });
+
+  it('calls aggregation fetch if more than page/sort have changed in query', () => {
+    const router = {
+      location: {
+        pathname: `${LITERATURE}`,
+        search: '?filter=value1&page=1',
+        query: { page: '1', filter: 'value1' },
+      },
+    };
+    const getState = () => ({ router });
+    const next = jest.fn();
+    const dispatch = middleware({ getState, dispatch: jest.fn() })(next);
+    const mockSearchForCurrentLocation = jest.fn();
+    const mockFetchSearchAggregationsForCurrentLocation = jest.fn();
+    search.searchForCurrentLocation = mockSearchForCurrentLocation;
+    search.fetchSearchAggregationsForCurrentLocation = mockFetchSearchAggregationsForCurrentLocation;
+    const action = {
+      type: LOCATION_CHANGE,
+      payload: {
+        pathname: `${LITERATURE}`,
+        search: '?filter=value2&page=2',
+        query: { page: '2', filter: 'value2' },
+      },
+    };
+    dispatch(action);
+    expect(mockSearchForCurrentLocation).toHaveBeenCalled();
+    expect(mockFetchSearchAggregationsForCurrentLocation).toHaveBeenCalled();
   });
 
   it('returns next(action) for any action', () => {

--- a/ui/src/middlewares/searchDispatcher.js
+++ b/ui/src/middlewares/searchDispatcher.js
@@ -1,9 +1,11 @@
 import { LOCATION_CHANGE } from 'react-router-redux';
+import omit from 'lodash.omit';
 import {
   searchForCurrentLocation,
   fetchSearchAggregationsForCurrentLocation,
 } from '../actions/search';
-import { SUBMISSIONS } from '../common/routes';
+import { SUBMISSIONS, LITERATURE, JOBS } from '../common/routes';
+import { shallowEqual } from '../common/utils';
 
 function getLocationFromRootState(state) {
   const {
@@ -28,7 +30,24 @@ export default function({ getState, dispatch }) {
         nextLocation.pathname !== currentLocation.pathname
       ) {
         dispatch(searchForCurrentLocation());
-        dispatch(fetchSearchAggregationsForCurrentLocation());
+      }
+      // TODO: change the shallowEqual once we make router immutable. This works for now because we generate the query from scratch everytime
+      if (
+        !shallowEqual(
+          omit(currentLocation.query, ['sort', 'page']),
+          omit(nextLocation.query, ['sort', 'page'])
+        ) ||
+        nextLocation.pathname !== currentLocation.pathname
+      ) {
+        if (nextLocation.pathname.startsWith(LITERATURE)) {
+          dispatch(fetchSearchAggregationsForCurrentLocation());
+        }
+        if (
+          nextLocation.pathname.startsWith(JOBS) &&
+          nextLocation.pathname !== currentLocation.pathname
+        ) {
+          dispatch(fetchSearchAggregationsForCurrentLocation(false));
+        }
       }
       return result;
     }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6031,6 +6031,11 @@ lodash.mergewith@4.6.1, lodash.mergewith@^4.6.0, lodash.mergewith@^4.6.1:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz#639057e726c3afbdb3e7d42741caa8d6e4335927"
 
+lodash.omit@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
+  integrity sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"


### PR DESCRIPTION
* Changed the location of calling the facets in the searchDispatcher so that it only calls facets for jobs the first time you go on jobs and it never calls facets for authors
* Added logic to not call facets when only page or sorting changed
* INSPIR-2468