### PR TITLE
serializers: add created and updated to the search with ui content type

### DIFF
--- a/inspirehep/records/config.py
+++ b/inspirehep/records/config.py
@@ -503,6 +503,8 @@ LITERATURE_SOURCE_INCLUDES_BY_CONTENT_TYPE = {
         "_ui_display",
         # we need this for the record fetcher
         "control_number",
+        "_created",
+        "_updated",
     ]
 }
 LITERATURE_SOURCE_EXCLUDES_BY_CONTENT_TYPE = {"application/json": ["_ui_display"]}


### PR DESCRIPTION
* added created and updated to the source of the ES query because they were missing from the literature search with ui content-type 
* INSPIR-2582