### PR TITLE
bibtex: display authors and editors

### DIFF
--- a/backend/inspirehep/records/marshmallow/literature/bibtex.py
+++ b/backend/inspirehep/records/marshmallow/literature/bibtex.py
@@ -21,6 +21,8 @@ class BibTexCommonSchema(Schema):
     address = fields.Method("get_address")
     archivePrefix = fields.Method("get_archive_prefix")
     author = fields.Method("get_author")
+    authors_with_role_author = fields.Method("get_authors_with_role_author")
+    authors_with_role_editor = fields.Method("get_authors_with_role_editor")
     booktitle = fields.Method("get_book_title")
     collaboration = fields.Method("get_collaboration")
     doc_type = fields.Raw()
@@ -115,6 +117,12 @@ class BibTexCommonSchema(Schema):
             return {}
 
         return sorted(only_publications, key=len, reverse=True)[0]
+
+    def get_authors_with_role_author(self, data):
+        return self.get_authors_with_role(data.get("authors", []), "author")
+
+    def get_authors_with_role_editor(self, data):
+        return self.get_authors_with_role(data.get("authors", []), "editor")
 
     def get_eprint(self, data):
         return get_value(data, "arxiv_eprints.value[0]", default=None)

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPushTask.test_push_new_work_already_existing.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPushTask.test_push_new_work_already_existing.yaml
@@ -3,8 +3,8 @@ interactions:
     body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
       http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
       \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{45,\n\
-      \    doi = \"10.1000/test.orcid.push\",\n    title = \"Some Results Arising\
-      \ from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>45</common:external-id-value><common:external-id-url>http://inspirehep.net/record/45</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.1000/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.1000/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/45</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
+      \    author = \"Rossoni, A.\",\n    doi = \"10.1000/test.orcid.push\",\n   \
+      \ title = \"Some Results Arising from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>45</common:external-id-value><common:external-id-url>http://inspirehep.net/record/45</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.1000/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.1000/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/45</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
       \ A.</work:credit-name><work:contributor-attributes><work:contributor-sequence>first</work:contributor-sequence><work:contributor-role>author</work:contributor-role></work:contributor-attributes></work:contributor></work:contributors></work:work>"
     headers:
       Accept:
@@ -14,7 +14,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1518'
+      - '1546'
       Content-Type:
       - application/orcid+xml
     method: POST
@@ -34,11 +34,11 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Wed, 07 Aug 2019 11:25:29 GMT
+      - Tue, 13 Aug 2019 09:46:12 GMT
       Expires:
       - '0'
       Location:
-      - http://api.orcid.org/orcid-api-web/v2.0/0000-0003-1134-6827/work/60303142
+      - http://api.orcid.org/orcid-api-web/v2.0/0000-0003-1134-6827/work/60484108
       Pragma:
       - no-cache
       Server:

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPushTask.test_push_new_work_happy_flow.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPushTask.test_push_new_work_happy_flow.yaml
@@ -52,4 +52,57 @@ interactions:
     status:
       code: 201
       message: Created
+- request:
+    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
+      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
+      \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{45,\n\
+      \    author = \"Rossoni, A.\",\n    doi = \"10.1000/test.orcid.push\",\n   \
+      \ title = \"Some Results Arising from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>45</common:external-id-value><common:external-id-url>http://inspirehep.net/record/45</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.1000/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.1000/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/45</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
+      \ A.</work:credit-name><work:contributor-attributes><work:contributor-sequence>first</work:contributor-sequence><work:contributor-role>author</work:contributor-role></work:contributor-attributes></work:contributor></work:contributors></work:work>"
+    headers:
+      Accept:
+      - application/orcid+json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1546'
+      Content-Type:
+      - application/orcid+xml
+    method: POST
+    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/orcid+json; qs=2;charset=UTF-8
+      Date:
+      - Wed, 07 Aug 2019 16:07:05 GMT
+      Expires:
+      - '0'
+      Location:
+      - http://api.orcid.org/orcid-api-web/v2.0/0000-0003-1134-6827/work/60314447
+      Pragma:
+      - no-cache
+      Server:
+      - nginx/1.10.0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
 version: 1

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPushTask.test_push_new_work_invalid_data_orcid.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPushTask.test_push_new_work_invalid_data_orcid.yaml
@@ -54,4 +54,59 @@ interactions:
     status:
       code: 404
       message: Not Found
+- request:
+    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
+      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
+      \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{45,\n\
+      \    author = \"Rossoni, A.\",\n    doi = \"10.1000/test.orcid.push\",\n   \
+      \ title = \"Some Results Arising from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>45</common:external-id-value><common:external-id-url>http://inspirehep.net/record/45</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.1000/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.1000/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/45</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
+      \ A.</work:credit-name><work:contributor-attributes><work:contributor-sequence>first</work:contributor-sequence><work:contributor-role>author</work:contributor-role></work:contributor-attributes></work:contributor></work:contributors></work:work>"
+    headers:
+      Accept:
+      - application/orcid+json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1546'
+      Content-Type:
+      - application/orcid+xml
+    method: POST
+    uri: https://api.orcid.org/v2.0/0000-0003-0000-XXXX/work
+  response:
+    body:
+      string: '{"response-code":404,"developer-message":"404 Not Found: The resource
+        was not found. Full validation error: ORCID iD 0000-0003-0000-XXXX not found","user-message":"The
+        resource was not found.","error-code":9016,"more-info":"https://members.orcid.org/api/resources/troubleshooting"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/orcid+json; qs=2;charset=UTF-8
+      Date:
+      - Wed, 07 Aug 2019 16:07:08 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - nginx/1.10.0
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '281'
+    status:
+      code: 404
+      message: Not Found
 version: 1

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherDuplicatedIdentifier.test_duplicated_external_identifier_pusher_exception.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherDuplicatedIdentifier.test_duplicated_external_identifier_pusher_exception.yaml
@@ -3,8 +3,8 @@ interactions:
     body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
       http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
       \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{999,\n\
-      \    doi = \"10.1111/test.orcid.push\",\n    title = \"Some Results Arising\
-      \ from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>999</common:external-id-value><common:external-id-url>http://inspirehep.net/record/999</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.1111/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.1111/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/999</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
+      \    author = \"Rossoni, A.\",\n    doi = \"10.1111/test.orcid.push\",\n   \
+      \ title = \"Some Results Arising from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>999</common:external-id-value><common:external-id-url>http://inspirehep.net/record/999</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.1111/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.1111/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/999</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
       \ A.</work:credit-name><work:contributor-attributes><work:contributor-sequence>first</work:contributor-sequence><work:contributor-role>author</work:contributor-role></work:contributor-attributes></work:contributor></work:contributors></work:work>"
     headers:
       Accept:
@@ -14,7 +14,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1522'
+      - '1550'
       Content-Type:
       - application/orcid+xml
     method: POST
@@ -23,7 +23,7 @@ interactions:
     body:
       string: '{"response-code":409,"developer-message":"409 Conflict: You have already
         added this activity (matched by external identifiers), please see element
-        with put-code 60275410. If you are trying to edit the item, please use PUT
+        with put-code 60484147. If you are trying to edit the item, please use PUT
         instead of POST.","user-message":"There was an error when updating the record.
         Please try again. If the error persists, please contact INSPIRE-HEP for assistance.","error-code":9021,"more-info":"https://members.orcid.org/api/resources/troubleshooting"}'
     headers:
@@ -38,7 +38,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Tue, 06 Aug 2019 16:15:43 GMT
+      - Tue, 13 Aug 2019 09:46:50 GMT
       Expires:
       - '0'
       Pragma:
@@ -67,8 +67,8 @@ interactions:
     uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/works
   response:
     body:
-      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1565108141291\n  },\n\
-        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1565108141291\n\
+      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1565689609140\n  },\n\
+        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1565689609140\n\
         \    },\n    \"external-ids\" : {\n      \"external-id\" : [ {\n        \"\
         external-id-type\" : \"other-id\",\n        \"external-id-value\" : \"999\"\
         ,\n        \"external-id-url\" : {\n          \"value\" : \"http://inspirehep.net/record/999\"\
@@ -77,9 +77,9 @@ interactions:
         \ \"10.1111/test.orcid.push\",\n        \"external-id-url\" : {\n        \
         \  \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\n        },\n\
         \        \"external-id-relationship\" : \"SELF\"\n      } ]\n    },\n    \"\
-        work-summary\" : [ {\n      \"put-code\" : 60275410,\n      \"created-date\"\
-        \ : {\n        \"value\" : 1565108138505\n      },\n      \"last-modified-date\"\
-        \ : {\n        \"value\" : 1565108141291\n      },\n      \"source\" : {\n\
+        work-summary\" : [ {\n      \"put-code\" : 60484147,\n      \"created-date\"\
+        \ : {\n        \"value\" : 1565689608557\n      },\n      \"last-modified-date\"\
+        \ : {\n        \"value\" : 1565689609140\n      },\n      \"source\" : {\n\
         \        \"source-orcid\" : null,\n        \"source-client-id\" : {\n    \
         \      \"uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \
         \    \"path\" : \"0000-0001-8607-8906\",\n          \"host\" : \"orcid.org\"\
@@ -96,7 +96,7 @@ interactions:
         external-id-url\" : {\n            \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\
         \n          },\n          \"external-id-relationship\" : \"SELF\"\n      \
         \  } ]\n      },\n      \"type\" : \"JOURNAL_ARTICLE\",\n      \"publication-date\"\
-        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/60275410\"\
+        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/60484147\"\
         ,\n      \"display-index\" : \"0\"\n    } ]\n  } ],\n  \"path\" : \"/0000-0003-1134-6827/works\"\
         \n}"
     headers:
@@ -109,7 +109,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Tue, 06 Aug 2019 16:15:43 GMT
+      - Tue, 13 Aug 2019 09:46:51 GMT
       Expires:
       - '0'
       Pragma:
@@ -133,8 +133,8 @@ interactions:
     body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
       http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
       \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{999,\n\
-      \    doi = \"10.1111/test.orcid.push\",\n    title = \"Some Results Arising\
-      \ from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>999</common:external-id-value><common:external-id-url>http://inspirehep.net/record/999</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.1111/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.1111/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/999</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
+      \    author = \"Rossoni, A.\",\n    doi = \"10.1111/test.orcid.push\",\n   \
+      \ title = \"Some Results Arising from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>999</common:external-id-value><common:external-id-url>http://inspirehep.net/record/999</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.1111/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.1111/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/999</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
       \ A.</work:credit-name><work:contributor-attributes><work:contributor-sequence>first</work:contributor-sequence><work:contributor-role>author</work:contributor-role></work:contributor-attributes></work:contributor></work:contributors></work:work>"
     headers:
       Accept:
@@ -144,7 +144,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1522'
+      - '1550'
       Content-Type:
       - application/orcid+xml
     method: POST
@@ -153,7 +153,7 @@ interactions:
     body:
       string: '{"response-code":409,"developer-message":"409 Conflict: You have already
         added this activity (matched by external identifiers), please see element
-        with put-code 60275410. If you are trying to edit the item, please use PUT
+        with put-code 60484147. If you are trying to edit the item, please use PUT
         instead of POST.","user-message":"There was an error when updating the record.
         Please try again. If the error persists, please contact INSPIRE-HEP for assistance.","error-code":9021,"more-info":"https://members.orcid.org/api/resources/troubleshooting"}'
     headers:
@@ -168,7 +168,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Tue, 06 Aug 2019 16:15:44 GMT
+      - Tue, 13 Aug 2019 09:46:51 GMT
       Expires:
       - '0'
       Pragma:

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherDuplicatedIdentifier.test_exc_in_apply_celery_task_with_retry.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherDuplicatedIdentifier.test_exc_in_apply_celery_task_with_retry.yaml
@@ -116,8 +116,6 @@ interactions:
       - no-cache
       Server:
       - nginx/1.10.0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -129,4 +127,59 @@ interactions:
     status:
       code: 200
       message: OK
+- request:
+    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
+      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
+      \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{999,\n\
+      \    author = \"Rossoni, A.\",\n    doi = \"10.1111/test.orcid.push\",\n   \
+      \ title = \"Some Results Arising from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>999</common:external-id-value><common:external-id-url>http://inspirehep.net/record/999</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.1111/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.1111/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/999</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
+      \ A.</work:credit-name><work:contributor-attributes><work:contributor-sequence>first</work:contributor-sequence><work:contributor-role>author</work:contributor-role></work:contributor-attributes></work:contributor></work:contributors></work:work>"
+    headers:
+      Accept:
+      - application/orcid+json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1550'
+      Content-Type:
+      - application/orcid+xml
+    method: POST
+    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work
+  response:
+    body:
+      string: '{"response-code":409,"developer-message":"409 Conflict: You have already
+        added this activity (matched by external identifiers), please see element
+        with put-code 60314420. If you are trying to edit the item, please use PUT
+        instead of POST.","user-message":"There was an error when updating the record.
+        Please try again. If the error persists, please contact INSPIRE-HEP for assistance.","error-code":9021,"more-info":"https://members.orcid.org/api/resources/troubleshooting"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '474'
+      Content-Type:
+      - application/orcid+json; qs=2;charset=UTF-8
+      Date:
+      - Wed, 07 Aug 2019 16:04:44 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - nginx/1.10.0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 409
+      message: Conflict
 version: 1

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherDuplicatedIdentifier.test_happy_flow_post.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherDuplicatedIdentifier.test_happy_flow_post.yaml
@@ -52,4 +52,57 @@ interactions:
     status:
       code: 201
       message: Created
+- request:
+    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
+      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
+      \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{666,\n\
+      \    author = \"Rossoni, A.\",\n    doi = \"10.1111/test.orcid.push\",\n   \
+      \ title = \"Some Results Arising from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>666</common:external-id-value><common:external-id-url>http://inspirehep.net/record/666</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.1111/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.1111/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/666</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
+      \ A.</work:credit-name><work:contributor-attributes><work:contributor-sequence>first</work:contributor-sequence><work:contributor-role>author</work:contributor-role></work:contributor-attributes></work:contributor></work:contributors></work:work>"
+    headers:
+      Accept:
+      - application/orcid+json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1550'
+      Content-Type:
+      - application/orcid+xml
+    method: POST
+    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/orcid+json; qs=2;charset=UTF-8
+      Date:
+      - Wed, 07 Aug 2019 16:04:39 GMT
+      Expires:
+      - '0'
+      Location:
+      - http://api.orcid.org/orcid-api-web/v2.0/0000-0003-1134-6827/work/60314420
+      Pragma:
+      - no-cache
+      Server:
+      - nginx/1.10.0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
 version: 1

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherDuplicatedIdentifier.test_happy_flow_put.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherDuplicatedIdentifier.test_happy_flow_put.yaml
@@ -3,7 +3,8 @@ interactions:
     body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
       http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
       \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{999,\n\
-      \    title = \"Some Results Arising from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>999</common:external-id-value><common:external-id-url>http://inspirehep.net/record/999</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/999</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
+      \    author = \"Rossoni, A.\",\n    title = \"Some Results Arising from the\
+      \ Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>999</common:external-id-value><common:external-id-url>http://inspirehep.net/record/999</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/999</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
       \ A.</work:credit-name><work:contributor-attributes><work:contributor-sequence>first</work:contributor-sequence><work:contributor-role>author</work:contributor-role></work:contributor-attributes></work:contributor></work:contributors></work:work>"
     headers:
       Accept:
@@ -13,7 +14,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1153'
+      - '1181'
       Content-Type:
       - application/orcid+xml
     method: POST
@@ -33,11 +34,11 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Tue, 06 Aug 2019 16:15:38 GMT
+      - Tue, 13 Aug 2019 09:46:48 GMT
       Expires:
       - '0'
       Location:
-      - http://api.orcid.org/orcid-api-web/v2.0/0000-0003-1134-6827/work/60275410
+      - http://api.orcid.org/orcid-api-web/v2.0/0000-0003-1134-6827/work/60484147
       Pragma:
       - no-cache
       Server:
@@ -53,10 +54,10 @@ interactions:
       message: Created
 - request:
     body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\" put-code=\"60275410\"><work:title><common:title>Some\
+      http://www.orcid.org/ns/work\" put-code=\"60484147\"><work:title><common:title>Some\
       \ Results Arising from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{999,\n\
-      \    doi = \"10.1111/test.orcid.push\",\n    title = \"Some Results Arising\
-      \ from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>999</common:external-id-value><common:external-id-url>http://inspirehep.net/record/999</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.1111/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.1111/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/999</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
+      \    author = \"Rossoni, A.\",\n    doi = \"10.1111/test.orcid.push\",\n   \
+      \ title = \"Some Results Arising from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>999</common:external-id-value><common:external-id-url>http://inspirehep.net/record/999</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.1111/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.1111/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/999</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
       \ A.</work:credit-name><work:contributor-attributes><work:contributor-sequence>first</work:contributor-sequence><work:contributor-role>author</work:contributor-role></work:contributor-attributes></work:contributor></work:contributors></work:work>"
     headers:
       Accept:
@@ -66,324 +67,31 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1542'
+      - '1570'
       Content-Type:
       - application/orcid+xml
     method: PUT
-    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/60275410
+    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/60484147
   response:
     body:
-      string: '{"response-code":409,"developer-message":"409 Conflict: You have already
-        added this activity (matched by external identifiers), please see element
-        with put-code 60275409. If you are trying to edit the item, please use PUT
-        instead of POST.","user-message":"There was an error when updating the record.
-        Please try again. If the error persists, please contact INSPIRE-HEP for assistance.","error-code":9021,"more-info":"https://members.orcid.org/api/resources/troubleshooting"}'
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '474'
-      Content-Type:
-      - application/orcid+json; qs=2;charset=UTF-8
-      Date:
-      - Tue, 06 Aug 2019 16:15:39 GMT
-      Expires:
-      - '0'
-      Pragma:
-      - no-cache
-      Server:
-      - nginx/1.10.0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 409
-      message: Conflict
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/orcid+json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-    method: GET
-    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/works
-  response:
-    body:
-      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1565108138505\n  },\n\
-        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1565108137613\n\
-        \    },\n    \"external-ids\" : {\n      \"external-id\" : [ {\n        \"\
-        external-id-type\" : \"other-id\",\n        \"external-id-value\" : \"666\"\
-        ,\n        \"external-id-url\" : {\n          \"value\" : \"http://inspirehep.net/record/666\"\
-        \n        },\n        \"external-id-relationship\" : \"SELF\"\n      }, {\n\
-        \        \"external-id-type\" : \"doi\",\n        \"external-id-value\" :\
-        \ \"10.1111/test.orcid.push\",\n        \"external-id-url\" : {\n        \
-        \  \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\n        },\n\
-        \        \"external-id-relationship\" : \"SELF\"\n      } ]\n    },\n    \"\
-        work-summary\" : [ {\n      \"put-code\" : 60275409,\n      \"created-date\"\
-        \ : {\n        \"value\" : 1565108137613\n      },\n      \"last-modified-date\"\
-        \ : {\n        \"value\" : 1565108137613\n      },\n      \"source\" : {\n\
-        \        \"source-orcid\" : null,\n        \"source-client-id\" : {\n    \
-        \      \"uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \
-        \    \"path\" : \"0000-0001-8607-8906\",\n          \"host\" : \"orcid.org\"\
-        \n        },\n        \"source-name\" : {\n          \"value\" : \"INSPIRE-HEP\"\
-        \n        }\n      },\n      \"title\" : {\n        \"title\" : {\n      \
-        \    \"value\" : \"Some Results Arising from the Study of ORCID push\"\n \
-        \       },\n        \"subtitle\" : null,\n        \"translated-title\" : null\n\
-        \      },\n      \"external-ids\" : {\n        \"external-id\" : [ {\n   \
-        \       \"external-id-type\" : \"other-id\",\n          \"external-id-value\"\
-        \ : \"666\",\n          \"external-id-url\" : {\n            \"value\" : \"\
-        http://inspirehep.net/record/666\"\n          },\n          \"external-id-relationship\"\
-        \ : \"SELF\"\n        }, {\n          \"external-id-type\" : \"doi\",\n  \
-        \        \"external-id-value\" : \"10.1111/test.orcid.push\",\n          \"\
-        external-id-url\" : {\n            \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\
-        \n          },\n          \"external-id-relationship\" : \"SELF\"\n      \
-        \  } ]\n      },\n      \"type\" : \"JOURNAL_ARTICLE\",\n      \"publication-date\"\
-        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/60275409\"\
-        ,\n      \"display-index\" : \"0\"\n    } ]\n  }, {\n    \"last-modified-date\"\
-        \ : {\n      \"value\" : 1565108138505\n    },\n    \"external-ids\" : {\n\
-        \      \"external-id\" : [ {\n        \"external-id-type\" : \"other-id\"\
-        ,\n        \"external-id-value\" : \"999\",\n        \"external-id-url\" :\
-        \ {\n          \"value\" : \"http://inspirehep.net/record/999\"\n        },\n\
-        \        \"external-id-relationship\" : \"SELF\"\n      } ]\n    },\n    \"\
-        work-summary\" : [ {\n      \"put-code\" : 60275410,\n      \"created-date\"\
-        \ : {\n        \"value\" : 1565108138505\n      },\n      \"last-modified-date\"\
-        \ : {\n        \"value\" : 1565108138505\n      },\n      \"source\" : {\n\
-        \        \"source-orcid\" : null,\n        \"source-client-id\" : {\n    \
-        \      \"uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \
-        \    \"path\" : \"0000-0001-8607-8906\",\n          \"host\" : \"orcid.org\"\
-        \n        },\n        \"source-name\" : {\n          \"value\" : \"INSPIRE-HEP\"\
-        \n        }\n      },\n      \"title\" : {\n        \"title\" : {\n      \
-        \    \"value\" : \"Some Results Arising from the Study of ORCID push\"\n \
-        \       },\n        \"subtitle\" : null,\n        \"translated-title\" : null\n\
-        \      },\n      \"external-ids\" : {\n        \"external-id\" : [ {\n   \
-        \       \"external-id-type\" : \"other-id\",\n          \"external-id-value\"\
-        \ : \"999\",\n          \"external-id-url\" : {\n            \"value\" : \"\
-        http://inspirehep.net/record/999\"\n          },\n          \"external-id-relationship\"\
-        \ : \"SELF\"\n        } ]\n      },\n      \"type\" : \"JOURNAL_ARTICLE\"\
-        ,\n      \"publication-date\" : null,\n      \"visibility\" : \"PUBLIC\",\n\
-        \      \"path\" : \"/0000-0003-1134-6827/work/60275410\",\n      \"display-index\"\
-        \ : \"0\"\n    } ]\n  } ],\n  \"path\" : \"/0000-0003-1134-6827/works\"\n}"
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/orcid+json; qs=2;charset=UTF-8
-      Date:
-      - Tue, 06 Aug 2019 16:15:39 GMT
-      Expires:
-      - '0'
-      Pragma:
-      - no-cache
-      Server:
-      - nginx/1.10.0
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '3719'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/orcid+json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-    method: GET
-    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/works
-  response:
-    body:
-      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1565108138505\n  },\n\
-        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1565108137613\n\
-        \    },\n    \"external-ids\" : {\n      \"external-id\" : [ {\n        \"\
-        external-id-type\" : \"other-id\",\n        \"external-id-value\" : \"666\"\
-        ,\n        \"external-id-url\" : {\n          \"value\" : \"http://inspirehep.net/record/666\"\
-        \n        },\n        \"external-id-relationship\" : \"SELF\"\n      }, {\n\
-        \        \"external-id-type\" : \"doi\",\n        \"external-id-value\" :\
-        \ \"10.1111/test.orcid.push\",\n        \"external-id-url\" : {\n        \
-        \  \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\n        },\n\
-        \        \"external-id-relationship\" : \"SELF\"\n      } ]\n    },\n    \"\
-        work-summary\" : [ {\n      \"put-code\" : 60275409,\n      \"created-date\"\
-        \ : {\n        \"value\" : 1565108137613\n      },\n      \"last-modified-date\"\
-        \ : {\n        \"value\" : 1565108137613\n      },\n      \"source\" : {\n\
-        \        \"source-orcid\" : null,\n        \"source-client-id\" : {\n    \
-        \      \"uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \
-        \    \"path\" : \"0000-0001-8607-8906\",\n          \"host\" : \"orcid.org\"\
-        \n        },\n        \"source-name\" : {\n          \"value\" : \"INSPIRE-HEP\"\
-        \n        }\n      },\n      \"title\" : {\n        \"title\" : {\n      \
-        \    \"value\" : \"Some Results Arising from the Study of ORCID push\"\n \
-        \       },\n        \"subtitle\" : null,\n        \"translated-title\" : null\n\
-        \      },\n      \"external-ids\" : {\n        \"external-id\" : [ {\n   \
-        \       \"external-id-type\" : \"other-id\",\n          \"external-id-value\"\
-        \ : \"666\",\n          \"external-id-url\" : {\n            \"value\" : \"\
-        http://inspirehep.net/record/666\"\n          },\n          \"external-id-relationship\"\
-        \ : \"SELF\"\n        }, {\n          \"external-id-type\" : \"doi\",\n  \
-        \        \"external-id-value\" : \"10.1111/test.orcid.push\",\n          \"\
-        external-id-url\" : {\n            \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\
-        \n          },\n          \"external-id-relationship\" : \"SELF\"\n      \
-        \  } ]\n      },\n      \"type\" : \"JOURNAL_ARTICLE\",\n      \"publication-date\"\
-        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/60275409\"\
-        ,\n      \"display-index\" : \"0\"\n    } ]\n  }, {\n    \"last-modified-date\"\
-        \ : {\n      \"value\" : 1565108138505\n    },\n    \"external-ids\" : {\n\
-        \      \"external-id\" : [ {\n        \"external-id-type\" : \"other-id\"\
-        ,\n        \"external-id-value\" : \"999\",\n        \"external-id-url\" :\
-        \ {\n          \"value\" : \"http://inspirehep.net/record/999\"\n        },\n\
-        \        \"external-id-relationship\" : \"SELF\"\n      } ]\n    },\n    \"\
-        work-summary\" : [ {\n      \"put-code\" : 60275410,\n      \"created-date\"\
-        \ : {\n        \"value\" : 1565108138505\n      },\n      \"last-modified-date\"\
-        \ : {\n        \"value\" : 1565108138505\n      },\n      \"source\" : {\n\
-        \        \"source-orcid\" : null,\n        \"source-client-id\" : {\n    \
-        \      \"uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \
-        \    \"path\" : \"0000-0001-8607-8906\",\n          \"host\" : \"orcid.org\"\
-        \n        },\n        \"source-name\" : {\n          \"value\" : \"INSPIRE-HEP\"\
-        \n        }\n      },\n      \"title\" : {\n        \"title\" : {\n      \
-        \    \"value\" : \"Some Results Arising from the Study of ORCID push\"\n \
-        \       },\n        \"subtitle\" : null,\n        \"translated-title\" : null\n\
-        \      },\n      \"external-ids\" : {\n        \"external-id\" : [ {\n   \
-        \       \"external-id-type\" : \"other-id\",\n          \"external-id-value\"\
-        \ : \"999\",\n          \"external-id-url\" : {\n            \"value\" : \"\
-        http://inspirehep.net/record/999\"\n          },\n          \"external-id-relationship\"\
-        \ : \"SELF\"\n        } ]\n      },\n      \"type\" : \"JOURNAL_ARTICLE\"\
-        ,\n      \"publication-date\" : null,\n      \"visibility\" : \"PUBLIC\",\n\
-        \      \"path\" : \"/0000-0003-1134-6827/work/60275410\",\n      \"display-index\"\
-        \ : \"0\"\n    } ]\n  } ],\n  \"path\" : \"/0000-0003-1134-6827/works\"\n}"
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/orcid+json; qs=2;charset=UTF-8
-      Date:
-      - Tue, 06 Aug 2019 16:15:40 GMT
-      Expires:
-      - '0'
-      Pragma:
-      - no-cache
-      Server:
-      - nginx/1.10.0
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '3719'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/orcid+json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      Content-Type:
-      - application/orcid+json
-    method: DELETE
-    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/60275409
-  response:
-    body:
-      string: ''
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/orcid+json; qs=2;charset=UTF-8
-      Date:
-      - Tue, 06 Aug 2019 16:15:40 GMT
-      Expires:
-      - '0'
-      Pragma:
-      - no-cache
-      Server:
-      - nginx/1.10.0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\" put-code=\"60275410\"><work:title><common:title>Some\
-      \ Results Arising from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{999,\n\
-      \    doi = \"10.1111/test.orcid.push\",\n    title = \"Some Results Arising\
-      \ from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>999</common:external-id-value><common:external-id-url>http://inspirehep.net/record/999</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.1111/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.1111/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/999</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
-      \ A.</work:credit-name><work:contributor-attributes><work:contributor-sequence>first</work:contributor-sequence><work:contributor-role>author</work:contributor-role></work:contributor-attributes></work:contributor></work:contributors></work:work>"
-    headers:
-      Accept:
-      - application/orcid+json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '1542'
-      Content-Type:
-      - application/orcid+xml
-    method: PUT
-    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/60275410
-  response:
-    body:
-      string: "{\n  \"created-date\" : {\n    \"value\" : 1565108138505\n  },\n  \"\
-        last-modified-date\" : {\n    \"value\" : 1565108141291\n  },\n  \"source\"\
+      string: "{\n  \"created-date\" : {\n    \"value\" : 1565689608557\n  },\n  \"\
+        last-modified-date\" : {\n    \"value\" : 1565689609140\n  },\n  \"source\"\
         \ : {\n    \"source-orcid\" : null,\n    \"source-client-id\" : {\n      \"\
         uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \"path\" :\
         \ \"0000-0001-8607-8906\",\n      \"host\" : \"orcid.org\"\n    },\n    \"\
         source-name\" : {\n      \"value\" : \"INSPIRE-HEP\"\n    }\n  },\n  \"put-code\"\
-        \ : 60275410,\n  \"path\" : null,\n  \"title\" : {\n    \"title\" : {\n  \
+        \ : 60484147,\n  \"path\" : null,\n  \"title\" : {\n    \"title\" : {\n  \
         \    \"value\" : \"Some Results Arising from the Study of ORCID push\"\n \
         \   },\n    \"subtitle\" : null,\n    \"translated-title\" : null\n  },\n\
         \  \"journal-title\" : null,\n  \"short-description\" : null,\n  \"citation\"\
         \ : {\n    \"citation-type\" : \"BIBTEX\",\n    \"citation-value\" : \"@article{999,\\\
-        n    doi = \\\"10.1111/test.orcid.push\\\",\\n    title = \\\"Some Results\
-        \ Arising from the Study of ORCID push\\\"\\n}\\n\"\n  },\n  \"type\" : \"\
-        JOURNAL_ARTICLE\",\n  \"publication-date\" : null,\n  \"external-ids\" : {\n\
-        \    \"external-id\" : [ {\n      \"external-id-type\" : \"other-id\",\n \
-        \     \"external-id-value\" : \"999\",\n      \"external-id-url\" : {\n  \
-        \      \"value\" : \"http://inspirehep.net/record/999\"\n      },\n      \"\
-        external-id-relationship\" : \"SELF\"\n    }, {\n      \"external-id-type\"\
+        n    author = \\\"Rossoni, A.\\\",\\n    doi = \\\"10.1111/test.orcid.push\\\
+        \",\\n    title = \\\"Some Results Arising from the Study of ORCID push\\\"\
+        \\n}\\n\"\n  },\n  \"type\" : \"JOURNAL_ARTICLE\",\n  \"publication-date\"\
+        \ : null,\n  \"external-ids\" : {\n    \"external-id\" : [ {\n      \"external-id-type\"\
+        \ : \"other-id\",\n      \"external-id-value\" : \"999\",\n      \"external-id-url\"\
+        \ : {\n        \"value\" : \"http://inspirehep.net/record/999\"\n      },\n\
+        \      \"external-id-relationship\" : \"SELF\"\n    }, {\n      \"external-id-type\"\
         \ : \"doi\",\n      \"external-id-value\" : \"10.1111/test.orcid.push\",\n\
         \      \"external-id-url\" : {\n        \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\
         \n      },\n      \"external-id-relationship\" : \"SELF\"\n    } ]\n  },\n\
@@ -404,7 +112,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Tue, 06 Aug 2019 16:15:41 GMT
+      - Tue, 13 Aug 2019 09:46:49 GMT
       Expires:
       - '0'
       Pragma:
@@ -420,7 +128,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1862'
+      - '1893'
     status:
       code: 200
       message: OK

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherPostNewWork.test_push_new_work_already_existing.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherPostNewWork.test_push_new_work_already_existing.yaml
@@ -3,8 +3,8 @@ interactions:
     body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
       http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
       \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{45,\n\
-      \    doi = \"10.1111/test.orcid.push\",\n    title = \"Some Results Arising\
-      \ from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>45</common:external-id-value><common:external-id-url>http://inspirehep.net/record/45</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.1111/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.1111/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/45</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
+      \    author = \"Rossoni, A.\",\n    doi = \"10.1111/test.orcid.push\",\n   \
+      \ title = \"Some Results Arising from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>45</common:external-id-value><common:external-id-url>http://inspirehep.net/record/45</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.1111/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.1111/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/45</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
       \ A.</work:credit-name><work:contributor-attributes><work:contributor-sequence>first</work:contributor-sequence><work:contributor-role>author</work:contributor-role></work:contributor-attributes></work:contributor></work:contributors></work:work>"
     headers:
       Accept:
@@ -14,18 +14,14 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1518'
+      - '1546'
       Content-Type:
       - application/orcid+xml
     method: POST
     uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work
   response:
     body:
-      string: '{"response-code":409,"developer-message":"409 Conflict: You have already
-        added this activity (matched by external identifiers), please see element
-        with put-code 60275458. If you are trying to edit the item, please use PUT
-        instead of POST.","user-message":"There was an error when updating the record.
-        Please try again. If the error persists, please contact INSPIRE-HEP for assistance.","error-code":9021,"more-info":"https://members.orcid.org/api/resources/troubleshooting"}'
+      string: ''
     headers:
       Access-Control-Allow-Origin:
       - '*'
@@ -34,13 +30,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '474'
+      - '0'
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Tue, 06 Aug 2019 16:18:48 GMT
+      - Tue, 13 Aug 2019 09:46:29 GMT
       Expires:
       - '0'
+      Location:
+      - http://api.orcid.org/orcid-api-web/v2.0/0000-0003-1134-6827/work/60484140
       Pragma:
       - no-cache
       Server:
@@ -52,291 +50,6 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
     status:
-      code: 409
-      message: Conflict
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/orcid+json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-    method: GET
-    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/works
-  response:
-    body:
-      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1565108326114\n  },\n\
-        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1565108326114\n\
-        \    },\n    \"external-ids\" : {\n      \"external-id\" : [ {\n        \"\
-        external-id-type\" : \"other-id\",\n        \"external-id-value\" : \"45\"\
-        ,\n        \"external-id-url\" : {\n          \"value\" : \"http://inspirehep.net/record/45\"\
-        \n        },\n        \"external-id-relationship\" : \"SELF\"\n      }, {\n\
-        \        \"external-id-type\" : \"doi\",\n        \"external-id-value\" :\
-        \ \"10.1111/test.orcid.push\",\n        \"external-id-url\" : {\n        \
-        \  \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\n        },\n\
-        \        \"external-id-relationship\" : \"SELF\"\n      } ]\n    },\n    \"\
-        work-summary\" : [ {\n      \"put-code\" : 60275458,\n      \"created-date\"\
-        \ : {\n        \"value\" : 1565108326114\n      },\n      \"last-modified-date\"\
-        \ : {\n        \"value\" : 1565108326114\n      },\n      \"source\" : {\n\
-        \        \"source-orcid\" : null,\n        \"source-client-id\" : {\n    \
-        \      \"uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \
-        \    \"path\" : \"0000-0001-8607-8906\",\n          \"host\" : \"orcid.org\"\
-        \n        },\n        \"source-name\" : {\n          \"value\" : \"INSPIRE-HEP\"\
-        \n        }\n      },\n      \"title\" : {\n        \"title\" : {\n      \
-        \    \"value\" : \"Some Results Arising from the Study of ORCID push\"\n \
-        \       },\n        \"subtitle\" : null,\n        \"translated-title\" : null\n\
-        \      },\n      \"external-ids\" : {\n        \"external-id\" : [ {\n   \
-        \       \"external-id-type\" : \"other-id\",\n          \"external-id-value\"\
-        \ : \"45\",\n          \"external-id-url\" : {\n            \"value\" : \"\
-        http://inspirehep.net/record/45\"\n          },\n          \"external-id-relationship\"\
-        \ : \"SELF\"\n        }, {\n          \"external-id-type\" : \"doi\",\n  \
-        \        \"external-id-value\" : \"10.1111/test.orcid.push\",\n          \"\
-        external-id-url\" : {\n            \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\
-        \n          },\n          \"external-id-relationship\" : \"SELF\"\n      \
-        \  } ]\n      },\n      \"type\" : \"JOURNAL_ARTICLE\",\n      \"publication-date\"\
-        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/60275458\"\
-        ,\n      \"display-index\" : \"0\"\n    } ]\n  } ],\n  \"path\" : \"/0000-0003-1134-6827/works\"\
-        \n}"
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/orcid+json; qs=2;charset=UTF-8
-      Date:
-      - Tue, 06 Aug 2019 16:18:48 GMT
-      Expires:
-      - '0'
-      Pragma:
-      - no-cache
-      Server:
-      - nginx/1.10.0
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '2175'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
-      \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{45,\n\
-      \    doi = \"10.1111/test.orcid.push\",\n    title = \"Some Results Arising\
-      \ from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>45</common:external-id-value><common:external-id-url>http://inspirehep.net/record/45</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.1111/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.1111/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/45</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
-      \ A.</work:credit-name><work:contributor-attributes><work:contributor-sequence>first</work:contributor-sequence><work:contributor-role>author</work:contributor-role></work:contributor-attributes></work:contributor></work:contributors></work:work>"
-    headers:
-      Accept:
-      - application/orcid+json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '1518'
-      Content-Type:
-      - application/orcid+xml
-    method: POST
-    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work
-  response:
-    body:
-      string: '{"response-code":409,"developer-message":"409 Conflict: You have already
-        added this activity (matched by external identifiers), please see element
-        with put-code 60275458. If you are trying to edit the item, please use PUT
-        instead of POST.","user-message":"There was an error when updating the record.
-        Please try again. If the error persists, please contact INSPIRE-HEP for assistance.","error-code":9021,"more-info":"https://members.orcid.org/api/resources/troubleshooting"}'
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '474'
-      Content-Type:
-      - application/orcid+json; qs=2;charset=UTF-8
-      Date:
-      - Tue, 06 Aug 2019 16:18:49 GMT
-      Expires:
-      - '0'
-      Pragma:
-      - no-cache
-      Server:
-      - nginx/1.10.0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 409
-      message: Conflict
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/orcid+json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-    method: GET
-    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/works
-  response:
-    body:
-      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1565108326114\n  },\n\
-        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1565108326114\n\
-        \    },\n    \"external-ids\" : {\n      \"external-id\" : [ {\n        \"\
-        external-id-type\" : \"other-id\",\n        \"external-id-value\" : \"45\"\
-        ,\n        \"external-id-url\" : {\n          \"value\" : \"http://inspirehep.net/record/45\"\
-        \n        },\n        \"external-id-relationship\" : \"SELF\"\n      }, {\n\
-        \        \"external-id-type\" : \"doi\",\n        \"external-id-value\" :\
-        \ \"10.1111/test.orcid.push\",\n        \"external-id-url\" : {\n        \
-        \  \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\n        },\n\
-        \        \"external-id-relationship\" : \"SELF\"\n      } ]\n    },\n    \"\
-        work-summary\" : [ {\n      \"put-code\" : 60275458,\n      \"created-date\"\
-        \ : {\n        \"value\" : 1565108326114\n      },\n      \"last-modified-date\"\
-        \ : {\n        \"value\" : 1565108326114\n      },\n      \"source\" : {\n\
-        \        \"source-orcid\" : null,\n        \"source-client-id\" : {\n    \
-        \      \"uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \
-        \    \"path\" : \"0000-0001-8607-8906\",\n          \"host\" : \"orcid.org\"\
-        \n        },\n        \"source-name\" : {\n          \"value\" : \"INSPIRE-HEP\"\
-        \n        }\n      },\n      \"title\" : {\n        \"title\" : {\n      \
-        \    \"value\" : \"Some Results Arising from the Study of ORCID push\"\n \
-        \       },\n        \"subtitle\" : null,\n        \"translated-title\" : null\n\
-        \      },\n      \"external-ids\" : {\n        \"external-id\" : [ {\n   \
-        \       \"external-id-type\" : \"other-id\",\n          \"external-id-value\"\
-        \ : \"45\",\n          \"external-id-url\" : {\n            \"value\" : \"\
-        http://inspirehep.net/record/45\"\n          },\n          \"external-id-relationship\"\
-        \ : \"SELF\"\n        }, {\n          \"external-id-type\" : \"doi\",\n  \
-        \        \"external-id-value\" : \"10.1111/test.orcid.push\",\n          \"\
-        external-id-url\" : {\n            \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\
-        \n          },\n          \"external-id-relationship\" : \"SELF\"\n      \
-        \  } ]\n      },\n      \"type\" : \"JOURNAL_ARTICLE\",\n      \"publication-date\"\
-        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/60275458\"\
-        ,\n      \"display-index\" : \"0\"\n    } ]\n  } ],\n  \"path\" : \"/0000-0003-1134-6827/works\"\
-        \n}"
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/orcid+json; qs=2;charset=UTF-8
-      Date:
-      - Tue, 06 Aug 2019 16:18:49 GMT
-      Expires:
-      - '0'
-      Pragma:
-      - no-cache
-      Server:
-      - nginx/1.10.0
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '2175'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\" put-code=\"60275458\"><work:title><common:title>Some\
-      \ Results Arising from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{45,\n\
-      \    doi = \"10.1111/test.orcid.push\",\n    title = \"Some Results Arising\
-      \ from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>45</common:external-id-value><common:external-id-url>http://inspirehep.net/record/45</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.1111/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.1111/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/45</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
-      \ A.</work:credit-name><work:contributor-attributes><work:contributor-sequence>first</work:contributor-sequence><work:contributor-role>author</work:contributor-role></work:contributor-attributes></work:contributor></work:contributors></work:work>"
-    headers:
-      Accept:
-      - application/orcid+json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '1538'
-      Content-Type:
-      - application/orcid+xml
-    method: PUT
-    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/60275458
-  response:
-    body:
-      string: "{\n  \"created-date\" : {\n    \"value\" : 1565108326114\n  },\n  \"\
-        last-modified-date\" : {\n    \"value\" : 1565108326114\n  },\n  \"source\"\
-        \ : {\n    \"source-orcid\" : null,\n    \"source-client-id\" : {\n      \"\
-        uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \"path\" :\
-        \ \"0000-0001-8607-8906\",\n      \"host\" : \"orcid.org\"\n    },\n    \"\
-        source-name\" : {\n      \"value\" : \"INSPIRE-HEP\"\n    }\n  },\n  \"put-code\"\
-        \ : 60275458,\n  \"path\" : null,\n  \"title\" : {\n    \"title\" : {\n  \
-        \    \"value\" : \"Some Results Arising from the Study of ORCID push\"\n \
-        \   },\n    \"subtitle\" : null,\n    \"translated-title\" : null\n  },\n\
-        \  \"journal-title\" : null,\n  \"short-description\" : null,\n  \"citation\"\
-        \ : {\n    \"citation-type\" : \"BIBTEX\",\n    \"citation-value\" : \"@article{45,\\\
-        n    doi = \\\"10.1111/test.orcid.push\\\",\\n    title = \\\"Some Results\
-        \ Arising from the Study of ORCID push\\\"\\n}\\n\"\n  },\n  \"type\" : \"\
-        JOURNAL_ARTICLE\",\n  \"publication-date\" : null,\n  \"external-ids\" : {\n\
-        \    \"external-id\" : [ {\n      \"external-id-type\" : \"other-id\",\n \
-        \     \"external-id-value\" : \"45\",\n      \"external-id-url\" : {\n   \
-        \     \"value\" : \"http://inspirehep.net/record/45\"\n      },\n      \"\
-        external-id-relationship\" : \"SELF\"\n    }, {\n      \"external-id-type\"\
-        \ : \"doi\",\n      \"external-id-value\" : \"10.1111/test.orcid.push\",\n\
-        \      \"external-id-url\" : {\n        \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\
-        \n      },\n      \"external-id-relationship\" : \"SELF\"\n    } ]\n  },\n\
-        \  \"url\" : {\n    \"value\" : \"http://inspirehep.net/record/45\"\n  },\n\
-        \  \"contributors\" : {\n    \"contributor\" : [ {\n      \"contributor-orcid\"\
-        \ : null,\n      \"credit-name\" : {\n        \"value\" : \"Rossoni, A.\"\n\
-        \      },\n      \"contributor-email\" : null,\n      \"contributor-attributes\"\
-        \ : {\n        \"contributor-sequence\" : \"FIRST\",\n        \"contributor-role\"\
-        \ : \"AUTHOR\"\n      }\n    } ]\n  },\n  \"language-code\" : null,\n  \"\
-        country\" : null,\n  \"visibility\" : \"PUBLIC\"\n}"
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/orcid+json; qs=2;charset=UTF-8
-      Date:
-      - Tue, 06 Aug 2019 16:18:50 GMT
-      Expires:
-      - '0'
-      Pragma:
-      - no-cache
-      Server:
-      - nginx/1.10.0
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '1858'
-    status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 version: 1

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherPostNewWork.test_push_new_work_already_existing_putcode_exception.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherPostNewWork.test_push_new_work_already_existing_putcode_exception.yaml
@@ -3,8 +3,8 @@ interactions:
     body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
       http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
       \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{46,\n\
-      \    doi = \"10.1111/test.orcid.push\",\n    title = \"Some Results Arising\
-      \ from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>46</common:external-id-value><common:external-id-url>http://inspirehep.net/record/46</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.1111/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.1111/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/46</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
+      \    author = \"Rossoni, A.\",\n    doi = \"10.1111/test.orcid.push\",\n   \
+      \ title = \"Some Results Arising from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>46</common:external-id-value><common:external-id-url>http://inspirehep.net/record/46</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.1111/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.1111/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/46</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
       \ A.</work:credit-name><work:contributor-attributes><work:contributor-sequence>first</work:contributor-sequence><work:contributor-role>author</work:contributor-role></work:contributor-attributes></work:contributor></work:contributors></work:work>"
     headers:
       Accept:
@@ -14,7 +14,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1518'
+      - '1546'
       Content-Type:
       - application/orcid+xml
     method: POST
@@ -23,7 +23,7 @@ interactions:
     body:
       string: '{"response-code":409,"developer-message":"409 Conflict: You have already
         added this activity (matched by external identifiers), please see element
-        with put-code 60275394. If you are trying to edit the item, please use PUT
+        with put-code 60484140. If you are trying to edit the item, please use PUT
         instead of POST.","user-message":"There was an error when updating the record.
         Please try again. If the error persists, please contact INSPIRE-HEP for assistance.","error-code":9021,"more-info":"https://members.orcid.org/api/resources/troubleshooting"}'
     headers:
@@ -38,7 +38,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Tue, 06 Aug 2019 16:15:08 GMT
+      - Tue, 13 Aug 2019 09:46:30 GMT
       Expires:
       - '0'
       Pragma:
@@ -67,8 +67,8 @@ interactions:
     uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/works
   response:
     body:
-      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1565108102415\n  },\n\
-        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1565108102415\n\
+      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1565689589733\n  },\n\
+        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1565689589733\n\
         \    },\n    \"external-ids\" : {\n      \"external-id\" : [ {\n        \"\
         external-id-type\" : \"other-id\",\n        \"external-id-value\" : \"45\"\
         ,\n        \"external-id-url\" : {\n          \"value\" : \"http://inspirehep.net/record/45\"\
@@ -77,9 +77,9 @@ interactions:
         \ \"10.1111/test.orcid.push\",\n        \"external-id-url\" : {\n        \
         \  \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\n        },\n\
         \        \"external-id-relationship\" : \"SELF\"\n      } ]\n    },\n    \"\
-        work-summary\" : [ {\n      \"put-code\" : 60275394,\n      \"created-date\"\
-        \ : {\n        \"value\" : 1565108102415\n      },\n      \"last-modified-date\"\
-        \ : {\n        \"value\" : 1565108102415\n      },\n      \"source\" : {\n\
+        work-summary\" : [ {\n      \"put-code\" : 60484140,\n      \"created-date\"\
+        \ : {\n        \"value\" : 1565689589733\n      },\n      \"last-modified-date\"\
+        \ : {\n        \"value\" : 1565689589733\n      },\n      \"source\" : {\n\
         \        \"source-orcid\" : null,\n        \"source-client-id\" : {\n    \
         \      \"uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \
         \    \"path\" : \"0000-0001-8607-8906\",\n          \"host\" : \"orcid.org\"\
@@ -96,7 +96,7 @@ interactions:
         external-id-url\" : {\n            \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\
         \n          },\n          \"external-id-relationship\" : \"SELF\"\n      \
         \  } ]\n      },\n      \"type\" : \"JOURNAL_ARTICLE\",\n      \"publication-date\"\
-        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/60275394\"\
+        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/60484140\"\
         ,\n      \"display-index\" : \"0\"\n    } ]\n  } ],\n  \"path\" : \"/0000-0003-1134-6827/works\"\
         \n}"
     headers:
