### PR TITLE
migrator/indexer: change how records are indexed

### DIFF
--- a/inspirehep/migrator/tasks.py
+++ b/inspirehep/migrator/tasks.py
@@ -250,8 +250,8 @@ def create_records_from_mirror_recids(recids):
                 record = migrate_record_from_mirror(
                     LegacyRecordsMirror.query.get(recid)
                 )
-        except Exception as e:
-            LOGGER.error("Cannot process record %s: %s", recid, e)
+        except Exception:
+            LOGGER.error("Cannot process record %s.", recid)
             continue
         if record:
             processed_records.add(str(record.id))
@@ -277,8 +277,8 @@ def recalculate_citations(uuids):
             with db.session.begin_nested():
                 record = InspireRecord.get_record(uuid)
                 record._update_refs_in_citation_table()
-        except Exception as e:
-            LOGGER.error("Cannot recalculate references for %s: %s", uuid, e)
+        except Exception:
+            LOGGER.error("Cannot recalculate references for %s.", uuid)
 
     db.session.commit()
     return uuids
@@ -292,15 +292,14 @@ def process_references_in_records(uuids):
             try:
                 record = InspireRecord.get_record(uuid)
                 references_to_reindex.extend(get_modified_references_uuids(record))
-            except Exception as e:
+            except Exception:
                 LOGGER.error(
-                    "Cannot process references of record %s on index_records task. %s",
+                    "Cannot process references of record %s on index_records task.",
                     uuid,
-                    e,
                 )
         batch_index(references_to_reindex)
     except Exception as e:
-        LOGGER.error("Cannot reindex references: %s", e)
+        LOGGER.error("Cannot reindex references.")
     return uuids
 
 
@@ -315,8 +314,8 @@ def index_records(uuids):
     """
     try:
         batch_index(uuids)
-    except Exception as e:
-        LOGGER.error("Cannot reindex: %s", e)
+    except Exception:
+        LOGGER.error("Cannot reindex.")
     return uuids
 
 
@@ -327,8 +326,8 @@ def run_orcid_push(uuids):
             record = InspireRecord.get_record(uuid)
             if isinstance(LiteratureRecord, record):
                 push_to_orcid(record)
-        except Exception as e:
-            LOGGER.error("Cannot push to orcid %s: %s", uuid, e)
+        except Exception:
+            LOGGER.error("Cannot push to orcid %s", uuid)
     return uuids
 
 
@@ -366,7 +365,7 @@ def migrate_record_from_mirror(
     try:
         json_record = marcxml2record(prod_record.marcxml)
     except Exception as exc:
-        LOGGER.exception("Migrator DoJSON Error: %s", exc)
+        LOGGER.exception("Migrator DoJSON Error.")
         prod_record.error = exc
         db.session.merge(prod_record)
         return None
@@ -389,7 +388,7 @@ def migrate_record_from_mirror(
         prod_record.error = exc
         db.session.merge(prod_record)
     except Exception as exc:
-        LOGGER.exception("Migrator Record Insert Error: %s", exc)
+        LOGGER.exception("Migrator Record Insert Error.")
         prod_record.error = exc
         db.session.merge(prod_record)
     else:

--- a/inspirehep/migrator/tasks.py
+++ b/inspirehep/migrator/tasks.py
@@ -298,7 +298,7 @@ def process_references_in_records(uuids):
                     uuid,
                 )
         batch_index(references_to_reindex)
-    except Exception as e:
+    except Exception:
         LOGGER.error("Cannot reindex references.")
     return uuids
 
@@ -324,7 +324,7 @@ def run_orcid_push(uuids):
     for uuid in uuids:
         try:
             record = InspireRecord.get_record(uuid)
-            if isinstance(LiteratureRecord, record):
+            if isinstance(record, LiteratureRecord):
                 push_to_orcid(record)
         except Exception:
             LOGGER.error("Cannot push to orcid %s", uuid)

--- a/inspirehep/records/api/base.py
+++ b/inspirehep/records/api/base.py
@@ -412,7 +412,7 @@ class InspireRecord(Record):
                 f"class {self.pid_type} type, but $schema says that this is"
                 f"{self._schema_type} type object!"
             )
-        if force_delete or self.get("delete", False):
+        if force_delete or self.get("deleted", False):
             result = InspireRecordIndexer().delete(self)
         else:
             result = InspireRecordIndexer().index(self)

--- a/inspirehep/records/indexer/tasks.py
+++ b/inspirehep/records/indexer/tasks.py
@@ -49,7 +49,6 @@ def process_references_for_record(record):
     if uuids:
         logger.info(f"({record.id}) contains pids - starting batch")
         return batch_index(uuids)
-
     else:
         raise MissingCitedRecordError(
             f"Cited records to reindex not found:\nuuids: {uuids}"

--- a/inspirehep/records/indexer/utils.py
+++ b/inspirehep/records/indexer/utils.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CERN.
+#
+# inspirehep is free software; you can redistribute it and/or modify it under
+# the terms of the MIT License; see LICENSE file for more details.
+import logging
+
+from invenio_db import db
+from invenio_pidstore.models import PersistentIdentifier
+from sqlalchemy import tuple_
+from sqlalchemy.orm.exc import StaleDataError
+
+from inspirehep.records.api import InspireRecord
+
+logger = logging.getLogger(__name__)
+
+
+def get_record(uuid, record_version=None):
+    logger.debug("Pulling record %s on version %s", uuid, record_version)
+
+    record = InspireRecord.get_record(uuid, with_deleted=True)
+
+    if record_version and record.model.version_id < record_version:
+        logger.info(
+            f"Cannot pull record {uuid} in version {record_version}."
+            f"Current version: {record.model.version_id}."
+        )
+        raise StaleDataError()
+    return record
+
+
+def get_modified_references_uuids(record):
+    """Tries to find differences in record references.
+
+        Args:
+            record: Record object in which references has changed.
+        Returns:
+            list(str): list of UUIDs
+        """
+
+    pids = record.get_modified_references()
+
+    if not pids:
+        logger.debug("No references change for record %s", record.id)
+        return None
+    logger.debug(
+        "(%s) There are %s records where references changed", record.id, len(pids)
+    )
+    uuids = [
+        str(pid.object_uuid)
+        for pid in db.session.query(PersistentIdentifier.object_uuid).filter(
+            PersistentIdentifier.object_type == "rec",
+            tuple_(PersistentIdentifier.pid_type, PersistentIdentifier.pid_value).in_(
+                pids
+            ),
+        )
+    ]
+    return uuids

--- a/inspirehep/records/indexer/utils.py
+++ b/inspirehep/records/indexer/utils.py
@@ -33,11 +33,11 @@ def get_record(uuid, record_version=None):
 def get_modified_references_uuids(record):
     """Tries to find differences in record references.
 
