### PR TITLE
citations: fix process records references

### DIFF
--- a/inspirehep/records/api/literature.py
+++ b/inspirehep/records/api/literature.py
@@ -223,7 +223,7 @@ class LiteratureRecord(FilesMixin, CitationMixin, InspireRecord):
         previous version.
 
         Returns:
-            Set[Tuple[str, int]]: pids of references changed from the previous
+            List: uuids of references changed from the previous
             version.
         """
         try:
@@ -235,18 +235,21 @@ class LiteratureRecord(FilesMixin, CitationMixin, InspireRecord):
             "deleted", False
         )
 
-        if changed_deleted_status:
-            return self.get_linked_pids_from_field("references.record")
+        pids_latest = self.get_linked_pids_from_field("references.record")
 
-        ids_latest = set(self.get_linked_pids_from_field("references.record"))
+        if changed_deleted_status:
+            return list(self.get_records_ids_by_pids(pids_latest))
+
         try:
-            ids_oldest = set(
+            pids_oldest = set(
                 self._previous_version.get_linked_pids_from_field("references.record")
             )
         except AttributeError:
-            return []
+            pids_oldest = []
 
-        return set.symmetric_difference(ids_latest, ids_oldest)
+        pids_changed = set.symmetric_difference(set(pids_latest), pids_oldest)
+
+        return list(self.get_records_ids_by_pids(list(pids_changed)))
 
 
 def import_article(identifier):

--- a/inspirehep/records/indexer/utils.py
+++ b/inspirehep/records/indexer/utils.py
@@ -6,9 +6,6 @@
 # the terms of the MIT License; see LICENSE file for more details.
 import logging
 
-from invenio_db import db
-from invenio_pidstore.models import PersistentIdentifier
-from sqlalchemy import tuple_
 from sqlalchemy.orm.exc import StaleDataError
 
 from inspirehep.records.api import InspireRecord
@@ -28,32 +25,3 @@ def get_record(uuid, record_version=None):
         )
         raise StaleDataError()
     return record
-
-
-def get_modified_references_uuids(record):
-    """Tries to find differences in record references.
-
-    Args:
-        record: Record object in which references has changed.
-    Returns:
-        list(str): list of UUIDs
-    """
-
-    pids = record.get_modified_references()
-
-    if not pids:
-        logger.debug("No references change for record %s", record.id)
-        return None
-    logger.debug(
-        "(%s) There are %s records where references changed", record.id, len(pids)
-    )
-    uuids = [
-        str(pid.object_uuid)
-        for pid in db.session.query(PersistentIdentifier.object_uuid).filter(
-            PersistentIdentifier.object_type == "rec",
-            tuple_(PersistentIdentifier.pid_type, PersistentIdentifier.pid_value).in_(
-                pids
-            ),
-        )
-    ]
-    return uuids

--- a/tests/integration-async/conftest.py
+++ b/tests/integration-async/conftest.py
@@ -127,7 +127,10 @@ def retry_until_matched():
                 _expected_result = step.get("expected_result")
                 _fun = step.get("step")
                 _expected_key = None
-                result = _fun(*_args, **_kwargs)
+                try:
+                    result = _fun(*_args, **_kwargs)
+                except:
+                    pass
                 _current_result = deepcopy(result)
                 if _expected_result:
                     if (

--- a/tests/integration-async/migrator/test_migrator_tasks.py
+++ b/tests/integration-async/migrator/test_migrator_tasks.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CERN.
+#
+# inspirehep is free software; you can redistribute it and/or modify it under
+# the terms of the MIT License; see LICENSE file for more details.
+
+from flask_sqlalchemy import models_committed
+from helpers.providers.faker import faker
+from invenio_db import db
+from invenio_search import current_search_client as es
+from mock import patch
+
+from inspirehep.records.api import LiteratureRecord
+from inspirehep.records.receivers import index_after_commit
+from inspirehep.search.api import LiteratureSearch
+
+
+def test_process_references_in_records(
+    app, celery_app_with_context, celery_session_worker, retry_until_matched
+):
+    # disconnect this signal so records don't get indexed
+    models_committed.disconnect(index_after_commit)
+
+    cited_record_1 = LiteratureRecord.create(faker.record("lit"))
+    cited_record_2 = LiteratureRecord.create(faker.record("lit"))
+
+    data_citing_record_1 = faker.record(
+        "lit", literature_citations=[cited_record_1["control_number"]]
+    )
+    citing_record_1 = LiteratureRecord.create(data_citing_record_1)
+    data_citing_record_2 = faker.record(
+        "lit", literature_citations=[cited_record_2["control_number"]]
+    )
+    citing_record_2 = LiteratureRecord.create(data_citing_record_2)
+
+    db.session.commit()
+
+    # reconnect signal before we call process_references_in_records
+    models_committed.connect(index_after_commit)
+
+    uuids = [citing_record_1.id, citing_record_2.id]
+    celery_app_with_context.send_task(
+        "inspirehep.migrator.tasks.process_references_in_records",
+        kwargs={"uuids": uuids},
+    )
+
+    # check the cited records got indexed during process references in records
+    steps = [
+        {"step": es.indices.refresh, "args": ["records-hep"]},
+        {
+            "step": es.search,
+            "args": ["records-hep"],
+            "expected_result": {"expected_key": "hits.total", "expected_result": 2},
+        },
+        {
+            "step": LiteratureSearch.get_record_data_from_es,
+            "args": [cited_record_1],
+            "expected_result": {"expected_key": "citation_count", "expected_result": 1},
+        },
+        {
+            "step": LiteratureSearch.get_record_data_from_es,
+            "args": [cited_record_2],
+            "expected_result": {"expected_key": "citation_count", "expected_result": 1},
+        },
+    ]
+    retry_until_matched(steps)

--- a/tests/integration/records/indexer/test_indexer_literature.py
+++ b/tests/integration/records/indexer/test_indexer_literature.py
@@ -8,6 +8,7 @@
 import json
 
 from invenio_search import current_search_client as es
+from mock import patch
 
 from inspirehep.search.api import LiteratureSearch
 
@@ -65,3 +66,16 @@ def test_indexer_deletes_record_from_es(es_clear, db, datadir, create_record):
 
     record_lit_es = LiteratureSearch().get_record(str(record.id)).execute().hits
     assert expected_records_count == len(record_lit_es)
+
+
+@patch("inspirehep.records.indexer.tasks.process_references_for_record")
+def test_indexer_doesnt_call_process_references_if_not_lit_record(
+    process_references_mock, es_clear, db, datadir, create_record
+):
+    create_record("aut")
+
+    process_references_mock.assert_not_called()
+
+    create_record("lit")
+
+    process_references_mock.call_count == 1


### PR DESCRIPTION
* Fix get_modified_references so it returns all references for just created records
* Make get_modified_references return list of uuids instead of list of pids
* Fix process_references which was throwing error whenever record didn't have modified references
* INSPIR-2477