### PR TITLE
ui: inject config to window on serve time

### DIFF
--- a/ui/public/config.js
+++ b/ui/public/config.js
@@ -1,0 +1,9 @@
+(() => {
+  const CONFIG = {
+    REACT_APP_PIWIK_URL: null,
+    REACT_APP_PIWIK_SITE_ID: null,
+    REACT_APP_SENTRY_DSN: null,
+  };
+
+  Object.defineProperty(window, 'CONFIG', { value: Object.freeze(CONFIG) });
+})();

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -10,6 +10,7 @@
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
+    <script type="text/javascript" src="%PUBLIC_URL%/config.js"></script>
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/ui/src/__tests__/tracker.test.js
+++ b/ui/src/__tests__/tracker.test.js
@@ -5,25 +5,21 @@ import { setUserCategoryFromRoles } from '../tracker';
 
 jest.mock('react-piwik');
 
-Piwik.push = jest.fn();
-
-function setPiwikConfig() {
-  process.env.REACT_APP_PIWIK_URL = 'some';
-  process.env.REACT_APP_PIWIK_SITE_ID = '1';
-}
-
-function resetPiwikConfig() {
-  process.env.REACT_APP_PIWIK_URL = undefined;
-  process.env.REACT_APP_PIWIK_SITE_ID = undefined;
-}
-
 describe('tracker', () => {
+  beforeAll(() => {
+    window.CONFIG = {};
+  });
+
   beforeEach(() => {
-    setPiwikConfig();
+    window.CONFIG = {
+      REACT_APP_PIWIK_URL: 'some',
+      REACT_APP_PIWIK_SITE_ID: '1',
+    };
   });
 
   afterEach(() => {
-    resetPiwikConfig();
+    window.CONFIG = {};
+    Piwik.push.mockClear();
   });
 
   describe('setUserCategoryFromRoles', () => {

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -15,7 +15,7 @@ import ErrorBoundary from './common/components/ErrorBoundary';
 import { injectTrackerToHistory } from './tracker';
 
 Sentry.init({
-  dsn: process.env.REACT_APP_SENTRY_DSN,
+  dsn: window.CONFIG.REACT_APP_SENTRY_DSN,
 });
 
 const store = createStore();

--- a/ui/src/tracker.js
+++ b/ui/src/tracker.js
@@ -2,13 +2,13 @@ import Piwik from 'react-piwik';
 import { isSuperUser, isCataloger } from './common/authorization';
 
 function isTrackerConfigured() {
-  const { REACT_APP_PIWIK_URL, REACT_APP_PIWIK_SITE_ID } = process.env;
+  const { REACT_APP_PIWIK_URL, REACT_APP_PIWIK_SITE_ID } = window.CONFIG;
   return REACT_APP_PIWIK_URL != null && REACT_APP_PIWIK_SITE_ID != null;
 }
 
 export function injectTrackerToHistory(history) {
   if (isTrackerConfigured()) {
-    const { REACT_APP_PIWIK_URL, REACT_APP_PIWIK_SITE_ID } = process.env;
+    const { REACT_APP_PIWIK_URL, REACT_APP_PIWIK_SITE_ID } = window.CONFIG;
     const piwik = new Piwik({
       url: REACT_APP_PIWIK_URL,
       siteId: Number(REACT_APP_PIWIK_SITE_ID),


### PR DESCRIPTION
Config variables such as SENTRY_DSN could be only set build time which
happens when we build an imagine with nginx and UI assets. This forced
us to create different images for QA and PROD.

Also it was not possible to change FEATURE_FLAGs (which we don't have
currently but plan to have) without rebuilding whole assets and the
imagine itself prior to deployment.

Note: This is the "MVP" as described in the task.

* INSPIR-2548