-        Args:
-            record: Record object in which references has changed.
-        Returns:
-            list(str): list of UUIDs
-        """
+    Args:
+        record: Record object in which references has changed.
+    Returns:
+        list(str): list of UUIDs
+    """
 
     pids = record.get_modified_references()
 

--- a/tests/integration/migrator/fixtures/dummy_deleted.xml
+++ b/tests/integration/migrator/fixtures/dummy_deleted.xml
@@ -1,0 +1,15 @@
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+<record>
+  <controlfield tag="001">12345</controlfield>
+  <datafield tag="245" ind1=" " ind2=" ">
+    <subfield code="a">On the validity of INSPIRE records</subfield>
+  </datafield>
+  <datafield tag="980" ind1=" " ind2=" ">'
+  	<subfield code="a">HEP</subfield>'
+  	<subfield code="c">DELETED</subfield>'
+  </datafield>'
+  <datafield tag="700" ind1=" " ind2=" ">
+    <subfield code="a">Carberry, Josiah</subfield>
+    <subfield code="j">ORCID:0000-0002-1825-0097</subfield>
+  </datafield>
+</record>

--- a/tests/integration/migrator/test_migrator_tasks.py
+++ b/tests/integration/migrator/test_migrator_tasks.py
@@ -91,7 +91,7 @@ def test_migrate_and_insert_record_dojson_error(mock_logger, base_app, db):
     assert prod_record.marcxml == raw_record
 
     assert not mock_logger.error.called
-    mock_logger.exception.assert_called_once()
+    mock_logger.exception.assert_called_once_with("Migrator DoJSON Error.")
 
 
 @patch("inspirehep.migrator.tasks.LOGGER")
@@ -179,7 +179,7 @@ def test_migrate_and_insert_record_other_exception(mock_logger, base_app, db):
     assert prod_record.marcxml == raw_record
 
     assert not mock_logger.error.called
