### PR TITLE
ui: display job contacts linked to author page

### DIFF
--- a/ui/src/common/__tests__/utils.test.js
+++ b/ui/src/common/__tests__/utils.test.js
@@ -17,6 +17,7 @@ import pluralizeUnlessSingle, {
   getFromObjectOrImmutableMap,
   pickEvenlyDistributedElements,
   removeProtocolAndWwwFromUrl,
+  getRecordIdFromRef,
 } from '../utils';
 
 describe('utils', () => {
@@ -448,6 +449,20 @@ describe('utils', () => {
       const url = 'home.cern/about';
       const expected = 'home.cern/about';
       const result = removeProtocolAndWwwFromUrl(url);
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('getRecordIdFromRef', () => {
+    it('returns null string if no $ref is passed', () => {
+      const result = getRecordIdFromRef(undefined);
+      expect(result).toEqual(null);
+    });
+
+    it('returns recid', () => {
+      const $ref = 'https://inspirehep.net/api/authors/12345';
+      const expected = '12345';
+      const result = getRecordIdFromRef($ref);
       expect(result).toEqual(expected);
     });
   });

--- a/ui/src/common/utils.js
+++ b/ui/src/common/utils.js
@@ -174,3 +174,12 @@ const protocolAndWwwRegexp = new RegExp('^(?:(https?:)?//)?(?:www.)?', 'i');
 export function removeProtocolAndWwwFromUrl(url) {
   return url.replace(protocolAndWwwRegexp, '');
 }
+
+export function getRecordIdFromRef($ref) {
+  if ($ref == null) {
+    return null;
+  }
+
+  const parts = $ref.split('/');
+  return parts[parts.length - 1];
+}

--- a/ui/src/jobs/components/Contact.jsx
+++ b/ui/src/jobs/components/Contact.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { List } from 'immutable';
 import ContactList from './ContactList';
 
+// TODO: Rename it to LabeledContactList or remove to use `InlineList.label`
 class Contact extends Component {
   render() {
     const { contactDetails } = this.props;

--- a/ui/src/jobs/components/ContactList.jsx
+++ b/ui/src/jobs/components/ContactList.jsx
@@ -1,22 +1,41 @@
 import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { List } from 'immutable';
 import ExternalLink from '../../common/components/ExternalLink';
 import InlineList from '../../common/components/InlineList';
+import { getRecordIdFromRef } from '../../common/utils';
+import { AUTHORS } from '../../common/routes';
 
 class ContactList extends Component {
+  static renderContactName(contact) {
+    const name = contact.get('name');
+    const contactRecordId = getRecordIdFromRef(
+      contact.getIn(['record', '$ref'])
+    );
+    return contactRecordId ? (
+      <Link to={`${AUTHORS}/${contactRecordId}`}>{name}</Link>
+    ) : (
+      <span>{name}</span>
+    );
+  }
+
   static renderContact(contact) {
     const email = contact.get('email');
     const name = contact.get('name');
     const renderParanthesis = name && email;
     return (
       <>
-        {name && <span>{name}</span>}
+        {name && ContactList.renderContactName(contact)}
         {renderParanthesis && ' ('}
         {email && <ExternalLink href={`mailto:${email}`}>{email}</ExternalLink>}
         {renderParanthesis && ')'}
       </>
     );
+  }
+
+  static contactEmailOrName(contact) {
+    return contact.get('email') || contact.get('name');
   }
 
   render() {
@@ -27,7 +46,7 @@ class ContactList extends Component {
         items={contacts}
         renderItem={ContactList.renderContact}
         wrapperClassName={wrapperClassName}
-        extractKey={contact => contact.get('email') || contact.get('name')}
+        extractKey={ContactList.contactEmailOrName}
       />
     );
   }

--- a/ui/src/jobs/components/__tests__/ContactList.test.jsx
+++ b/ui/src/jobs/components/__tests__/ContactList.test.jsx
@@ -18,6 +18,18 @@ describe('ContactList', () => {
     const wrapper = shallow(<ContactList contacts={contactDetails} />);
     expect(wrapper.dive()).toMatchSnapshot();
   });
+
+  it('renders with contacts with record and name', () => {
+    const contactDetails = fromJS([
+      {
+        name: 'John',
+        record: { $ref: 'http://inspirehep.net/api/authors/12345' },
+      },
+    ]);
+    const wrapper = shallow(<ContactList contacts={contactDetails} />);
+    expect(wrapper.dive()).toMatchSnapshot();
+  });
+
   it('renders with contacts with only email or name', () => {
     const contactDetails = fromJS([
       {

--- a/ui/src/jobs/components/__tests__/__snapshots__/ContactList.test.jsx.snap
+++ b/ui/src/jobs/components/__tests__/__snapshots__/ContactList.test.jsx.snap
@@ -65,3 +65,24 @@ exports[`ContactList renders with contacts with only email or name 1`] = `
   </ul>
 </div>
 `;
+
+exports[`ContactList renders with contacts with record and name 1`] = `
+<div
+  className="__InlineList__"
+>
+  <ul
+    className="separate-items-with-comma"
+  >
+    <li
+      key="John"
+    >
+      <Link
+        replace={false}
+        to="/authors/12345"
+      >
+        John
+      </Link>
+    </li>
+  </ul>
+</div>
+`;

--- a/ui/src/submissions/jobs/components/JobForm.jsx
+++ b/ui/src/submissions/jobs/components/JobForm.jsx
@@ -32,6 +32,10 @@ class JobForm extends Component {
     return suggestion._source.legacy_name;
   }
 
+  static getSuggestionSourceNameValue(suggestion) {
+    return suggestion._source.name.value;
+  }
+
   isPostDocSubmission() {
     const { values } = this.props;
 
@@ -149,9 +153,15 @@ class JobForm extends Component {
               <Col span={11}>
                 <Field
                   onlyChild
+                  recordFieldPath={`${itemName}.record`}
                   name={`${itemName}.name`}
                   placeholder="Name"
-                  component={TextField}
+                  pidType="authors"
+                  suggesterName="author"
+                  extractItemCompletionValue={
+                    JobForm.getSuggestionSourceNameValue
+                  }
+                  component={SuggesterField}
                 />
               </Col>
               <Col span={11}>


### PR DESCRIPTION
* Displays contacts with linked to their author page if they are linked.

* Makes contact.name autocomplete on job submission form in order to
link contacts to athor profile if submitter picks a suggested name.

INSPIR-2620