### PR TITLE
ui: stop using `self` in suggerter field

### DIFF
--- a/ui/src/submissions/common/components/SuggesterField.jsx
+++ b/ui/src/submissions/common/components/SuggesterField.jsx
@@ -31,9 +31,13 @@ class SuggesterField extends Component {
   }
 
   onSelect(_, selectedOptionComponent) {
-    const { self } = selectedOptionComponent.props.result._source;
-    const { form, recordFieldPath } = this.props;
-    form.setFieldValue(recordFieldPath, self);
+    const selectedRecordData = selectedOptionComponent.props.result._source;
+    const { form, recordFieldPath, pidType } = this.props;
+    // TODO: only send control_number to backend, and create the $ref url there.
+    const $ref = `${window.location.origin}/api/${pidType}/${
+      selectedRecordData.control_number
+    }`;
+    form.setFieldValue(recordFieldPath, { $ref });
     this.hasChangedBySuggestionSelection = true;
   }
 


### PR DESCRIPTION
SuggesterField was populating `record`, when a suggestion is selected by
using the `self` field in the selected suggestion. But `self` is
deprecated and doesn't exist in some collections such as `authors`. So
now it is using `control_number` and generating the `$ref` url on the
UI side as a quick fix.