-    mock_logger.exception.assert_called_once()
+    mock_logger.exception.assert_called_once_with("Migrator Record Insert Error.")
 
 
 def test_orcid_push_disabled_on_migrate_from_mirror(

--- a/tests/integration/migrator/test_migrator_tasks/dummy_record.json
+++ b/tests/integration/migrator/test_migrator_tasks/dummy_record.json
@@ -1,0 +1,15 @@
+{
+  "self": { "$ref": "http://localhost:5000/api/literature/12345" },
+  "titles": [{ "title": "On the validity of INSPIRE records" }],
+  "$schema": "http://localhost:5000/schemas/records/hep.json",
+  "authors": [
+    {
+      "ids": [{ "value": "0000-0002-1825-0097", "schema": "ORCID" }],
+      "full_name": "Carberry, Josiah"
+    }
+  ],
+  "curated": true,
+  "_collections": ["Literature"],
+  "document_type": ["article"],
+  "control_number": 12345
+}

--- a/tests/integration/records/indexer/test_indexer_authors/999108.json
+++ b/tests/integration/records/indexer/test_indexer_authors/999108.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://labs.inspirehep.net/schemas/records/authors.json",
+  "_collections": ["Authors"],
+  "advisors": [
+    {
+      "degree_type": "other",
+      "ids": [{ "schema": "INSPIRE ID", "value": "INSPIRE-00070625" }],
+      "name": "Callan, Curtis G."
+    }
+  ],
+  "arxiv_categories": ["hep-th", "gr-qc"],
+  "control_number": 999108,
+  "deleted": false,
+  "email_addresses": [
+    { "current": true, "value": "malda@ias.edu" },
+    { "current": false, "hidden": true, "value": "malda@pauli.harvard.edu" },
+    { "current": false, "hidden": true, "value": "malda@ias.edu" }
+  ],
+  "ids": [
+    { "schema": "INSPIRE ID", "value": "INSPIRE-00304313" },
+    { "schema": "INSPIRE BAI", "value": "J.M.Maldacena.1" },
+    { "schema": "ORCID", "value": "0000-0002-9127-1687" },
+    { "schema": "SPIRES", "value": "HEPNAMES-193534" }
+  ],
+  "legacy_creation_date": "1999-05-04",
+  "legacy_version": "20160711200442.0",
+  "name": {
+    "name_variants": ["Maldacena, Juan Martin"],
+    "preferred_name": "Juan Martin Maldacena",
+    "value": "Maldacena, Juan Martin"
+  },
+  "positions": [
+    {
+      "curated_relation": true,
+      "current": true,
+      "institution": "Princeton, Inst. Advanced Study",
+      "rank": "SENIOR",
+      "record": {
+        "$ref": "http://labs.inspirehep.net/api/institutions/903138"
+      },
+      "start_date": "2001"
+    },
+    {
+      "curated_relation": true,
+      "end_date": "2001",
+      "institution": "Harvard U.",
+      "rank": "SENIOR",
+      "record": {
+        "$ref": "http://labs.inspirehep.net/api/institutions/902835"
+      },
+      "start_date": "1997"
+    },
+    {
+      "curated_relation": true,
+      "end_date": "1997",
+      "institution": "Rutgers U., Piscataway",
+      "rank": "POSTDOC",
+      "record": {
+        "$ref": "http://labs.inspirehep.net/api/institutions/903404"
+      },
+      "start_date": "1996"
+    },
+    {
+      "curated_relation": true,
+      "end_date": "1996",
+      "institution": "Princeton U.",
+      "rank": "PHD",
+      "record": {
+        "$ref": "http://labs.inspirehep.net/api/institutions/903139"
+      },
+      "start_date": "1992"
+    },
+    {
+      "curated_relation": true,
+      "end_date": "1991",
+      "institution": "Cuyo U.",
+      "rank": "UNDERGRADUATE",
+      "record": {
+        "$ref": "http://labs.inspirehep.net/api/institutions/902758"
+      },
+      "start_date": "1988"
+    }
+  ],
+  "public_notes": [
+    { "value": "Fundamental Physics Price 2012" },
+    { "value": "Dirac Medal 2008" },
+    { "value": "Heineman Prize 2007" }
+  ],
+  "self": { "$ref": "http://labs.inspirehep.net/api/authors/999108" },
+  "status": "active",
+  "stub": false,
+  "urls": [{ "value": "http://www.sns.ias.edu/~malda" }]
+}

