### PR TITLE
bibtex: hide urls, change report numbers display

### DIFF
--- a/inspirehep/records/marshmallow/literature/bibtex.py
+++ b/inspirehep/records/marshmallow/literature/bibtex.py
@@ -209,7 +209,9 @@ class BibTexCommonSchema(Schema):
     def get_report_number(self, data):
         if "report_numbers" in data:
             return ", ".join(
-                report["value"] for report in data.get("report_numbers", [])
+                report["value"]
+                for report in data.get("report_numbers", [])
+                if not report.get("hidden", False)
             )
 
     def get_school(self, data):

--- a/inspirehep/records/serializers/bibtex.py
+++ b/inspirehep/records/serializers/bibtex.py
@@ -35,14 +35,14 @@ class BibTexSerializer:
         "month",
         "note",
         "primaryClass",
+        "reportNumber",
         "title",
-        "url",
         "year",
     ]
 
     FIELDS_FOR_ENTRY_TYPE = {
         "techreport": ["author", "number", "address", "type", "institution"],
-        "phdthesis": ["reportNumber", "school", "address", "type", "author"],
+        "phdthesis": ["school", "address", "type", "author"],
         "inproceedings": [
             "publisher",
             "author",
@@ -50,20 +50,18 @@ class BibTexSerializer:
             "booktitle",
             "number",
             "volume",
-            "reportNumber",
             "editor",
             "address",
             "organization",
             "pages",
         ],
-        "misc": ["howpublished", "reportNumber", "author"],
-        "mastersthesis": ["reportNumber", "school", "address", "type", "author"],
+        "misc": ["howpublished", "author"],
+        "mastersthesis": ["school", "address", "type", "author"],
         "proceedings": [
             "publisher",
             "series",
             "number",
             "volume",
-            "reportNumber",
             "editor",
             "address",
             "organization",
@@ -78,7 +76,6 @@ class BibTexSerializer:
             "volume",
             "edition",
             "editor",
-            "reportNumber",
             "address",
         ],
         "inbook": [
@@ -90,12 +87,11 @@ class BibTexSerializer:
             "volume",
             "edition",
             "editor",
-            "reportNumber",
             "address",
             "type",
             "pages",
         ],
-        "article": ["author", "journal", "number", "volume", "reportNumber", "pages"],
+        "article": ["author", "journal", "number", "volume", "pages"],
     }
 
     def __init__(self, schema_class=BibTexCommonSchema):

--- a/tests/unit/records/marshmallow/literature/test_bibtex_schema.py
+++ b/tests/unit/records/marshmallow/literature/test_bibtex_schema.py
@@ -160,6 +160,7 @@ def test_get_report_number():
         "report_numbers": [
             {"value": "CERN-SOME-REPORT"},
             {"value": "CERN-SOME-OTHER-REPORT"},
+            {"value": "CERN-HIDDEN", "hidden": True},
         ],
     }
     expected_report_numbers = "CERN-SOME-REPORT, CERN-SOME-OTHER-REPORT"


### PR DESCRIPTION
* URLs are now hidden (what and when to show them needs more thought)
  and report numbers are now shown for all entry types, unless they are
  marked as hidden in the metadata.

Signed-off-by: Micha Moskovic <michamos@gmail.com>