### PR TITLE
ui: fix citations by year grap x axis

### DIFF
--- a/ui/src/actions/__tests__/authors.test.js
+++ b/ui/src/actions/__tests__/authors.test.js
@@ -47,7 +47,11 @@ describe('AUTHOR - async action creators', () => {
 
       const expectedActions = [
         { type: AUTHOR_REQUEST, payload: { recordId: 123 } },
-        { type: AUTHOR_ERROR, payload: { message: 'Error' } },
+        {
+          type: AUTHOR_ERROR,
+          payload: { message: 'Error' },
+          meta: { redirectableError: true },
+        },
       ];
 
       const store = getStore();

--- a/ui/src/actions/authors.js
+++ b/ui/src/actions/authors.js
@@ -32,6 +32,7 @@ function fetchAuthorError(error) {
   return {
     type: AUTHOR_ERROR,
     payload: error,
+    meta: { redirectableError: true },
   };
 }
 

--- a/ui/src/common/__tests__/utils.test.js
+++ b/ui/src/common/__tests__/utils.test.js
@@ -15,6 +15,7 @@ import pluralizeUnlessSingle, {
   shallowEqual,
   getSearchRank,
   getFromObjectOrImmutableMap,
+  pickEvenlyDistributedElements,
 } from '../utils';
 
 describe('utils', () => {
@@ -409,6 +410,89 @@ describe('utils', () => {
       const count = 1;
       const result = pluralizeUnlessSingle(word, count);
       expect(result).toEqual(word);
+    });
+  });
+
+  describe('pickEvenlyDistributedElements', () => {
+    it('returns evenly distributed sub array for half of the array 10', () => {
+      const array = [
+        1990,
+        1991,
+        1992,
+        1993,
+        1994,
+        1995,
+        1996,
+        1997,
+        1998,
+        1999,
+      ];
+      const numberOfElements = 5;
+      const expected = [1990, 1992, 1994, 1996, 1998];
+      const result = pickEvenlyDistributedElements(array, numberOfElements);
+      expect(result).toEqual(expected);
+    });
+
+    it('returns evenly distributed sub array for 6 of the array 10', () => {
+      const array = [
+        1990,
+        1991,
+        1992,
+        1993,
+        1994,
+        1995,
+        1996,
+        1997,
+        1998,
+        1999,
+      ];
+      const numberOfElements = 6;
+      const expected = [1990, 1992, 1994, 1996, 1998, 1999];
+      const result = pickEvenlyDistributedElements(array, numberOfElements);
+      expect(result).toEqual(expected);
+    });
+
+    it('returns evenly distributed sub array for 7 of the array of 10', () => {
+      const array = [
+        1990,
+        1991,
+        1992,
+        1993,
+        1994,
+        1995,
+        1996,
+        1997,
+        1998,
+        1999,
+      ];
+      const numberOfElements = 7;
+      const expected = [1990, 1992, 1994, 1996, 1998, 1999];
+      const result = pickEvenlyDistributedElements(array, numberOfElements);
+      expect(result).toEqual(expected);
+    });
+
+    it('returns evenly distributed sub array for 3 elements of array 5', () => {
+      const array = [1990, 1991, 1992, 1993, 1994];
+      const numberOfElements = 3;
+      const expected = [1990, 1992, 1994];
+      const result = pickEvenlyDistributedElements(array, numberOfElements);
+      expect(result).toEqual(expected);
+    });
+
+    it('returns evenly distributed sub array for 2 elements of array 5', () => {
+      const array = [1990, 1991, 1992, 1993, 1994];
+      const numberOfElements = 2;
+      const expected = [1990, 1994];
+      const result = pickEvenlyDistributedElements(array, numberOfElements);
+      expect(result).toEqual(expected);
+    });
+
+    it('returns evenly distributed sub array for 4 elements of array 5', () => {
+      const array = [1990, 1991, 1992, 1993, 1994];
+      const numberOfElements = 4;
+      const expected = [1990, 1991, 1992, 1993];
+      const result = pickEvenlyDistributedElements(array, numberOfElements);
+      expect(result).toEqual(expected);
     });
   });
 });

--- a/ui/src/common/components/CitationsByYearGraph/CitationsByYearGraph.jsx
+++ b/ui/src/common/components/CitationsByYearGraph/CitationsByYearGraph.jsx
@@ -8,14 +8,16 @@ import styleVariables from '../../../styleVariables';
 import { ErrorPropType } from '../../propTypes';
 import LoadingOrChildren from '../LoadingOrChildren';
 import ErrorAlertOrChildren from '../ErrorAlertOrChildren';
-import pluralizeUnlessSingle from '../../utils';
+import pluralizeUnlessSingle, {
+  pickEvenlyDistributedElements,
+} from '../../utils';
 
 const BLUE = styleVariables['primary-color'];
 const GRAPH_MARGIN = { left: 40, right: 20, top: 10, bottom: 40 };
 const GRAPH_HEIGHT = 250;
 
 const MIN_NUMBER_OF_DATAPOINTS = 3;
