### PR TITLE
ui: fix leftovers from containers refactoring

### DIFF
--- a/ui/src/common/components/SearchScopeSelect.jsx
+++ b/ui/src/common/components/SearchScopeSelect.jsx
@@ -1,0 +1,31 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import SelectBox from './SelectBox';
+import { searchScopes } from '../../reducers/search';
+
+const SCOPE_OPTIONS = searchScopes
+  .keySeq()
+  .map(scope => ({ value: scope }))
+  .toJS();
+
+class SearchScopeSelect extends Component {
+  render() {
+    const { searchScopeName, onSearchScopeChange } = this.props;
+    return (
+      <SelectBox
+        dropdownClassName="header-dropdown"
+        onChange={onSearchScopeChange}
+        value={searchScopeName}
+        options={SCOPE_OPTIONS}
+      />
+    );
+  }
+}
+
+SearchScopeSelect.propTypes = {
+  onSearchScopeChange: PropTypes.func.isRequired,
+  searchScopeName: PropTypes.string.isRequired,
+};
+
+export default SearchScopeSelect;

--- a/ui/src/common/components/__tests__/SearchScopeSelect.test.jsx
+++ b/ui/src/common/components/__tests__/SearchScopeSelect.test.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import SearchScopeSelect from '../SearchScopeSelect';
+import SelectBox from '../SelectBox';
+
+describe('SearchScopeSelect', () => {
+  it('render initial state with all props set', () => {
+    const wrapper = shallow(
+      <SearchScopeSelect
+        onSearchScopeChange={jest.fn()}
+        searchScopeName="authors"
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('calls onSearchScopeChange on select change', () => {
+    const onSearchScopeChange = jest.fn();
+    const wrapper = shallow(
+      <SearchScopeSelect
+        searchScopeName="literature"
+        onSearchScopeChange={onSearchScopeChange}
+      />
+    );
+    const onSelectChange = wrapper.find(SelectBox).prop('onChange');
+    const newScope = 'authors';
+    onSelectChange(newScope);
+    expect(onSearchScopeChange).toBeCalledWith(newScope);
+  });
+});

--- a/ui/src/common/components/__tests__/__snapshots__/SearchBox.test.jsx.snap
+++ b/ui/src/common/components/__tests__/__snapshots__/SearchBox.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`SearchBox ovverides internal state with prop 1`] = `
 <Search
-  addonBefore={<Connect(SearchScopeSelectContainer) />}
+  addonBefore={<Connect(SearchScopeSelect) />}
   enterButton={true}
   inputPrefixCls="ant-input"
   onChange={[Function]}
@@ -21,7 +21,7 @@ exports[`SearchBox ovverides internal state with prop 1`] = `
 
 exports[`SearchBox render initial state with all props set 1`] = `
 <Search
-  addonBefore={<Connect(SearchScopeSelectContainer) />}
+  addonBefore={<Connect(SearchScopeSelect) />}
   enterButton={true}
   inputPrefixCls="ant-input"
   onChange={[Function]}
@@ -40,7 +40,7 @@ exports[`SearchBox render initial state with all props set 1`] = `
 
 exports[`SearchBox renders new value on change 1`] = `
 <Search
-  addonBefore={<Connect(SearchScopeSelectContainer) />}
+  addonBefore={<Connect(SearchScopeSelect) />}
   enterButton={true}
   inputPrefixCls="ant-input"
   onChange={[Function]}

--- a/ui/src/common/components/__tests__/__snapshots__/SearchScopeSelect.test.jsx.snap
+++ b/ui/src/common/components/__tests__/__snapshots__/SearchScopeSelect.test.jsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SearchScopeSelect render initial state with all props set 1`] = `
+<SelectBox
+  dropdownClassName="header-dropdown"
+  onChange={[MockFunction]}
+  options={
+    Array [
+      Object {
+        "value": "literature",
+      },
+      Object {
+        "value": "authors",
+      },
+      Object {
+        "value": "jobs",
+      },
+    ]
+  }
+  value="authors"
+/>
+`;

--- a/ui/src/common/containers/SearchScopeSelectContainer.jsx
+++ b/ui/src/common/containers/SearchScopeSelectContainer.jsx
@@ -1,34 +1,7 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import SelectBox from '../components/SelectBox';
+import SearchScopeSelect from '../components/SearchScopeSelect';
 import { changeSearchScope } from '../../actions/search';
-import { searchScopes } from '../../reducers/search';
-
-const SCOPE_OPTIONS = searchScopes
-  .keySeq()
-  .map(scope => ({ value: scope }))
-  .toJS();
-
-class SearchScopeSelectContainer extends Component {
-  render() {
-    const { searchScopeName, onSearchScopeChange } = this.props;
-    return (
-      <SelectBox
-        dropdownClassName="header-dropdown"
-        onChange={onSearchScopeChange}
-        value={searchScopeName}
-        options={SCOPE_OPTIONS}
-      />
-    );
-  }
-}
-
-SearchScopeSelectContainer.propTypes = {
-  onSearchScopeChange: PropTypes.func.isRequired,
-  searchScopeName: PropTypes.string.isRequired,
-};
 
 const stateToProps = state => ({
   searchScopeName: state.search.getIn(['scope', 'name']),
@@ -40,6 +13,4 @@ export const dispatchToProps = dispatch => ({
   },
 });
 
-export default connect(stateToProps, dispatchToProps)(
-  SearchScopeSelectContainer
-);
+export default connect(stateToProps, dispatchToProps)(SearchScopeSelect);

--- a/ui/src/common/containers/__tests__/GoBackLinkContainer.test.jsx
+++ b/ui/src/common/containers/__tests__/GoBackLinkContainer.test.jsx
@@ -4,10 +4,18 @@ import { goBack } from 'connected-react-router';
 import { Provider } from 'react-redux';
 
 import { getStore } from '../../../fixtures/store';
-import GoBackLinkContainer, { dispatchToProps } from '../GoBackLinkContainer';
+import GoBackLinkContainer from '../GoBackLinkContainer';
 import GoBackLink from '../../components/GoBackLink';
 
+jest.mock('connected-react-router');
+
+goBack.mockReturnValue(async () => {});
+
 describe('GoBackLinkContainer', () => {
+  afterEach(() => {
+    goBack.mockClear();
+  });
+
   it('render with custom children', () => {
     const wrapper = mount(
       <Provider store={getStore()}>
@@ -20,10 +28,14 @@ describe('GoBackLinkContainer', () => {
     });
   });
 
-  it('calls dispatch with goBack() on click', () => {
-    const mockDispatch = jest.fn();
-    const { onClick } = dispatchToProps(mockDispatch);
+  it('calls goBack() on click', () => {
+    const wrapper = mount(
+      <Provider store={getStore()}>
+        <GoBackLinkContainer />
+      </Provider>
+    );
+    const onClick = wrapper.find(GoBackLink).prop('onClick');
     onClick();
-    expect(mockDispatch).toHaveBeenCalledWith(goBack());
+    expect(goBack).toHaveBeenCalled();
   });
 });

--- a/ui/src/common/containers/__tests__/PaginationContainer.test.jsx
+++ b/ui/src/common/containers/__tests__/PaginationContainer.test.jsx
@@ -3,12 +3,13 @@ import { mount } from 'enzyme';
 import { fromJS } from 'immutable';
 import { Provider } from 'react-redux';
 
-import { getStoreWithState } from '../../../fixtures/store';
-import PaginationContainer, { dispatchToProps } from '../PaginationContainer';
+import { getStoreWithState, getStore } from '../../../fixtures/store';
+import PaginationContainer from '../PaginationContainer';
 import { pushQueryToLocation } from '../../../actions/search';
 import SearchPagination from '../../components/SearchPagination';
 
 jest.mock('../../../actions/search');
+pushQueryToLocation.mockReturnValue(async () => {});
 
 describe('PaginationContainer', () => {
   afterEach(() => {
@@ -42,9 +43,14 @@ describe('PaginationContainer', () => {
   });
 
   it('calls pushQueryToLocation onPageChange', () => {
-    const props = dispatchToProps(jest.fn());
+    const wrapper = mount(
+      <Provider store={getStore()}>
+        <PaginationContainer />
+      </Provider>
+    );
+    const onPageChange = wrapper.find(SearchPagination).prop('onPageChange');
     const page = 3;
-    props.onPageChange(page);
+    onPageChange(page);
     expect(pushQueryToLocation).toHaveBeenCalledWith({ page });
   });
 });

--- a/ui/src/common/containers/__tests__/SearchBoxContainer.test.jsx
+++ b/ui/src/common/containers/__tests__/SearchBoxContainer.test.jsx
@@ -2,14 +2,20 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
 
-import * as search from '../../../actions/search';
-import { getStoreWithState } from '../../../fixtures/store';
-import SearchBoxContainer, { dispatchToProps } from '../SearchBoxContainer';
+import { pushQueryToLocation } from '../../../actions/search';
+import { getStoreWithState, getStore } from '../../../fixtures/store';
+import SearchBoxContainer from '../SearchBoxContainer';
 import SearchBox from '../../components/SearchBox';
 
 jest.mock('../../../actions/search');
 
+pushQueryToLocation.mockReturnValue(async () => {});
+
 describe('SearchBoxContainer', () => {
+  afterEach(() => {
+    pushQueryToLocation.mockClear();
+  });
+
   it('passes url query q param to SearchBox', () => {
     const store = getStoreWithState({
       router: { location: { query: { q: 'test' } } },
@@ -23,10 +29,13 @@ describe('SearchBoxContainer', () => {
   });
 
   it('calls pushQueryToLocation onSearch', async () => {
-    const mockPushQueryToLocation = jest.fn();
-    search.pushQueryToLocation = mockPushQueryToLocation;
-    const props = dispatchToProps(jest.fn());
-    props.onSearch('test');
-    expect(mockPushQueryToLocation).toHaveBeenCalledWith({ q: 'test' }, true);
+    const wrapper = mount(
+      <Provider store={getStore()}>
+        <SearchBoxContainer />
+      </Provider>
+    );
+    const onSearch = wrapper.find(SearchBox).prop('onSearch');
+    onSearch('test');
+    expect(pushQueryToLocation).toHaveBeenCalledWith({ q: 'test' }, true);
   });
 });

--- a/ui/src/common/containers/__tests__/SearchScopeSelectContainer.test.jsx
+++ b/ui/src/common/containers/__tests__/SearchScopeSelectContainer.test.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import { fromJS } from 'immutable';
+
+import { changeSearchScope } from '../../../actions/search';
+import { getStoreWithState, getStore } from '../../../fixtures/store';
+import SearchScopeSelectContainer from '../SearchScopeSelectContainer';
+import SearchScopeSelect from '../../components/SearchScopeSelect';
+
+jest.mock('../../../actions/search');
+
+changeSearchScope.mockReturnValue(async () => {});
+
+describe('SearchScopeSelectContainer', () => {
+  afterEach(() => {
+    changeSearchScope.mockClear();
+  });
+
+  it('passes url query q param to SearchBox', () => {
+    const store = getStoreWithState({
+      search: fromJS({
+        scope: {
+          name: 'authors',
+        },
+      }),
+    });
+    const wrapper = mount(
+      <Provider store={store}>
+        <SearchScopeSelectContainer />
+      </Provider>
+    );
+    expect(wrapper.find(SearchScopeSelect)).toHaveProp({
+      searchScopeName: 'authors',
+    });
+  });
+
+  it('calls changeSearchScope onSearchScopeChange', async () => {
+    const wrapper = mount(
+      <Provider store={getStore()}>
+        <SearchScopeSelectContainer />
+      </Provider>
+    );
+    const onSearchScopeChange = wrapper
+      .find(SearchScopeSelect)
+      .prop('onSearchScopeChange');
+    onSearchScopeChange('test');
+    expect(changeSearchScope).toHaveBeenCalledWith('test');
+  });
+});

--- a/ui/src/common/containers/__tests__/SortByContainer.test.jsx
+++ b/ui/src/common/containers/__tests__/SortByContainer.test.jsx
@@ -2,12 +2,14 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
 
-import { getStoreWithState } from '../../../fixtures/store';
-import SortByContainer, { dispatchToProps } from '../SortByContainer';
+import { getStoreWithState, getStore } from '../../../fixtures/store';
+import SortByContainer from '../SortByContainer';
 import { pushQueryToLocation } from '../../../actions/search';
 import SortBy from '../../components/SortBy';
 
 jest.mock('../../../actions/search');
+
+pushQueryToLocation.mockReturnValue(async () => {});
 
 describe('SortByContainer', () => {
   afterEach(() => {
@@ -27,9 +29,14 @@ describe('SortByContainer', () => {
   });
 
   it('dispatches search onSortChange', () => {
-    const props = dispatchToProps(jest.fn());
+    const wrapper = mount(
+      <Provider store={getStore()}>
+        <SortByContainer />
+      </Provider>
+    );
+    const onSortChange = wrapper.find(SortBy).prop('onSortChange');
     const sort = 'mostcited';
-    props.onSortChange(sort);
+    onSortChange(sort);
     expect(pushQueryToLocation).toHaveBeenCalledWith({ sort });
   });
 });

--- a/ui/src/submissions/jobs/components/StatusField.jsx
+++ b/ui/src/submissions/jobs/components/StatusField.jsx
@@ -1,0 +1,35 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import SelectField from '../../common/components/SelectField';
+import { statusOptions, unAuthorizedStatusOptions } from '../schemas/constants';
+
+class StatusField extends Component {
+  render() {
+    const {
+      isCatalogerLoggedIn,
+      isUpdateSubmission,
+      ...selectFieldProps
+    } = this.props;
+
+    const disabled = !isUpdateSubmission && !isCatalogerLoggedIn;
+    const options = isCatalogerLoggedIn
+      ? statusOptions
+      : unAuthorizedStatusOptions;
+
+    return (
+      <SelectField
+        {...selectFieldProps}
+        disabled={disabled}
+        options={options}
+      />
+    );
+  }
+}
+
+StatusField.propTypes = {
+  isUpdateSubmission: PropTypes.bool.isRequired,
+  isCatalogerLoggedIn: PropTypes.bool.isRequired,
+};
+
+export default StatusField;

--- a/ui/src/submissions/jobs/components/__tests__/StatusField.test.jsx
+++ b/ui/src/submissions/jobs/components/__tests__/StatusField.test.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import StatusField from '../StatusField';
+
+describe('StatusField', () => {
+  it('renders if not update submissions and not cataloger', () => {
+    const wrapper = shallow(
+      <StatusField isUpdateSubmission={false} isCatalogerLoggedIn={false} />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders if update submissions but not cataloger', () => {
+    const wrapper = shallow(
+      <StatusField isUpdateSubmission isCatalogerLoggedIn={false} />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders if update submissions and cataloger', () => {
+    const wrapper = shallow(
+      <StatusField isUpdateSubmission isCatalogerLoggedIn />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders if not update submissions but cataloger', () => {
+    const wrapper = shallow(
+      <StatusField isUpdateSubmission={false} isCatalogerLoggedIn />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/ui/src/submissions/jobs/components/__tests__/__snapshots__/StatusField.test.jsx.snap
+++ b/ui/src/submissions/jobs/components/__tests__/__snapshots__/StatusField.test.jsx.snap
@@ -1,0 +1,105 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StatusField renders if not update submissions and not cataloger 1`] = `
+<WithFormItem(SelectField)
+  disabled={true}
+  labelCol={
+    Object {
+      "span": 5,
+    }
+  }
+  options={
+    Array [
+      Object {
+        "value": "closed",
+      },
+    ]
+  }
+  wrapperCol={
+    Object {
+      "span": 19,
+    }
+  }
+/>
+`;
+
+exports[`StatusField renders if not update submissions but cataloger 1`] = `
+<WithFormItem(SelectField)
+  disabled={false}
+  labelCol={
+    Object {
+      "span": 5,
+    }
+  }
+  options={
+    Array [
+      Object {
+        "value": "open",
+      },
+      Object {
+        "value": "pending",
+      },
+      Object {
+        "value": "closed",
+      },
+    ]
+  }
+  wrapperCol={
+    Object {
+      "span": 19,
+    }
+  }
+/>
+`;
+
+exports[`StatusField renders if update submissions and cataloger 1`] = `
+<WithFormItem(SelectField)
+  disabled={false}
+  labelCol={
+    Object {
+      "span": 5,
+    }
+  }
+  options={
+    Array [
+      Object {
+        "value": "open",
+      },
+      Object {
+        "value": "pending",
+      },
+      Object {
+        "value": "closed",
+      },
+    ]
+  }
+  wrapperCol={
+    Object {
+      "span": 19,
+    }
+  }
+/>
+`;
+
+exports[`StatusField renders if update submissions but not cataloger 1`] = `
+<WithFormItem(SelectField)
+  disabled={false}
+  labelCol={
+    Object {
+      "span": 5,
+    }
+  }
+  options={
+    Array [
+      Object {
+        "value": "closed",
+      },
+    ]
+  }
+  wrapperCol={
+    Object {
+      "span": 19,
+    }
+  }
+/>
+`;

--- a/ui/src/submissions/jobs/containers/StatusFieldContainer.jsx
+++ b/ui/src/submissions/jobs/containers/StatusFieldContainer.jsx
@@ -1,37 +1,11 @@
-import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Set } from 'immutable';
-import PropTypes from 'prop-types';
-import SelectField from '../../common/components/SelectField';
+
 import { SUBMISSIONS_JOB } from '../../../common/routes';
 import { isCataloger } from '../../../common/authorization';
-import { statusOptions, unAuthorizedStatusOptions } from '../schemas/constants';
+import StatusField from '../components/StatusField';
 
-class StatusField extends Component {
-  render() {
-    const { isCatalogerLoggedIn, isUpdateSubmission, ...selectFieldProps } = this.props;
-
-    const disabled = !isUpdateSubmission && !isCatalogerLoggedIn;
-    const options = isCatalogerLoggedIn
-      ? statusOptions
-      : unAuthorizedStatusOptions;
-
-    return (
-      <SelectField
-        {...selectFieldProps}
-        disabled={disabled}
-        options={options}
-      />
-    );
-  }
-}
-
-StatusField.propTypes = {
-  isUpdateSubmission: PropTypes.bool.isRequired,
-  isCatalogerLoggedIn: PropTypes.bool.isRequired,
-};
-
-export const stateToProps = state => ({
+const stateToProps = state => ({
   isCatalogerLoggedIn: isCataloger(Set(state.user.getIn(['data', 'roles']))),
   isUpdateSubmission: String(state.router.location.pathname).startsWith(
     `${SUBMISSIONS_JOB}/`


### PR DESCRIPTION
* fixes tests of small search components by droping usage of
`dispatchToProp` on the tests.

* Separates StatusFieldContainer into a container and a component.
Unfortunately container can't be tested because mounting `formik` stuff
is painful.

* INSPIR-2515