--- a/tests/integration/records/indexer/test_indexer_authors/999108_expected.json
+++ b/tests/integration/records/indexer/test_indexer_authors/999108_expected.json
@@ -1,0 +1,139 @@
+{
+  "author_suggest": {
+    "input": [
+      "Juan Martin Maldacena",
+      "Maldacena, Juan Martin",
+      "Maldacena, Juan Martin"
+    ]
+  },
+  "control_number": 999108,
+  "advisors": [
+    {
+      "degree_type": "other",
+      "ids": [
+        {
+          "schema": "INSPIRE ID",
+          "value": "INSPIRE-00070625"
+        }
+      ],
+      "name": "Callan, Curtis G."
+    }
+  ],
+  "$schema": "https://labs.inspirehep.net/schemas/records/authors.json",
+  "urls": [
+    {
+      "value": "http://www.sns.ias.edu/~malda"
+    }
+  ],
+  "stub": false,
+  "_updated": "2010-12-19T00:00:00+00:00",
+  "public_notes": [
+    {
+      "value": "Fundamental Physics Price 2012"
+    },
+    {
+      "value": "Dirac Medal 2008"
+    },
+    {
+      "value": "Heineman Prize 2007"
+    }
+  ],
+  "email_addresses": [
+    {
+      "current": true,
+      "value": "malda@ias.edu"
+    },
+    {
+      "current": false,
+      "hidden": true,
+      "value": "malda@pauli.harvard.edu"
+    },
+    {
+      "current": false,
+      "hidden": true,
+      "value": "malda@ias.edu"
+    }
+  ],
+  "legacy_version": "20160711200442.0",
+  "positions": [
+    {
+      "curated_relation": true,
+      "current": true,
+      "institution": "Princeton, Inst. Advanced Study",
+      "rank": "SENIOR",
+      "record": {
+        "$ref": "http://labs.inspirehep.net/api/institutions/903138"
+      },
+      "start_date": "2001"
+    },
+    {
+      "curated_relation": true,
+      "end_date": "2001",
+      "institution": "Harvard U.",
+      "rank": "SENIOR",
+      "record": {
+        "$ref": "http://labs.inspirehep.net/api/institutions/902835"
+      },
+      "start_date": "1997"
+    },
+    {
+      "curated_relation": true,
+      "end_date": "1997",
+      "institution": "Rutgers U., Piscataway",
+      "rank": "POSTDOC",
+      "record": {
+        "$ref": "http://labs.inspirehep.net/api/institutions/903404"
+      },
+      "start_date": "1996"
+    },
+    {
+      "curated_relation": true,
+      "end_date": "1996",
+      "institution": "Princeton U.",
+      "rank": "PHD",
+      "record": {
+        "$ref": "http://labs.inspirehep.net/api/institutions/903139"
+      },
+      "start_date": "1992"
+    },
+    {
+      "curated_relation": true,
+      "end_date": "1991",
+      "institution": "Cuyo U.",
+      "rank": "UNDERGRADUATE",
+      "record": {
+        "$ref": "http://labs.inspirehep.net/api/institutions/902758"
+      },
+      "start_date": "1988"
+    }
+  ],
+  "ids": [
+    {
+      "schema": "INSPIRE ID",
+      "value": "INSPIRE-00304313"
+    },
+    {
+      "schema": "INSPIRE BAI",
+      "value": "J.M.Maldacena.1"
+    },
+    {
+      "schema": "ORCID",
+      "value": "0000-0002-9127-1687"
+    },
+    {
+      "schema": "SPIRES",
+      "value": "HEPNAMES-193534"
+    }
+  ],
+  "arxiv_categories": ["hep-th", "gr-qc"],
+  "status": "active",
+  "_collections": ["Authors"],
+  "legacy_creation_date": "1999-05-04",
+  "name": {
+    "name_variants": ["Maldacena, Juan Martin"],
+    "preferred_name": "Juan Martin Maldacena",
+    "value": "Maldacena, Juan Martin"
+  },
+  "_created": "1999-05-04T00:00:00+00:00",
+  "deleted": false
+}

--- a/tests/integration/records/indexer/test_indexer_data.py
+++ b/tests/integration/records/indexer/test_indexer_data.py
@@ -8,6 +8,8 @@ from copy import deepcopy
 
 from invenio_search import current_search_client as es
 
