### PR TITLE
citations: reindex references of records when earliest_date changes

### DIFF
--- a/inspirehep/records/api/literature.py
+++ b/inspirehep/records/api/literature.py
@@ -235,9 +235,13 @@ class LiteratureRecord(FilesMixin, CitationMixin, InspireRecord):
             "deleted", False
         )
 
+        changed_earliest_date = (
+            self.earliest_date != LiteratureRecord(prev_version).earliest_date
+        )
+
         pids_latest = self.get_linked_pids_from_field("references.record")
 
-        if changed_deleted_status:
+        if changed_deleted_status or changed_earliest_date:
             return list(self.get_records_ids_by_pids(pids_latest))
 
         try:

--- a/tests/integration-async/records/api/test_base.py
+++ b/tests/integration-async/records/api/test_base.py
@@ -39,3 +39,81 @@ def test_record_versioning(app, clear_environment):
     assert expected_version_updated == record_updated.model.version_id
     assert expected_count_updated == record_updated.model.versions.count()
     assert record._previous_version
+
+
+def test_get_modified_references_returns_all_references_when_earliest_date_changed(
+    app, clear_environment
+):
+    cited_data = {
+        "$schema": "http://localhost:5000/schemas/records/hep.json",
+        "titles": [{"title": "Test a valid record"}],
+        "document_type": ["article"],
+        "_collections": ["Literature"],
+    }
+    cited_record = LiteratureRecord.create(cited_data)
+
+    citing_data = {
+        "$schema": "http://localhost:5000/schemas/records/hep.json",
+        "titles": [{"title": "My Title"}],
+        "document_type": ["article"],
+        "_collections": ["Literature"],
+        "preprint_date": "2019-06-28",
+        "references": [
+            {
+                "record": {
+                    "$ref": f"http://localhost:5000/api/literature/{cited_record['control_number']}"
+                }
+            }
+        ],
+    }
+
+    citing_record = LiteratureRecord.create(citing_data)
+    db.session.commit()
+
+    assert citing_record.get_modified_references() == [cited_record.id]
+
+    data_update = {"preprint_date": "2018-06-28"}
+    citing_data.update(data_update)
+    citing_record.update(citing_data)
+    db.session.commit()
+
+    assert citing_record.get_modified_references() == [cited_record.id]
+
+
+def test_get_modified_references_returns_no_references_when_non_impacting_metadata_changed(
+    app, clear_environment
+):
+    cited_data = {
+        "$schema": "http://localhost:5000/schemas/records/hep.json",
+        "titles": [{"title": "Test a valid record"}],
+        "document_type": ["article"],
+        "_collections": ["Literature"],
+    }
+    cited_record = LiteratureRecord.create(cited_data)
+
+    citing_data = {
+        "$schema": "http://localhost:5000/schemas/records/hep.json",
+        "titles": [{"title": "My title"}],
+        "document_type": ["article"],
+        "_collections": ["Literature"],
+        "preprint_date": "2019-06-28",
+        "references": [
+            {
+                "record": {
+                    "$ref": f"http://localhost:5000/api/literature/{cited_record['control_number']}"
+                }
+            }
+        ],
+    }
+
+    citing_record = LiteratureRecord.create(citing_data)
+    db.session.commit()
+
+    assert citing_record.get_modified_references() == [cited_record.id]
+
+    data_update = {"titles": [{"title": "updated title"}]}
+    citing_data.update(data_update)
+    citing_record.update(citing_data)
+    db.session.commit()
+
+    assert citing_record.get_modified_references() == []

--- a/tests/integration-async/records/indexer/test_literature.py
+++ b/tests/integration-async/records/indexer/test_literature.py
@@ -277,6 +277,53 @@ def test_lit_record_updates_references_when_reference_is_added(
     retry_until_matched(steps)
 
 
+def test_lit_record_reindexes_references_when_earliest_date_changed(
+    app, celery_app_with_context, celery_session_worker, retry_until_matched
+):
+    data_cited_record = faker.record("lit")
+    cited_record = LiteratureRecord.create(data_cited_record)
+    db.session.commit()
+
+    citations = [cited_record["control_number"]]
+    data_citing_record = faker.record(
+        "lit", literature_citations=citations, data={"preprint_date": "2018-06-28"}
+    )
+    citing_record = LiteratureRecord.create(data_citing_record)
+    db.session.commit()
+
+    steps = [
+        {"step": es.indices.refresh, "args": ["records-hep"]},
+        {
+            "step": LiteratureSearch.get_record_data_from_es,
+            "args": [cited_record],
+            "expected_result": {
+                "expected_key": "citations_by_year",
+                "expected_result": [{"count": 1, "year": 2018}],
+            },
+        },
+    ]
+    retry_until_matched(steps)
+
+    data_citing_record["preprint_date"] = "2019-06-28"
+    citing_record.update(data_citing_record)
+    db.session.commit()
+
+    es.indices.refresh("records-hep")
+
+    steps = [
+        {"step": es.indices.refresh, "args": ["records-hep"]},
+        {
+            "step": LiteratureSearch.get_record_data_from_es,
+            "args": [cited_record],
+            "expected_result": {
+                "expected_key": "citations_by_year",
+                "expected_result": [{"count": 1, "year": 2019}],
+            },
+        },
+    ]
+    retry_until_matched(steps)
+
+
 def test_many_records_in_one_commit(
     app, celery_app_with_context, celery_session_worker, retry_until_matched
 ):


### PR DESCRIPTION
* Reindexes all references for records when earliest_date of the record changes. This is needed to keep the citations_by_year of the references up-to-date.