### PR TITLE
ui: Fix the citations label in the citation summary graph

### DIFF
--- a/ui/src/App.scss
+++ b/ui/src/App.scss
@@ -24,7 +24,9 @@
 
     // :fist-child to avoid setting padding for `UserFeedback`
     & > *:first-child:not(.__Jobs__) {
-      padding: 0 2.85rem;
+      @media (min-width: $screen-xs-max) {
+        padding: 0 2.85rem;
+      }
     }
 
     @media (max-width: $screen-xs-max) {

--- a/ui/src/common/components/CitationSummaryGraph/CitationSummaryGraph.jsx
+++ b/ui/src/common/components/CitationSummaryGraph/CitationSummaryGraph.jsx
@@ -6,6 +6,7 @@ import {
   LabelSeries,
   FlexibleWidthXYPlot,
   DiscreteColorLegend,
+  ChartLabel,
 } from 'react-vis';
 import PropTypes from 'prop-types';
 import { Row, Col } from 'antd';
@@ -195,8 +196,12 @@ class CitationSummaryGraph extends Component {
                   >
                     <XAxis
                       className="x-axis"
-                      title="Citations"
                       tickFormat={v => xValueToLabel[v]}
+                    />
+                    <ChartLabel
+                      text="Citations"
+                      xPercent={0.92}
+                      yPercent={0.73}
                     />
                     <YAxis title="Papers" />
                     <VerticalBarSeries

--- a/ui/src/common/components/CitationSummaryGraph/CitationSummaryGraph.scss
+++ b/ui/src/common/components/CitationSummaryGraph/CitationSummaryGraph.scss
@@ -25,11 +25,17 @@
 
   .legend {
     position: absolute;
-    left: 50px;
+    left: 60px;
     top: 10px;
   }
 
   .series-bar {
     cursor: pointer;
+  }
+
+  .rv-xy-plot__axis__title {
+    @media (max-width: $screen-sm-max) {
+      display: none;
+    }
   }
 }

--- a/ui/src/common/components/__tests__/__snapshots__/CitationSummaryGraph.test.jsx.snap
+++ b/ui/src/common/components/__tests__/__snapshots__/CitationSummaryGraph.test.jsx.snap
@@ -42,7 +42,14 @@ exports[`CitationSummaryGraph renders graph with selectedBar 1`] = `
               className="x-axis"
               orientation="bottom"
               tickFormat={[Function]}
-              title="Citations"
+            />
+            <ChartLabel
+              className=""
+              includeMargin={true}
+              style={Object {}}
+              text="Citations"
+              xPercent={0.92}
+              yPercent={0.73}
             />
             <YAxis
               attr="y"
@@ -323,7 +330,14 @@ exports[`CitationSummaryGraph renders graph without SelectedBar 1`] = `
               className="x-axis"
               orientation="bottom"
               tickFormat={[Function]}
-              title="Citations"
+            />
+            <ChartLabel
+              className=""
+              includeMargin={true}
+              style={Object {}}
+              text="Citations"
+              xPercent={0.92}
+              yPercent={0.73}
             />
             <YAxis
               attr="y"
@@ -604,7 +618,14 @@ exports[`CitationSummaryGraph renders with hovered bar 1`] = `
               className="x-axis"
               orientation="bottom"
               tickFormat={[Function]}
-              title="Citations"
+            />
+            <ChartLabel
+              className=""
+              includeMargin={true}
+              style={Object {}}
+              text="Citations"
+              xPercent={0.92}
+              yPercent={0.73}
             />
             <YAxis
               attr="y"


### PR DESCRIPTION
* Moved the citations label in the citation summary graph so it doesn't overlap
* INSPIR-2452