### PR TITLE
ui: clear job mails subscription confirmation

### DIFF
--- a/ui/src/jobs/components/SubscribeJobsModalButton.jsx
+++ b/ui/src/jobs/components/SubscribeJobsModalButton.jsx
@@ -38,6 +38,7 @@ export default class SubscribeJobsModalButton extends Component {
     this.onModalCancel = this.onModalCancel.bind(this);
     this.onInputChange = this.onInputChange.bind(this);
     this.onModalSubscribeClick = this.onModalSubscribeClick.bind(this);
+    this.afterModalCloase = this.afterModalCloase.bind(this);
   }
 
   onInputChange({ target }) {
@@ -67,6 +68,12 @@ export default class SubscribeJobsModalButton extends Component {
     } catch (error) {
       this.setState({ hasError: true });
     }
+  }
+
+  afterModalCloase() {
+    this.setState({
+      isSubscriptionSubmitted: false,
+    });
   }
 
   renderSubscribeForm() {
@@ -138,6 +145,7 @@ export default class SubscribeJobsModalButton extends Component {
           title="Subscribe to the INSPIRE job mailing list"
           visible={isModalVisible}
           okText="Subscribe"
+          afterClose={this.afterModalCloase}
           okButtonProps={{ disabled: isSubscribeButtonDislabed }}
           onCancel={this.onModalCancel}
           onOk={this.onModalSubscribeClick}

--- a/ui/src/jobs/components/__tests__/SubscribeJobsModalButton.test.jsx
+++ b/ui/src/jobs/components/__tests__/SubscribeJobsModalButton.test.jsx
@@ -37,6 +37,17 @@ describe('SubscribeJobsModalButton', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('sets isSubscriptionSubmitted false after modal is closed', () => {
+    const wrapper = shallow(<SubscribeJobsModalButton />);
+
+    wrapper.setState({ isSubscriptionSubmitted: true });
+
+    const afterModalClose = wrapper.find(Modal).prop('afterClose');
+    afterModalClose();
+
+    expect(wrapper).toHaveState({ isSubscriptionSubmitted: false });
+  });
+
   it('calls subscribeJobMailingList with filled data on modal OK click', () => {
     const wrapper = shallow(<SubscribeJobsModalButton />);
 

--- a/ui/src/jobs/components/__tests__/__snapshots__/SubscribeJobsModalButton.test.jsx.snap
+++ b/ui/src/jobs/components/__tests__/__snapshots__/SubscribeJobsModalButton.test.jsx.snap
@@ -15,6 +15,7 @@ exports[`SubscribeJobsModalButton renders confirmation if subscription is submit
     />
   </LinkLikeButton>
   <Modal
+    afterClose={[Function]}
     confirmLoading={false}
     footer={null}
     maskTransitionName="fade"
@@ -59,6 +60,7 @@ exports[`SubscribeJobsModalButton renders with error alert if hasError 1`] = `
     />
   </LinkLikeButton>
   <Modal
+    afterClose={[Function]}
     confirmLoading={false}
     maskTransitionName="fade"
     okButtonProps={
@@ -144,6 +146,7 @@ exports[`SubscribeJobsModalButton renders with initial state 1`] = `
     />
   </LinkLikeButton>
   <Modal
+    afterClose={[Function]}
     confirmLoading={false}
     maskTransitionName="fade"
     okButtonProps={


### PR DESCRIPTION
Clears the confirmation state for job mails subscription, so that when
subscription modal opened again, it show the form instead of the
confirmation.