### PR TITLE
migrator: make pid_types blacklistable

### DIFF
--- a/backend/inspirehep/migrator/config.py
+++ b/backend/inspirehep/migrator/config.py
@@ -10,3 +10,4 @@
 #: Special redis for continuous migration and ORCID token migration
 MIGRATION_REDIS_URL = None
 MIGRATION_POLLING_SLEEP = 1
+MIGRATION_PID_TYPE_BLACKLIST = []

--- a/backend/tests/unit/pidstore/api/test_pidstore_base.py
+++ b/backend/tests/unit/pidstore/api/test_pidstore_base.py
@@ -46,6 +46,8 @@ def test_get_pid_type_from_endpoint(
     "schema,expected",
     [
         ("http://localhost:5000/schemas/record/hep.json", "lit"),
+        ("http://localhost:5000/schemas/record/jobs.json", "job"),
+        ("jobs.json", "job"),
         ("http://localhost:5000/schemas/record/jes.json", None),
         ("jes.json", None),
         (None, None),
@@ -57,7 +59,7 @@ def test_get_pid_type_from_endpoint(
 )
 @patch(
     "inspirehep.pidstore.api.PidStoreBase._get_config_pid_types_to_schema",
-    return_value={"hep": "lit"},
+    return_value={"hep": "lit", "jobs": "job"},
 )
 def test_get_pid_type_from_schema(
     mock_get_config_pid_types_to_endpointsck_get,


### PR DESCRIPTION
* Now a pid_type for continous migration can be blacklisted

* INSPIR-2666