@@ -109,7 +109,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Tue, 06 Aug 2019 16:15:09 GMT
+      - Tue, 13 Aug 2019 09:46:31 GMT
       Expires:
       - '0'
       Pragma:
@@ -133,8 +133,8 @@ interactions:
     body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
       http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
       \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{46,\n\
-      \    doi = \"10.1111/test.orcid.push\",\n    title = \"Some Results Arising\
-      \ from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>46</common:external-id-value><common:external-id-url>http://inspirehep.net/record/46</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.1111/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.1111/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/46</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
+      \    author = \"Rossoni, A.\",\n    doi = \"10.1111/test.orcid.push\",\n   \
+      \ title = \"Some Results Arising from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>46</common:external-id-value><common:external-id-url>http://inspirehep.net/record/46</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.1111/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.1111/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/46</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
       \ A.</work:credit-name><work:contributor-attributes><work:contributor-sequence>first</work:contributor-sequence><work:contributor-role>author</work:contributor-role></work:contributor-attributes></work:contributor></work:contributors></work:work>"
     headers:
       Accept:
@@ -144,7 +144,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1518'
+      - '1546'
       Content-Type:
       - application/orcid+xml
     method: POST
@@ -153,7 +153,7 @@ interactions:
     body:
       string: '{"response-code":409,"developer-message":"409 Conflict: You have already
         added this activity (matched by external identifiers), please see element
-        with put-code 60275394. If you are trying to edit the item, please use PUT
+        with put-code 60484140. If you are trying to edit the item, please use PUT
         instead of POST.","user-message":"There was an error when updating the record.
         Please try again. If the error persists, please contact INSPIRE-HEP for assistance.","error-code":9021,"more-info":"https://members.orcid.org/api/resources/troubleshooting"}'
     headers:
@@ -168,7 +168,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Tue, 06 Aug 2019 16:15:10 GMT
+      - Tue, 13 Aug 2019 09:46:32 GMT
       Expires:
       - '0'
       Pragma:
@@ -197,8 +197,8 @@ interactions:
     uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/works
   response:
     body:
-      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1565108102415\n  },\n\
-        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1565108102415\n\
+      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1565689589733\n  },\n\
+        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1565689589733\n\
         \    },\n    \"external-ids\" : {\n      \"external-id\" : [ {\n        \"\
         external-id-type\" : \"other-id\",\n        \"external-id-value\" : \"45\"\
         ,\n        \"external-id-url\" : {\n          \"value\" : \"http://inspirehep.net/record/45\"\
@@ -207,9 +207,9 @@ interactions:
         \ \"10.1111/test.orcid.push\",\n        \"external-id-url\" : {\n        \
         \  \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\n        },\n\
         \        \"external-id-relationship\" : \"SELF\"\n      } ]\n    },\n    \"\
-        work-summary\" : [ {\n      \"put-code\" : 60275394,\n      \"created-date\"\
-        \ : {\n        \"value\" : 1565108102415\n      },\n      \"last-modified-date\"\
-        \ : {\n        \"value\" : 1565108102415\n      },\n      \"source\" : {\n\
+        work-summary\" : [ {\n      \"put-code\" : 60484140,\n      \"created-date\"\
+        \ : {\n        \"value\" : 1565689589733\n      },\n      \"last-modified-date\"\
+        \ : {\n        \"value\" : 1565689589733\n      },\n      \"source\" : {\n\
         \        \"source-orcid\" : null,\n        \"source-client-id\" : {\n    \
         \      \"uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \
         \    \"path\" : \"0000-0001-8607-8906\",\n          \"host\" : \"orcid.org\"\
@@ -226,7 +226,7 @@ interactions:
         external-id-url\" : {\n            \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\
         \n          },\n          \"external-id-relationship\" : \"SELF\"\n      \
         \  } ]\n      },\n      \"type\" : \"JOURNAL_ARTICLE\",\n      \"publication-date\"\
-        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/60275394\"\
+        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/60484140\"\
         ,\n      \"display-index\" : \"0\"\n    } ]\n  } ],\n  \"path\" : \"/0000-0003-1134-6827/works\"\
         \n}"
     headers:
@@ -239,7 +239,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Tue, 06 Aug 2019 16:15:11 GMT
+      - Tue, 13 Aug 2019 09:46:32 GMT
       Expires:
       - '0'
       Pragma:

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherPostNewWork.test_push_new_work_already_existing_with_recids.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherPostNewWork.test_push_new_work_already_existing_with_recids.yaml
@@ -52,4 +52,57 @@ interactions:
     status:
       code: 201
       message: Created
+- request:
+    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
+      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
+      \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{45,\n\
+      \    author = \"Rossoni, A.\",\n    doi = \"10.1111/test.orcid.push\",\n   \
+      \ title = \"Some Results Arising from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>45</common:external-id-value><common:external-id-url>http://inspirehep.net/record/45</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.1111/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.1111/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/45</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
+      \ A.</work:credit-name><work:contributor-attributes><work:contributor-sequence>first</work:contributor-sequence><work:contributor-role>author</work:contributor-role></work:contributor-attributes></work:contributor></work:contributors></work:work>"
+    headers:
+      Accept:
+      - application/orcid+json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1546'
+      Content-Type:
+      - application/orcid+xml
+    method: POST
+    uri: https://api.orcid.org/v2.0/0000-0001-8627-769X/work
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/orcid+json; qs=2;charset=UTF-8
+      Date:
+      - Wed, 07 Aug 2019 16:03:55 GMT
+      Expires:
+      - '0'
+      Location:
+      - http://api.orcid.org/orcid-api-web/v2.0/0000-0001-8627-769X/work/60314412
+      Pragma:
+      - no-cache
+      Server:
+      - nginx/1.10.0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
 version: 1

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherPostNewWork.test_push_new_work_happy_flow.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherPostNewWork.test_push_new_work_happy_flow.yaml
@@ -31,8 +31,6 @@ interactions:
       - no-cache
       Server:
       - nginx/1.10.0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -76,8 +74,6 @@ interactions:
       - no-cache
       Server:
       - nginx/1.10.0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -129,6 +125,59 @@ interactions:
       - '0'
       Location:
       - http://api.orcid.org/orcid-api-web/v2.0/0000-0003-1134-6827/work/60275458
+      Pragma:
+      - no-cache
+      Server:
+      - nginx/1.10.0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
+      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
+      \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{45,\n\
+      \    author = \"Rossoni, A.\",\n    doi = \"10.1111/test.orcid.push\",\n   \
+      \ title = \"Some Results Arising from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>45</common:external-id-value><common:external-id-url>http://inspirehep.net/record/45</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.1111/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.1111/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/45</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
+      \ A.</work:credit-name><work:contributor-attributes><work:contributor-sequence>first</work:contributor-sequence><work:contributor-role>author</work:contributor-role></work:contributor-attributes></work:contributor></work:contributors></work:work>"
+    headers:
+      Accept:
+      - application/orcid+json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1546'
+      Content-Type:
+      - application/orcid+xml
+    method: POST
+    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/orcid+json; qs=2;charset=UTF-8
+      Date:
+      - Wed, 07 Aug 2019 16:03:47 GMT
+      Expires:
+      - '0'
+      Location:
+      - http://api.orcid.org/orcid-api-web/v2.0/0000-0003-1134-6827/work/60314409
       Pragma:
       - no-cache
       Server:

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherPostNewWork.test_push_new_work_invalid_data_orcid.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherPostNewWork.test_push_new_work_invalid_data_orcid.yaml
@@ -54,4 +54,59 @@ interactions:
     status:
       code: 404
       message: Not Found
+- request:
+    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
+      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
+      \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{45,\n\
+      \    author = \"Rossoni, A.\",\n    doi = \"10.1111/test.orcid.push\",\n   \
+      \ title = \"Some Results Arising from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>45</common:external-id-value><common:external-id-url>http://inspirehep.net/record/45</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.1111/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.1111/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/45</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
+      \ A.</work:credit-name><work:contributor-attributes><work:contributor-sequence>first</work:contributor-sequence><work:contributor-role>author</work:contributor-role></work:contributor-attributes></work:contributor></work:contributors></work:work>"
+    headers:
+      Accept:
+      - application/orcid+json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1546'
+      Content-Type:
+      - application/orcid+xml
+    method: POST
+    uri: https://api.orcid.org/v2.0/0000-0002-0000-XXXX/work
+  response:
+    body:
+      string: '{"response-code":404,"developer-message":"404 Not Found: The resource
+        was not found. Full validation error: ORCID iD 0000-0002-0000-XXXX not found","user-message":"The
+        resource was not found.","error-code":9016,"more-info":"https://members.orcid.org/api/resources/troubleshooting"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/orcid+json; qs=2;charset=UTF-8
+      Date:
+      - Wed, 07 Aug 2019 16:03:48 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - nginx/1.10.0
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '281'
+    status:
+      code: 404
+      message: Not Found
 version: 1

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherPostNewWork.test_push_new_work_invalid_data_token.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherPostNewWork.test_push_new_work_invalid_data_token.yaml
@@ -56,4 +56,61 @@ interactions:
     status:
       code: 401
       message: Unauthorized
+- request:
+    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
+      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
+      \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{45,\n\
+      \    author = \"Rossoni, A.\",\n    doi = \"10.1111/test.orcid.push\",\n   \
+      \ title = \"Some Results Arising from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>45</common:external-id-value><common:external-id-url>http://inspirehep.net/record/45</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.1111/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.1111/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/45</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
+      \ A.</work:credit-name><work:contributor-attributes><work:contributor-sequence>first</work:contributor-sequence><work:contributor-role>author</work:contributor-role></work:contributor-attributes></work:contributor></work:contributors></work:work>"
+    headers:
+      Accept:
+      - application/orcid+json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1546'
+      Content-Type:
+      - application/orcid+xml
+    method: POST
+    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work
+  response:
+    body:
+      string: "{\n  \"error\" : \"invalid_token\",\n  \"error_description\" : \"Invalid\
+        \ access token: tokeninvalid\"\n}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/orcid+json;charset=UTF-8
+      Date:
+      - Wed, 07 Aug 2019 16:03:49 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      - no-cache
+      Server:
+      - nginx/1.10.0
+      Transfer-Encoding:
+      - chunked
+      WWW-Authenticate:
+      - 'Bearer realm="ORCID T2 API", error="invalid_token", error_description="Invalid
+        access token: tokeninvalid"'
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 401
+      message: Unauthorized
 version: 1

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherPutUpdatedWork.test_push_updated_work_happy_flow.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherPutUpdatedWork.test_push_updated_work_happy_flow.yaml
@@ -1,95 +1,5 @@
 interactions:
 - request:
-    body: null
-    headers:
-      Accept:
-      - application/orcid+json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-    method: GET
-    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/works
-  response:
-    body:
-      string: "{\n  \"last-modified-date\" : null,\n  \"group\" : [ ],\n  \"path\"\
-        \ : \"/0000-0003-1134-6827/works\"\n}"
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/orcid+json; qs=2;charset=UTF-8
-      Date:
-      - Tue, 06 Aug 2019 16:15:14 GMT
-      Expires:
-      - '0'
-      Pragma:
-      - no-cache
-      Server:
-      - nginx/1.10.0
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '91'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/orcid+json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-    method: GET
-    uri: https://api.orcid.org/v2.0/0000-0001-8627-769X/works
-  response:
-    body:
-      string: "{\n  \"last-modified-date\" : null,\n  \"group\" : [ ],\n  \"path\"\
-        \ : \"/0000-0001-8627-769X/works\"\n}"
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/orcid+json; qs=2;charset=UTF-8
-      Date:
-      - Tue, 06 Aug 2019 16:15:14 GMT
-      Expires:
-      - '0'
-      Pragma:
-      - no-cache
-      Server:
-      - nginx/1.10.0
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-XSS-Protection:
-      - 1; mode=block
-      content-length:
-      - '91'
-    status:
-      code: 200
-      message: OK
-- request:
     body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
       http://www.orcid.org/ns/work\">\n    <work:title>\n        <common:title>Some\
       \ Results Arising from the Study of ORCID push</common:title>\n    </work:title>\n\
@@ -137,11 +47,11 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Tue, 06 Aug 2019 16:15:15 GMT
+      - Tue, 13 Aug 2019 10:01:28 GMT
       Expires:
       - '0'
       Location:
-      - http://api.orcid.org/orcid-api-web/v2.0/0000-0003-1134-6827/work/60275397
+      - http://api.orcid.org/orcid-api-web/v2.0/0000-0003-1134-6827/work/60484640
       Pragma:
       - no-cache
       Server:
@@ -157,10 +67,10 @@ interactions:
       message: Created
 - request:
     body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\" put-code=\"60275397\"><work:title><common:title>Some\
+      http://www.orcid.org/ns/work\" put-code=\"60484640\"><work:title><common:title>Some\
       \ Results Arising from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{999,\n\
-      \    doi = \"10.9999/test.orcid.push\",\n    title = \"Some Results Arising\
-      \ from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>999</common:external-id-value><common:external-id-url>http://inspirehep.net/record/999</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.9999/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.9999/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/999</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
+      \    author = \"Rossoni, A.\",\n    doi = \"10.9999/test.orcid.push\",\n   \
+      \ title = \"Some Results Arising from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>999</common:external-id-value><common:external-id-url>http://inspirehep.net/record/999</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.9999/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.9999/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/999</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
       \ A.</work:credit-name><work:contributor-attributes><work:contributor-sequence>first</work:contributor-sequence><work:contributor-role>author</work:contributor-role></work:contributor-attributes></work:contributor></work:contributors></work:work>"
     headers:
       Accept:
@@ -170,31 +80,31 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1542'
+      - '1570'
       Content-Type:
       - application/orcid+xml
     method: PUT
-    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/60275397
+    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/60484640
   response:
     body:
-      string: "{\n  \"created-date\" : {\n    \"value\" : 1565108115166\n  },\n  \"\
-        last-modified-date\" : {\n    \"value\" : 1565108115770\n  },\n  \"source\"\
+      string: "{\n  \"created-date\" : {\n    \"value\" : 1565690488089\n  },\n  \"\
+        last-modified-date\" : {\n    \"value\" : 1565690488703\n  },\n  \"source\"\
         \ : {\n    \"source-orcid\" : null,\n    \"source-client-id\" : {\n      \"\
         uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \"path\" :\
         \ \"0000-0001-8607-8906\",\n      \"host\" : \"orcid.org\"\n    },\n    \"\
         source-name\" : {\n      \"value\" : \"INSPIRE-HEP\"\n    }\n  },\n  \"put-code\"\
-        \ : 60275397,\n  \"path\" : null,\n  \"title\" : {\n    \"title\" : {\n  \
+        \ : 60484640,\n  \"path\" : null,\n  \"title\" : {\n    \"title\" : {\n  \
         \    \"value\" : \"Some Results Arising from the Study of ORCID push\"\n \
         \   },\n    \"subtitle\" : null,\n    \"translated-title\" : null\n  },\n\
         \  \"journal-title\" : null,\n  \"short-description\" : null,\n  \"citation\"\
         \ : {\n    \"citation-type\" : \"BIBTEX\",\n    \"citation-value\" : \"@article{999,\\\
-        n    doi = \\\"10.9999/test.orcid.push\\\",\\n    title = \\\"Some Results\
-        \ Arising from the Study of ORCID push\\\"\\n}\\n\"\n  },\n  \"type\" : \"\
-        JOURNAL_ARTICLE\",\n  \"publication-date\" : null,\n  \"external-ids\" : {\n\
-        \    \"external-id\" : [ {\n      \"external-id-type\" : \"other-id\",\n \
-        \     \"external-id-value\" : \"999\",\n      \"external-id-url\" : {\n  \
-        \      \"value\" : \"http://inspirehep.net/record/999\"\n      },\n      \"\
-        external-id-relationship\" : \"SELF\"\n    }, {\n      \"external-id-type\"\
+        n    author = \\\"Rossoni, A.\\\",\\n    doi = \\\"10.9999/test.orcid.push\\\
+        \",\\n    title = \\\"Some Results Arising from the Study of ORCID push\\\"\
+        \\n}\\n\"\n  },\n  \"type\" : \"JOURNAL_ARTICLE\",\n  \"publication-date\"\
+        \ : null,\n  \"external-ids\" : {\n    \"external-id\" : [ {\n      \"external-id-type\"\
+        \ : \"other-id\",\n      \"external-id-value\" : \"999\",\n      \"external-id-url\"\
+        \ : {\n        \"value\" : \"http://inspirehep.net/record/999\"\n      },\n\
+        \      \"external-id-relationship\" : \"SELF\"\n    }, {\n      \"external-id-type\"\
         \ : \"doi\",\n      \"external-id-value\" : \"10.9999/test.orcid.push\",\n\
         \      \"external-id-url\" : {\n        \"value\" : \"http://dx.doi.org/10.9999/test.orcid.push\"\
         \n      },\n      \"external-id-relationship\" : \"SELF\"\n    } ]\n  },\n\
@@ -215,7 +125,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Tue, 06 Aug 2019 16:15:15 GMT
+      - Tue, 13 Aug 2019 10:01:28 GMT
       Expires:
       - '0'
       Pragma:
@@ -231,7 +141,7 @@ interactions:
       X-XSS-Protection:
       - 1; mode=block
       content-length:
-      - '1862'
+      - '1893'
     status:
       code: 200
       message: OK

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherPutUpdatedWork.test_push_updated_work_invalid_data_orcid.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherPutUpdatedWork.test_push_updated_work_invalid_data_orcid.yaml
@@ -61,8 +61,6 @@ interactions:
       - no-cache
       Server:
       - nginx/1.10.0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -150,8 +148,6 @@ interactions:
       - no-cache
       Server:
       - nginx/1.10.0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -265,6 +261,63 @@ interactions:
       - application/orcid+json;charset=UTF-8
       Date:
       - Tue, 06 Aug 2019 16:15:18 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      - no-cache
+      Server:
+      - nginx/1.10.0
+      Transfer-Encoding:
+      - chunked
+      WWW-Authenticate:
+      - 'Bearer realm="ORCID T2 API", error="invalid_token", error_description="Invalid
+        access token: tokeninvalid"'
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 401
+      message: Unauthorized
+- request:
+    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
+      http://www.orcid.org/ns/work\" put-code=\"60275400\"><work:title><common:title>Some\
+      \ Results Arising from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{999,\n\
+      \    author = \"Rossoni, A.\",\n    doi = \"10.9999/test.orcid.push\",\n   \
+      \ title = \"Some Results Arising from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>999</common:external-id-value><common:external-id-url>http://inspirehep.net/record/999</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.9999/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.9999/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/999</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
+      \ A.</work:credit-name><work:contributor-attributes><work:contributor-sequence>first</work:contributor-sequence><work:contributor-role>author</work:contributor-role></work:contributor-attributes></work:contributor></work:contributors></work:work>"
+    headers:
+      Accept:
+      - application/orcid+json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1570'
+      Content-Type:
+      - application/orcid+xml
+    method: PUT
+    uri: https://api.orcid.org/v2.0/0000-0002-0000-XXXX/work/60275400
+  response:
+    body:
+      string: "{\n  \"error\" : \"invalid_token\",\n  \"error_description\" : \"Invalid\
+        \ access token: tokeninvalid\"\n}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/orcid+json;charset=UTF-8
+      Date:
+      - Wed, 07 Aug 2019 16:04:09 GMT
       Expires:
       - '0'
       Pragma:

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherPutUpdatedWork.test_push_updated_work_invalid_data_putcode.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherPutUpdatedWork.test_push_updated_work_invalid_data_putcode.yaml
@@ -61,8 +61,6 @@ interactions:
       - no-cache
       Server:
       - nginx/1.10.0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -150,8 +148,6 @@ interactions:
       - no-cache
       Server:
       - nginx/1.10.0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -269,6 +265,59 @@ interactions:
       - '0'
       Location:
       - http://api.orcid.org/orcid-api-web/v2.0/0000-0001-8627-769X/work/60275405
+      Pragma:
+      - no-cache
+      Server:
+      - nginx/1.10.0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
+      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
+      \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{999,\n\
+      \    author = \"Rossoni, A.\",\n    doi = \"10.9999/test.orcid.push\",\n   \
+      \ title = \"Some Results Arising from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>999</common:external-id-value><common:external-id-url>http://inspirehep.net/record/999</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.9999/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.9999/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/999</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
+      \ A.</work:credit-name><work:contributor-attributes><work:contributor-sequence>first</work:contributor-sequence><work:contributor-role>author</work:contributor-role></work:contributor-attributes></work:contributor></work:contributors></work:work>"
+    headers:
+      Accept:
+      - application/orcid+json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1550'
+      Content-Type:
+      - application/orcid+xml
+    method: POST
+    uri: https://api.orcid.org/v2.0/0000-0001-8627-769X/work
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/orcid+json; qs=2;charset=UTF-8
+      Date:
+      - Wed, 07 Aug 2019 16:04:17 GMT
+      Expires:
+      - '0'
+      Location:
+      - http://api.orcid.org/orcid-api-web/v2.0/0000-0001-8627-769X/work/60314416
       Pragma:
       - no-cache
       Server:

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherPutUpdatedWork.test_push_updated_work_invalid_data_token.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherPutUpdatedWork.test_push_updated_work_invalid_data_token.yaml
@@ -61,8 +61,6 @@ interactions:
       - no-cache
       Server:
       - nginx/1.10.0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -150,8 +148,6 @@ interactions:
       - no-cache
       Server:
       - nginx/1.10.0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -265,6 +261,63 @@ interactions:
       - application/orcid+json;charset=UTF-8
       Date:
       - Tue, 06 Aug 2019 16:15:21 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      - no-cache
+      Server:
+      - nginx/1.10.0
+      Transfer-Encoding:
+      - chunked
+      WWW-Authenticate:
+      - 'Bearer realm="ORCID T2 API", error="invalid_token", error_description="Invalid
+        access token: tokeninvalid"'
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 401
+      message: Unauthorized
+- request:
+    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
+      http://www.orcid.org/ns/work\" put-code=\"60275401\"><work:title><common:title>Some\
+      \ Results Arising from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{999,\n\
+      \    author = \"Rossoni, A.\",\n    doi = \"10.9999/test.orcid.push\",\n   \
+      \ title = \"Some Results Arising from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>999</common:external-id-value><common:external-id-url>http://inspirehep.net/record/999</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.9999/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.9999/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/999</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
+      \ A.</work:credit-name><work:contributor-attributes><work:contributor-sequence>first</work:contributor-sequence><work:contributor-role>author</work:contributor-role></work:contributor-attributes></work:contributor></work:contributors></work:work>"
+    headers:
+      Accept:
+      - application/orcid+json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1570'
+      Content-Type:
+      - application/orcid+xml
+    method: PUT
+    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/60275401
+  response:
+    body:
+      string: "{\n  \"error\" : \"invalid_token\",\n  \"error_description\" : \"Invalid\
+        \ access token: tokeninvalid\"\n}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/orcid+json;charset=UTF-8
+      Date:
+      - Wed, 07 Aug 2019 16:04:13 GMT
       Expires:
       - '0'
       Pragma:

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherRecordDBVersion.test_happy_flow.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherRecordDBVersion.test_happy_flow.yaml
@@ -52,4 +52,57 @@ interactions:
     status:
       code: 201
       message: Created
+- request:
+    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
+      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
+      \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{45,\n\
+      \    author = \"Rossoni, A.\",\n    doi = \"10.1100/test.orcid.push\",\n   \
+      \ title = \"Some Results Arising from the Study of ORCID push\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>45</common:external-id-value><common:external-id-url>http://inspirehep.net/record/45</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.1100/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.1100/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/45</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
+      \ A.</work:credit-name><work:contributor-attributes><work:contributor-sequence>first</work:contributor-sequence><work:contributor-role>author</work:contributor-role></work:contributor-attributes></work:contributor></work:contributors></work:work>"
+    headers:
+      Accept:
+      - application/orcid+json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1546'
+      Content-Type:
+      - application/orcid+xml
+    method: POST
+    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/orcid+json; qs=2;charset=UTF-8
+      Date:
+      - Wed, 07 Aug 2019 16:04:53 GMT
+      Expires:
+      - '0'
+      Location:
+      - http://api.orcid.org/orcid-api-web/v2.0/0000-0003-1134-6827/work/60314425
+      Pragma:
+      - no-cache
+      Server:
+      - nginx/1.10.0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
 version: 1

--- a/backend/tests/integration/orcid/conftest.py
+++ b/backend/tests/integration/orcid/conftest.py
@@ -24,7 +24,7 @@
 import pytest
 
 IS_VCR_ENABLED = True
-IS_VCR_EPISODE_OR_ERROR = True  # False to record new cassettes.
+IS_VCR_EPISODE_OR_ERROR = False  # False to record new cassettes.
 
 
 @pytest.fixture(scope="session")

--- a/backend/tests/integration/orcid/test_orcid_domain_models.py
+++ b/backend/tests/integration/orcid/test_orcid_domain_models.py
@@ -273,7 +273,6 @@ class TestOrcidPusherPutUpdatedWork(TestOrcidPusherBase):
         self.recid = factory.record_metadata.json["control_number"]
         self.inspire_record = factory.inspire_record
 
-        self.delete_all_work()
         self.putcode = self.add_work("test_orcid_domain_models_TestOrcidPusher.xml")
         self.cache.write_work_putcode(self.putcode)
 

--- a/backend/tests/integration/records/serializers/test_bibtex.py
+++ b/backend/tests/integration/records/serializers/test_bibtex.py
@@ -29,6 +29,36 @@ def test_bibtex(api_client, db, es, create_record_factory):
     assert expected_result == response_data
 
 
+def test_bibtex_returns_all_expected_fields(api_client, db, es, create_record_factory):
+    headers = {"Accept": "application/x-bibtex"}
+    data = {
+        "_collections": ["Literature"],
+        "authors": [
+            {"full_name": "Smith, John", "inspire_roles": ["editor"]},
+            {"full_name": "Rossi, Maria", "inspire_roles": ["author"]},
+        ],
+        "control_number": 637275237,
+        "titles": [{"title": "This is a title."}],
+        "document_type": ["conference paper"],
+        "texkeys": ["Smith:2019abc"],
+    }
+    record = create_record_factory(
+        "lit", data=data, with_indexing=True, with_validation=True
+    )
+    record_control_number = record.json["control_number"]
+
+    expected_status_code = 200
+    expected_result = '@inproceedings{Smith:2019abc,\n    author = "Rossi, Maria",\n    editor = "Smith, John",\n    booktitle = "This is a title.",\n    title = "This is a title."\n}\n'
+    response = api_client.get(
+        "/literature/{}".format(record_control_number), headers=headers
+    )
+
+    response_status_code = response.status_code
+    response_data = response.get_data(as_text=True)
+    assert expected_status_code == response_status_code
+    assert expected_result == response_data
+
+
 def test_bibtex_search(api_client, db, es, create_record_factory):
     headers = {"Accept": "application/x-bibtex"}
     data_1 = {"control_number": 637275237, "titles": [{"title": "This is a title."}]}

--- a/backend/tests/unit/records/marshmallow/literature/test_bibtex_schema.py
+++ b/backend/tests/unit/records/marshmallow/literature/test_bibtex_schema.py
@@ -12,29 +12,35 @@ from inspire_schemas.api import load_schema, validate
 from inspirehep.records.marshmallow.literature.bibtex import BibTexCommonSchema
 
 
-def test_get_author_by_role():
+def test_get_authors_with_role_author():
     record = {
+        "document_type": ["article"],
         "authors": [
             {"full_name": "Kiritsis, Elias", "inspire_roles": ["editor"]},
             {"full_name": "Nitti, Francesco", "inspire_roles": ["author"]},
             {"full_name": "Pimenta, Leandro Silva"},
-        ]
+        ],
     }
     expected = ["Nitti, Francesco", "Pimenta, Leandro Silva"]
-    result = BibTexCommonSchema.get_authors_with_role(record["authors"], "author")
-    assert expected == result
+    schema = BibTexCommonSchema()
+    result = schema.dump(record).data
+
+    assert expected == result["authors_with_role_author"]
 
 
-def test_get_editor_by_role():
+def test_get_authors_with_role_editor():
     record = {
+        "document_type": ["article"],
         "authors": [
             {"full_name": "Kiritsis, Elias", "inspire_roles": ["editor"]},
             {"full_name": "Nitti, Francesco", "inspire_roles": ["author"]},
-        ]
+        ],
     }
     expected = ["Kiritsis, Elias"]
-    result = BibTexCommonSchema.get_authors_with_role(record.get("authors"), "editor")
-    assert expected == result
+    schema = BibTexCommonSchema()
+    result = schema.dump(record).data
+
+    assert expected == result["authors_with_role_editor"]
 
 
 def test_get_collaboration():


### PR DESCRIPTION
* Authors and editors were not displayed in the BibTeX output
  because the serializer was trying to read `authors` from the schema output,
  where it was not present. This logic has now been moved to the
  `BibTexCommonSchema`, so it can access the required data.
* INSPIR-2591

Signed-off-by: Micha Moskovic <michamos@gmail.com>