+from inspirehep.search.api import DataSearch
+
 
 def test_index_data_record(base_app, es_clear, db, datadir, create_record):
     record = create_record("dat")
@@ -19,3 +21,16 @@ def test_index_data_record(base_app, es_clear, db, datadir, create_record):
 
     assert response["hits"]["total"] == expected_count
     assert response["hits"]["hits"][0]["_source"] == expected_metadata
+
+
+def test_indexer_deletes_record_from_es(es_clear, db, datadir, create_record):
+    record = create_record("dat")
+
+    record["deleted"] = True
+    record._index()
+    es_clear.indices.refresh("records-data")
+
+    expected_records_count = 0
+
+    record_lit_es = DataSearch().get_record(str(record.id)).execute().hits
+    assert expected_records_count == len(record_lit_es)

--- a/tests/integration/records/indexer/test_indexer_experiments.py
+++ b/tests/integration/records/indexer/test_indexer_experiments.py
@@ -10,6 +10,8 @@ from copy import deepcopy
 
 from invenio_search import current_search_client as es
 
+from inspirehep.search.api import ExperimentsSearch
+
 
 def test_index_experiment_record(base_app, es_clear, db, datadir, create_record):
     data = json.loads((datadir / "1108541.json").read_text())
@@ -33,3 +35,17 @@ def test_index_experiment_record(base_app, es_clear, db, datadir, create_record)
 
     assert response["hits"]["total"] == expected_count
     assert response["hits"]["hits"][0]["_source"] == expected_metadata
+
+
+def test_indexer_deletes_record_from_es(es_clear, db, datadir, create_record):
+    data = json.loads((datadir / "1108541.json").read_text())
+    record = create_record("exp", data=data)
+
+    record["deleted"] = True
+    record._index()
+    es_clear.indices.refresh("records-experiments")
+
+    expected_records_count = 0
+
+    record_lit_es = ExperimentsSearch().get_record(str(record.id)).execute().hits
+    assert expected_records_count == len(record_lit_es)

--- a/tests/integration/records/indexer/test_indexer_jobs.py
+++ b/tests/integration/records/indexer/test_indexer_jobs.py
@@ -9,6 +9,8 @@ from copy import deepcopy
 
 from invenio_search import current_search_client as es
 
+from inspirehep.search.api import JobsSearch
+
 
 def test_index_job_record(base_app, es_clear, db, datadir, create_record):
     record = create_record("job")
@@ -24,3 +26,16 @@ def test_index_job_record(base_app, es_clear, db, datadir, create_record):
 
     assert expected_total == response_total
     assert expected_source == response_source
+
+
+def test_indexer_deletes_record_from_es(es_clear, db, datadir, create_record):
+    record = create_record("job")
+
+    record["deleted"] = True
+    record._index()
+    es_clear.indices.refresh("records-jobs")
+
+    expected_records_count = 0
+
+    record_lit_es = JobsSearch().get_record(str(record.id)).execute().hits
+    assert expected_records_count == len(record_lit_es)

--- a/tests/integration/records/indexer/test_indexer_literature.py
+++ b/tests/integration/records/indexer/test_indexer_literature.py
@@ -9,6 +9,8 @@ import json
 
 from invenio_search import current_search_client as es
 
+from inspirehep.search.api import LiteratureSearch
+
 
 def test_index_literature_record(es_clear, db, datadir, create_record):
     author_data = json.loads((datadir / "1032336.json").read_text())
@@ -36,3 +38,17 @@ def test_index_literature_record(es_clear, db, datadir, create_record):
     assert result_ui_display == expected_metadata_ui_display
     assert len(record.get("authors")) == len(result_facet_author_name)
     assert sorted(result_facet_author_name) == sorted(expected_facet_author_name)
+
+
+def test_indexer_deletes_record_from_es(es_clear, db, datadir, create_record):
+    data = json.loads((datadir / "1630825.json").read_text())
+    record = create_record("lit", data=data)
+
+    record["deleted"] = True
+    record._index()
+    es_clear.indices.refresh("records-hep")
+
+    expected_records_count = 0
+
+    record_lit_es = LiteratureSearch().get_record(str(record.id)).execute().hits
+    assert expected_records_count == len(record_lit_es)


### PR DESCRIPTION
* Delete records from ES if it is marked as deleted
* Process references of records if migrator is not processing all records from mirror table
* Fix jobs and Authors to index properly