### PR TITLE
literature: fix earliest_date on ui serializer

### DIFF
--- a/inspirehep/records/marshmallow/literature/base.py
+++ b/inspirehep/records/marshmallow/literature/base.py
@@ -9,7 +9,6 @@ import json
 from itertools import chain
 
 from inspire_dojson.utils import strip_empty_values
-from inspire_utils.date import format_date
 from inspire_utils.helpers import force_list
 from inspire_utils.record import get_value
 from marshmallow import Schema, fields, missing, post_dump
@@ -155,7 +154,7 @@ class LiteratureMetadataUISchemaV1(LiteratureMetadataRawPublicSchemaV1):
         attribute="publication_info",
         many=True,
     )
-    date = fields.Method("get_formatted_date")
+    earliest_date = fields.Raw(dump_only=True, dump_to="date")
     dois = fields.Nested(DOISchemaV1, dump_only=True, many=True)
     external_system_identifiers = fields.Nested(
         ExternalSystemIdentifierSchemaV1, dump_only=True, many=True
@@ -167,12 +166,6 @@ class LiteratureMetadataUISchemaV1(LiteratureMetadataRawPublicSchemaV1):
         PublicationInfoItemSchemaV1, dump_only=True, many=True
     )
     thesis_info = fields.Nested(ThesisInfoSchemaV1, dump_only=True)
-
-    def get_formatted_date(self, data):
-        earliest_date = data.get("earliest_date")
-        if earliest_date is None:
-            return missing
-        return format_date(earliest_date)
 
     def get_number_of_authors(self, data):
         authors = data.get("authors")

--- a/tests/integration/records/views/test_views_literature.py
+++ b/tests/integration/records/views/test_views_literature.py
@@ -54,6 +54,7 @@ def test_literature_search_application_json_ui_get(
     data = {
         "control_number": 666,
         "titles": [{"title": "Partner walk again seek job."}],
+        "preprint_date": "2019-07-02",
     }
     create_record("lit", data=data)
     headers = {"Accept": "application/vnd+inspire.record.ui+json"}
@@ -63,6 +64,8 @@ def test_literature_search_application_json_ui_get(
         "control_number": 666,
         "document_type": ["article"],
         "titles": [{"title": "Partner walk again seek job."}],
+        "preprint_date": "2019-07-02",
+        "date": "2019-07-02",
     }
 
     response = api_client.get("/literature", headers=headers)

--- a/ui/src/literature/components/LiteratureDate.jsx
+++ b/ui/src/literature/components/LiteratureDate.jsx
@@ -1,11 +1,12 @@
 import React, { Component } from 'react';
+import moment from 'moment';
 import PropTypes from 'prop-types';
 
 class LiteratureDate extends Component {
   render() {
     const { date } = this.props;
-
-    return <span>{date}</span>;
+    const formattedDate = moment(date).format('MMM DD, YYYY');
+    return <span>{formattedDate}</span>;
   }
 }
 

--- a/ui/src/literature/components/__tests__/__snapshots__/LiteratureDate.test.jsx.snap
+++ b/ui/src/literature/components/__tests__/__snapshots__/LiteratureDate.test.jsx.snap
@@ -2,6 +2,6 @@
 
 exports[`LiteratureDate renders with date 1`] = `
 <span>
-  1993-06-07
+  Jun 07, 1993
 </span>
 `;


### PR DESCRIPTION
earliest_date was not serialized as `date` on UI response because it
was accessed via `dict.get` while being a regular property on
`LiteratureRecord` class

This also moves date formatting for UI to frontend (where it belongs)

* INSPIR-2539