### PR TITLE
ui: fix citations summary graph label for Safari

### DIFF
--- a/ui/src/common/__tests__/browser.test.js
+++ b/ui/src/common/__tests__/browser.test.js
@@ -1,0 +1,48 @@
+import { browser, BROWSERS } from '../browser';
+
+describe('browser', () => {
+  const userAgentGetter = jest.spyOn(navigator, 'userAgent', 'get');
+
+  describe('getBrowserName', () => {
+    it('returns "Apple Safari" for Safari', () => {
+      userAgentGetter.mockReturnValueOnce(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 11_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.0 Mobile/15E148 Safari/604.1 980x1306'
+      );
+
+      const result = browser.getBrowserName();
+      expect(result).toEqual(BROWSERS.Safari);
+    });
+
+    it('returns "Google Chrome or Chromium" for Chrome ', () => {
+      userAgentGetter.mockReturnValueOnce(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Safari/537.36'
+      );
+      const result = browser.getBrowserName();
+      expect(result).toEqual(BROWSERS.Chrome);
+    });
+
+    it('returns "Unknown" for "WHATEVER"', () => {
+      userAgentGetter.mockReturnValueOnce('WHATEVER');
+      const result = browser.getBrowserName();
+      expect(result).toEqual(BROWSERS.Unknown);
+    });
+  });
+
+  describe('isSafari', () => {
+    it('returns true for Safari', () => {
+      userAgentGetter.mockReturnValueOnce(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 11_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.0 Mobile/15E148 Safari/604.1 980x1306'
+      );
+      const result = browser.isSafari();
+      expect(result).toBe(true);
+    });
+
+    it('returns false for Firefox', () => {
+      userAgentGetter.mockReturnValueOnce(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:66.0) Gecko/20100101 Firefox/66.0'
+      );
+      const result = browser.isSafari();
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/ui/src/common/browser.js
+++ b/ui/src/common/browser.js
@@ -1,0 +1,44 @@
+export const BROWSERS = {
+  Safari: 'Apple Safari',
+  Chrome: 'Google Chrome or Chromium',
+  Edge: 'Microsoft Edge',
+  IE: 'Microsoft Internet Explorer',
+  Opera: 'Opera',
+  Firefox: 'Mozilla Firefox',
+  Unknown: 'Unknown',
+};
+
+class Browser {
+  isSafari() {
+    return this.getBrowserName() === BROWSERS.Safari;
+  }
+
+  // adapted from https://developer.mozilla.org/en-US/docs/Web/API/Window/navigator
+  // use a library (npmjs.com/package/bowser) if more info from userAgent is needed (like OS, version etc.)
+  // eslint-disable-next-line class-methods-use-this
+  getBrowserName() {
+    const { userAgent } = navigator;
+    if (userAgent.indexOf('Firefox') > -1) {
+      return BROWSERS.Firefox;
+    }
+    if (userAgent.indexOf('Opera') > -1 || userAgent.indexOf('OPR') > -1) {
+      return BROWSERS.Opera;
+    }
+    if (userAgent.indexOf('Trident') > -1) {
+      return BROWSERS.IE;
+    }
+    if (userAgent.indexOf('Edge') > -1) {
+      return BROWSERS.Edge;
+    }
+    if (userAgent.indexOf('Chrome') > -1) {
+      return BROWSERS.Chrome;
+    }
+    if (userAgent.indexOf('Safari') > -1) {
+      return BROWSERS.Safari;
+    }
+
+    return BROWSERS.Unknown;
+  }
+}
+
+export const browser = new Browser();

--- a/ui/src/common/components/CitationSummaryGraph/CitationSummaryGraph.jsx
+++ b/ui/src/common/components/CitationSummaryGraph/CitationSummaryGraph.jsx
@@ -19,10 +19,12 @@ import ErrorAlertOrChildren from '../ErrorAlertOrChildren';
 import { CITEABLE_BAR_TYPE, PUBLISHED_BAR_TYPE } from '../../constants';
 import styleVariables from '../../../styleVariables';
 import { shallowEqual } from '../../utils';
+import { browser } from '../../browser';
 
 const BAR_WIDTH = 0.5;
 const GRAPH_MARGIN = { left: 40, right: 20, top: 10, bottom: 40 };
 const GRAPH_HEIGHT = 250;
+const LABEL_ANCHOR_AT_Y = browser.isSafari() ? 'text-top' : 'text-after-edge';
 
 export const ORANGE = styleVariables['orange-6'];
 export const HOVERED_ORANGE = styleVariables['orange-7'];
@@ -216,7 +218,7 @@ class CitationSummaryGraph extends Component {
                     />
                     <LabelSeries
                       data={citeableSeriesData}
-                      labelAnchorY="text-after-edge"
+                      labelAnchorY={LABEL_ANCHOR_AT_Y}
                       labelAnchorX="middle"
                     />
                     <VerticalBarSeries
@@ -231,7 +233,7 @@ class CitationSummaryGraph extends Component {
                     />
                     <LabelSeries
                       data={publishedSeriesData}
-                      labelAnchorY="text-after-edge"
+                      labelAnchorY={LABEL_ANCHOR_AT_Y}
                       labelAnchorX="middle"
                     />
                     <DiscreteColorLegend

--- a/ui/src/common/utils.js
+++ b/ui/src/common/utils.js
@@ -145,6 +145,7 @@ export function wait(milisec) {
 }
 
 // appending `s` is all that's needed for the current usages
+// TODO: do not export default (leftover)
 export default function pluralizeUnlessSingle(singularWord, count) {
   return count !== 1 ? `${singularWord}s` : singularWord;
 }


### PR DESCRIPTION
* `dominant-baseline` with `text-after-edge` value works differently on
Safari. That's why we needed to use a different value.

* INSPIR-2525