-const MAX_NUMBER_OF_TICKS_AT_X = 7;
+const MAX_NUMBER_OF_TICKS_AT_X = 5;
 const MAX_NUMBER_OF_TICKS_AT_Y = 5;
 
 class CitationsByYearGraph extends Component {
@@ -30,8 +32,9 @@ class CitationsByYearGraph extends Component {
   }
 
   static citationsByYearToSeriesData(citationsByYear) {
-    const minYear = Math.min(...Object.keys(citationsByYear));
-    const maxYear = Math.max(...Object.keys(citationsByYear));
+    const years = Object.keys(citationsByYear);
+    const minYear = Math.min(...years);
+    const maxYear = Math.max(...years);
     const seriesData = [];
     // eslint-disable-next-line no-plusplus
     for (let year = minYear; year <= maxYear; year++) {
@@ -85,16 +88,15 @@ class CitationsByYearGraph extends Component {
 
   renderXAxis() {
     const { seriesData } = this.state;
-    // set tickValues at X explicitly to avoid ticks like `2011.5`
-    // only if it has less than MAX_NUMBER_OF_TICKS_AT_X data points.
+
+    const valuesAtX = seriesData.map(point => point.x);
     const tickValuesAtX =
       seriesData.length < MAX_NUMBER_OF_TICKS_AT_X
-        ? seriesData.map(point => point.x)
-        : null;
+        ? valuesAtX
+        : pickEvenlyDistributedElements(valuesAtX, MAX_NUMBER_OF_TICKS_AT_X);
     return (
       <XAxis
         tickValues={tickValuesAtX}
-        tickTotal={MAX_NUMBER_OF_TICKS_AT_X}
         tickFormat={value => value /* avoid comma per 3 digit */}
       />
     );

--- a/ui/src/common/components/CitationsByYearGraph/__tests__/__snapshots__/CitationsByYearGraph.test.jsx.snap
+++ b/ui/src/common/components/CitationsByYearGraph/__tests__/__snapshots__/CitationsByYearGraph.test.jsx.snap
@@ -48,7 +48,6 @@ exports[`CitationsByYearGraph renders citations for less than 3 years with dummy
           attrAxis="y"
           orientation="bottom"
           tickFormat={[Function]}
-          tickTotal={7}
           tickValues={
             Array [
               1997,
@@ -151,7 +150,6 @@ exports[`CitationsByYearGraph renders citations for less than 5 different citati
           attrAxis="y"
           orientation="bottom"
           tickFormat={[Function]}
-          tickTotal={7}
           tickValues={
             Array [
               1999,
@@ -259,7 +257,6 @@ exports[`CitationsByYearGraph renders citations for more than 3 less than 8 year
           attrAxis="y"
           orientation="bottom"
           tickFormat={[Function]}
-          tickTotal={7}
           tickValues={
             Array [
               1999,
@@ -369,8 +366,15 @@ exports[`CitationsByYearGraph renders filling missing years with 0 1`] = `
           attrAxis="y"
           orientation="bottom"
           tickFormat={[Function]}
-          tickTotal={7}
-          tickValues={null}
+          tickValues={
+            Array [
+              2000,
+              2004,
+              2008,
+              2012,
+              2015,
+            ]
+          }
         />
         <YAxis
           attr="y"
@@ -524,7 +528,6 @@ exports[`CitationsByYearGraph renders hovered info in a tooltip on line series h
           attrAxis="y"
           orientation="bottom"
           tickFormat={[Function]}
-          tickTotal={7}
           tickValues={
             Array [
               1999,
@@ -628,8 +631,15 @@ exports[`CitationsByYearGraph renders more than 5 different citation counts with
           attrAxis="y"
           orientation="bottom"
           tickFormat={[Function]}
-          tickTotal={7}
-          tickValues={null}
+          tickValues={
+            Array [
+              1999,
+              2001,
+              2003,
+              2005,
+              2005,
+            ]
+          }
         />
         <YAxis
           attr="y"
@@ -736,8 +746,15 @@ exports[`CitationsByYearGraph renders more than 8 years without explicit tickVal
           attrAxis="y"
           orientation="bottom"
           tickFormat={[Function]}
-          tickTotal={7}
-          tickValues={null}
+          tickValues={
+            Array [
+              1999,
+              2003,
+              2007,
+              2011,
+              2015,
+            ]
+          }
         />
         <YAxis
           attr="y"
@@ -884,7 +901,6 @@ exports[`CitationsByYearGraph renders without citations 1`] = `
           attrAxis="y"
           orientation="bottom"
           tickFormat={[Function]}
-          tickTotal={7}
           tickValues={Array []}
         />
         <YAxis

--- a/ui/src/common/utils.js
+++ b/ui/src/common/utils.js
@@ -148,3 +148,23 @@ export function wait(milisec) {
 export default function pluralizeUnlessSingle(singularWord, count) {
   return count !== 1 ? `${singularWord}s` : singularWord;
 }
+
+export function pickEvenlyDistributedElements(array, numberOfElements) {
+  if (numberOfElements <= 1) {
+    throw new Error('number of elements must be greater than 1');
+  }
+
+  const step = Math.round((array.length - 1) / (numberOfElements - 1));
+  const someElements = [];
+  for (let i = 0; i < numberOfElements; i += 1) {
+    const element = array[i * step];
+
+    if (element) {
+      someElements.push(element);
+    } else {
+      someElements.push(array[array.length - 1]);
+      break;
+    }
+  }
+  return someElements;
+}


### PR DESCRIPTION
* Reduces number of years display on the graph.

Now we set tickValues on the X axis explicitly for all conditions because tickTotal is
unreliable.

* Also makes fetchAuthorError redirectable so that it redirects to
error pages when request fails.

* INSPIR-2443