### PR TITLE
Use tilt for local dev.

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,5 @@
+docker_build('inspirehep/hep', '.')
+docker_build('inspirehep/ui', 'ui/')
+
+k8s_yaml(local('kustomize build ssh://git@gitlab.cern.ch:7999/inspire/kubernetes.git//inspire/overlays/local'))
+k8s_resource('traefik', port_forwards=['8443:443', '8080:80', '8081:8080'])


### PR DESCRIPTION
The current version of skaffold doesn't allow use to run kustomize v3 or on remote repositories.
Tilt is using the same code but is more flexible and let us run kustomize in a shell.