### PR TITLE
migrator: rename update_refs_in_citation_table

### DIFF
--- a/inspirehep/migrator/tasks.py
+++ b/inspirehep/migrator/tasks.py
@@ -231,7 +231,7 @@ def create_records_from_mirror_recids(recids):
 
 @shared_task(ignore_results=False, queue="migrator", acks_late=True)
 def recalculate_citations(uuids):
-    """Task which updates records_citations table with references of this record
+    """Task which updates records_citations table with references of this record.
 
     Args:
         uuids: records uuids for which references should be reprocessed
@@ -242,7 +242,8 @@ def recalculate_citations(uuids):
         try:
             with db.session.begin_nested():
                 record = InspireRecord.get_record(uuid)
-                record._update_refs_in_citation_table()
+                if hasattr(record, "update_refs_in_citation_table"):
+                    record.update_refs_in_citation_table()
         except Exception:
             LOGGER.error("Cannot recalculate references for %s.", uuid)
 

--- a/inspirehep/records/api/literature.py
+++ b/inspirehep/records/api/literature.py
@@ -95,7 +95,7 @@ class LiteratureRecord(FilesMixin, CitationMixin, InspireRecord):
             if disable_citation_update:
                 logger.info("Citation update is disabled in record.create")
             else:
-                record._update_refs_in_citation_table()
+                record.update_refs_in_citation_table()
             if disable_orcid_push:
                 logger.info("ORCID PUSH disabled by argument in record.create")
             else:
@@ -111,7 +111,7 @@ class LiteratureRecord(FilesMixin, CitationMixin, InspireRecord):
             if disable_citation_update:
                 logger.info("Citation update is disabled in record.create")
             else:
-                self._update_refs_in_citation_table()
+                self.update_refs_in_citation_table()
 
             if disable_orcid_push:
                 logger.info("ORCID PUSH disabled by argument in record.update")

--- a/inspirehep/records/api/mixins.py
+++ b/inspirehep/records/api/mixins.py
@@ -68,7 +68,7 @@ class CitationMixin:
         """
         return "successor" in self.get_value("related_records.relation", "")
 
-    def _update_refs_in_citation_table(self, save_every=100):
+    def update_refs_in_citation_table(self, save_every=100):
         """Updates all references in citation table.
 
         First removes all references (where citer is this record),

--- a/inspirehep/records/tasks.py
+++ b/inspirehep/records/tasks.py
@@ -24,7 +24,7 @@ def batch_recalculate(self, records_uuids):
         try:
             with db.session.begin_nested():
                 record = InspireRecord.get_record(record_uuid)
-                record._update_refs_in_citation_table()
+                record.update_refs_in_citation_table()
         except Exception as e:
             logger.error(f"Cannot recalculate {record_uuid}: {e}")
     db.session.commit()

--- a/tests/integration/records/api/test_api_literature.py
+++ b/tests/integration/records/api/test_api_literature.py
@@ -971,7 +971,7 @@ def test_record_create_not_skips_orcid_on_default(orcid_mock, base_app, db):
 
 
 @mock.patch(
-    "inspirehep.records.api.literature.LiteratureRecord._update_refs_in_citation_table"
+    "inspirehep.records.api.literature.LiteratureRecord.update_refs_in_citation_table"
 )
 def test_record_create_skips_citation_recalculate_when_passed_parameter_to_skip(
     citation_recalculate_mock, base_app, db
@@ -982,7 +982,7 @@ def test_record_create_skips_citation_recalculate_when_passed_parameter_to_skip(
 
 
 @mock.patch(
-    "inspirehep.records.api.literature.LiteratureRecord._update_refs_in_citation_table"
+    "inspirehep.records.api.literature.LiteratureRecord.update_refs_in_citation_table"
 )
 def test_record_create_runs_citation_recalculate_on_default(
     citation_recalculate_mock, base_app, db
@@ -1013,7 +1013,7 @@ def test_record_update_not_skips_orcid_on_default(orcid_mock, base_app, db):
 
 
 @mock.patch(
-    "inspirehep.records.api.literature.LiteratureRecord._update_refs_in_citation_table"
+    "inspirehep.records.api.literature.LiteratureRecord.update_refs_in_citation_table"
 )
 def test_record_update_skips_citation_recalculate_when_passed_parameter_to_skip(
     citation_recalculate_mock, base_app, db
@@ -1026,7 +1026,7 @@ def test_record_update_skips_citation_recalculate_when_passed_parameter_to_skip(
 
 
 @mock.patch(
-    "inspirehep.records.api.literature.LiteratureRecord._update_refs_in_citation_table"
+    "inspirehep.records.api.literature.LiteratureRecord.update_refs_in_citation_table"
 )
 def test_record_update_runs_citation_recalculate_on_default(
     citation_recalculate_mock, base_app, db


### PR DESCRIPTION
* Fixes the bug caused by calling `update_refs_in_citation_table` on records different than LiteratureRecord.

* INSPIR-2563

Signed-off-by: Harris Tzovanakis <me@drjova.com>