### PR TITLE
literature: fix date formatting

### DIFF
--- a/inspirehep/records/marshmallow/literature/base.py
+++ b/inspirehep/records/marshmallow/literature/base.py
@@ -9,6 +9,7 @@ import json
 from itertools import chain
 
 from inspire_dojson.utils import strip_empty_values
+from inspire_utils.date import format_date
 from inspire_utils.helpers import force_list
 from inspire_utils.record import get_value
 from marshmallow import Schema, fields, missing, post_dump
@@ -154,7 +155,7 @@ class LiteratureMetadataUISchemaV1(LiteratureMetadataRawPublicSchemaV1):
         attribute="publication_info",
         many=True,
     )
-    earliest_date = fields.Raw(dump_only=True, dump_to="date")
+    date = fields.Method("get_formatted_earliest_date")
     dois = fields.Nested(DOISchemaV1, dump_only=True, many=True)
     external_system_identifiers = fields.Nested(
         ExternalSystemIdentifierSchemaV1, dump_only=True, many=True
@@ -166,6 +167,12 @@ class LiteratureMetadataUISchemaV1(LiteratureMetadataRawPublicSchemaV1):
         PublicationInfoItemSchemaV1, dump_only=True, many=True
     )
     thesis_info = fields.Nested(ThesisInfoSchemaV1, dump_only=True)
+
+    def get_formatted_earliest_date(self, data):
+        earliest_date = data.earliest_date
+        if earliest_date is None:
+            return missing
+        return format_date(earliest_date)
 
     def get_number_of_authors(self, data):
         authors = data.get("authors")

--- a/tests/integration/records/views/test_views_literature.py
+++ b/tests/integration/records/views/test_views_literature.py
@@ -65,7 +65,7 @@ def test_literature_search_application_json_ui_get(
         "document_type": ["article"],
         "titles": [{"title": "Partner walk again seek job."}],
         "preprint_date": "2019-07-02",
-        "date": "2019-07-02",
+        "date": "Jul 2, 2019",
     }
 
     response = api_client.get("/literature", headers=headers)

--- a/ui/src/literature/components/LiteratureDate.jsx
+++ b/ui/src/literature/components/LiteratureDate.jsx
@@ -1,12 +1,10 @@
 import React, { Component } from 'react';
-import moment from 'moment';
 import PropTypes from 'prop-types';
 
 class LiteratureDate extends Component {
   render() {
     const { date } = this.props;
-    const formattedDate = moment(date).format('MMM DD, YYYY');
-    return <span>{formattedDate}</span>;
+    return <span>{date}</span>;
   }
 }
 

--- a/ui/src/literature/components/LiteratureItem.jsx
+++ b/ui/src/literature/components/LiteratureItem.jsx
@@ -40,7 +40,7 @@ class LiteratureItem extends Component {
     const eprints = metadata.get('arxiv_eprints');
     const collaborations = metadata.get('collaborations');
     const collaborationsWithSuffix = metadata.get('collaborations_with_suffix');
-    const canEdit = metadata.get('can_edit', false)
+    const canEdit = metadata.get('can_edit', false);
 
     return (
       <ResultItem
@@ -49,7 +49,9 @@ class LiteratureItem extends Component {
             {arxivId && <ArxivPdfDownloadAction arxivId={arxivId} />}
             {dois && <DOILinkAction dois={dois} />}
             <CiteModalActionContainer recordId={recordId} />
-            { canEdit && <EditRecordAction pidType="literature" pidValue={ recordId }/> }
+            {canEdit && (
+              <EditRecordAction pidType="literature" pidValue={recordId} />
+            )}
           </Fragment>
         }
         rightActions={
@@ -90,9 +92,13 @@ class LiteratureItem extends Component {
             collaborations={collaborations}
             collaborationsWithSuffix={collaborationsWithSuffix}
           />
-          {' ('}
-          <LiteratureDate date={date} />
-          {')'}
+          {date && (
+            <>
+              {' ('}
+              <LiteratureDate date={date} />
+              {')'}
+            </>
+          )}
         </div>
         <div className="mt1">
           <ul className="bulleted-list">

--- a/ui/src/literature/components/__tests__/__snapshots__/LiteratureDate.test.jsx.snap
+++ b/ui/src/literature/components/__tests__/__snapshots__/LiteratureDate.test.jsx.snap
@@ -2,6 +2,6 @@
 
 exports[`LiteratureDate renders with date 1`] = `
 <span>
-  Jun 07, 1993
+  1993-06-07
 </span>
 `;

--- a/ui/src/literature/components/__tests__/__snapshots__/LiteratureItem.test.jsx.snap
+++ b/ui/src/literature/components/__tests__/__snapshots__/LiteratureItem.test.jsx.snap
@@ -65,11 +65,6 @@ exports[`LiteratureItem does not arxiv pdf download action if there is no eprint
       collaborationsWithSuffix={Immutable.List []}
       enableAuthorsShowAll={false}
     />
-     (
-    <LiteratureDate
-      date={null}
-    />
-    )
   </div>
   <div
     className="mt1"
@@ -146,11 +141,6 @@ exports[`LiteratureItem renders 0 citations if it does not exist 1`] = `
       collaborationsWithSuffix={Immutable.List []}
       enableAuthorsShowAll={false}
     />
-     (
-    <LiteratureDate
-      date={null}
-    />
-    )
   </div>
   <div
     className="mt1"


### PR DESCRIPTION
* Moves back date formatting to backend where all the edge cases are
handled correctly

* Hides `()` that wraps date in search result if there is no date. This
isn't supposed to happen but it does due to some bugs.