### PR TITLE
ui: display update form data fetch errors

### DIFF
--- a/ui/src/submissions/authors/containers/AuthorUpdateSubmissionPage.jsx
+++ b/ui/src/submissions/authors/containers/AuthorUpdateSubmissionPage.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Map } from 'immutable';
-import { Row, Col } from 'antd';
+import { Row, Col, Alert } from 'antd';
 
 import {
   fetchUpdateFormData,
@@ -11,7 +11,7 @@ import {
 import AuthorSubmission from '../components/AuthorSubmission';
 import ExternalLink from '../../../common/components/ExternalLink';
 import { AUTHORS_PID_TYPE } from '../../../common/constants';
-
+import LoadingOrChildren from '../../../common/components/LoadingOrChildren';
 
 class AuthorUpdateSubmissionPage extends Component {
   static getRecordIdFromProps(props) {
@@ -37,7 +37,9 @@ class AuthorUpdateSubmissionPage extends Component {
   }
 
   async onSubmit(formData) {
-    await this.dispatch(submitUpdate(AUTHORS_PID_TYPE, this.recordId, formData));
+    await this.dispatch(
+      submitUpdate(AUTHORS_PID_TYPE, this.recordId, formData)
+    );
   }
 
   get dispatch() {
@@ -50,33 +52,45 @@ class AuthorUpdateSubmissionPage extends Component {
   }
 
   render() {
-    // TODO: display updateFormDataError ?
-    const { error, updateFormData, loadingUpdateFormData } = this.props;
+    const {
+      error,
+      updateFormData,
+      loadingUpdateFormData,
+      updateFormDataError,
+    } = this.props;
     return (
-      !loadingUpdateFormData && (
-        <Row type="flex" justify="center">
-          <Col className="mt3 mb3" xs={24} md={21} lg={16} xl={15} xxl={14}>
-            <Row className="mb3 pa3 bg-white">
-              <h3>Update author</h3>
-              This form allows you to update information of an existing author.
-              All modifications are transferred to{' '}
-              <ExternalLink href="//inspirehep.net/hepnames">
-                inspirehep.net/hepnames
-              </ExternalLink>{' '}
-              upon approval.
-            </Row>
+      <Row type="flex" justify="center">
+        <Col className="mt3 mb3" xs={24} md={21} lg={16} xl={15} xxl={14}>
+          <Row className="mb3 pa3 bg-white">
+            <h3>Update author</h3>
+            This form allows you to update information of an existing author.
+            All modifications are transferred to{' '}
+            <ExternalLink href="//inspirehep.net/hepnames">
+              inspirehep.net/hepnames
+            </ExternalLink>{' '}
+            upon approval.
+          </Row>
+          <LoadingOrChildren loading={loadingUpdateFormData}>
             <Row>
               <Col>
-                <AuthorSubmission
-                  error={error}
-                  onSubmit={this.onSubmit}
-                  initialFormData={updateFormData}
-                />
+                {updateFormDataError ? (
+                  <Alert
+                    message={updateFormDataError.get('message')}
+                    type="error"
+                    showIcon
+                  />
+                ) : (
+                  <AuthorSubmission
+                    error={error}
+                    onSubmit={this.onSubmit}
+                    initialFormData={updateFormData}
+                  />
+                )}
               </Col>
             </Row>
-          </Col>
-        </Row>
-      )
+          </LoadingOrChildren>
+        </Col>
+      </Row>
     );
   }
 }
@@ -86,12 +100,14 @@ AuthorUpdateSubmissionPage.propTypes = {
   dispatch: PropTypes.func.isRequired,
   error: PropTypes.instanceOf(Map), // eslint-disable-line react/require-default-props
   updateFormData: PropTypes.instanceOf(Map), // eslint-disable-line react/require-default-props
+  updateFormDataError: PropTypes.instanceOf(Map), // eslint-disable-line react/require-default-props
   loadingUpdateFormData: PropTypes.bool.isRequired,
 };
 
 const stateToProps = state => ({
   error: state.submissions.get('submitError'),
   updateFormData: state.submissions.get('initialData'),
+  updateFormDataError: state.submissions.get('initialDataError'),
   loadingUpdateFormData: state.submissions.get('loadingInitialData'),
 });
 

--- a/ui/src/submissions/jobs/containers/JobUpdateSubmissionPage.jsx
+++ b/ui/src/submissions/jobs/containers/JobUpdateSubmissionPage.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Map } from 'immutable';
-import { Row, Col } from 'antd';
+import { Row, Col, Alert } from 'antd';
 
 import {
   fetchUpdateFormData,
@@ -10,6 +10,7 @@ import {
 } from '../../../actions/submissions';
 import { JOBS_PID_TYPE } from '../../../common/constants';
 import JobSubmission from '../components/JobSubmission';
+import LoadingOrChildren from '../../../common/components/LoadingOrChildren';
 
 class JobUpdateSubmissionPage extends Component {
   static getRecordIdFromProps(props) {
@@ -48,28 +49,42 @@ class JobUpdateSubmissionPage extends Component {
   }
 
   render() {
-    // TODO: display updateFormDataError ?
-    const { error, updateFormData, loadingUpdateFormData } = this.props;
+    const {
+      error,
+      updateFormData,
+      loadingUpdateFormData,
+      updateFormDataError,
+    } = this.props;
     return (
-      !loadingUpdateFormData && (
-        <Row type="flex" justify="center">
-          <Col className="mt3 mb3" xs={24} md={21} lg={16} xl={15} xxl={14}>
-            <Row className="mb3 pa3 bg-white">
+      <Row type="flex" justify="center">
+        <Col className="mt3 mb3" xs={24} md={21} lg={16} xl={15} xxl={14}>
+          <Row className="mb3 pa3 bg-white">
+            <Col>
               <h3>Update a job opening</h3>
               All modifications will appear immediately.
-            </Row>
+            </Col>
+          </Row>
+          <LoadingOrChildren loading={loadingUpdateFormData}>
             <Row>
               <Col>
-                <JobSubmission
-                  error={error}
-                  onSubmit={this.onSubmit}
-                  initialFormData={updateFormData}
-                />
+                {updateFormDataError ? (
+                  <Alert
+                    message={updateFormDataError.get('message')}
+                    type="error"
+                    showIcon
+                  />
+                ) : (
+                  <JobSubmission
+                    error={error}
+                    onSubmit={this.onSubmit}
+                    initialFormData={updateFormData}
+                  />
+                )}
               </Col>
             </Row>
-          </Col>
-        </Row>
-      )
+          </LoadingOrChildren>
+        </Col>
+      </Row>
     );
   }
 }
@@ -79,12 +94,14 @@ JobUpdateSubmissionPage.propTypes = {
   dispatch: PropTypes.func.isRequired,
   error: PropTypes.instanceOf(Map), // eslint-disable-line react/require-default-props
   updateFormData: PropTypes.instanceOf(Map), // eslint-disable-line react/require-default-props
+  updateFormDataError: PropTypes.instanceOf(Map), // eslint-disable-line react/require-default-props
   loadingUpdateFormData: PropTypes.bool.isRequired,
 };
 
 const stateToProps = state => ({
   error: state.submissions.get('submitError'),
   updateFormData: state.submissions.get('initialData'),
+  updateFormDataError: state.submissions.get('initialDataError'),
   loadingUpdateFormData: state.submissions.get('loadingInitialData'),
 });
 


### PR DESCRIPTION
* Displays errors happens while fetchign update data for an update
submission form, and doesn't render empty form fields incase of error.

* Displays loading feedback instead of not rendering while fetching
update form data.