### PR TITLE
disambiguation: don't touch curated signatures

### DIFF
--- a/backend/inspirehep/disambiguation/utils.py
+++ b/backend/inspirehep/disambiguation/utils.py
@@ -29,13 +29,18 @@ def link_signature_to_author(signature_data, author_control_number):
         ),
         None,
     )
-    if not signature:
+    if not signature or ("record" in signature and signature.get("curated_relation")):
         return None
-    if signature.get(
-        "curated_relation"
-    ) and not LiteratureRecord.get_linked_records_from_dict_field(signature, "record"):
+
+    if signature.get("curated_relation") and "record" not in signature:
         signature["curated_relation"] = False
-    signature["record"] = get_record_ref(author_control_number, "authors")
+
+    new_author_record = get_record_ref(author_control_number, "authors")
+    if new_author_record == signature.get("record"):
+        # no changes, avoid creating a new useless version of the record
+        return None
+
+    signature["record"] = new_author_record
     record.update(dict(record))
     return signature
 

--- a/backend/tests/integration/disambiguation/test_utils.py
+++ b/backend/tests/integration/disambiguation/test_utils.py
@@ -39,6 +39,50 @@ def test_link_signature_to_author(base_app, db, es_clear, create_record, redis):
     assert expected_signatures == record["authors"]
 
 
+def test_link_signature_to_author_with_no_change(
+    base_app, db, es_clear, create_record, redis
+):
+    data = {
+        "authors": [
+            {
+                "full_name": "Doe, John",
+                "uuid": "94fc2b0a-dc17-42c2-bae3-ca0024079e51",
+                "signature_block": "Dj",
+                "record": {"$ref": "http://localhost:5000/api/authors/123"},
+            }
+        ]
+    }
+    record = create_record("lit", data=data)
+    signature_data = {
+        "publication_id": record["control_number"],
+        "signature_uuid": "94fc2b0a-dc17-42c2-bae3-ca0024079e51",
+    }
+    signature = link_signature_to_author(signature_data, 123)
+    assert signature is None
+
+
+def test_link_signature_to_author_with_curated_signature_and_ref(
+    base_app, db, es_clear, create_record, redis
+):
+    data = {
+        "authors": [
+            {
+                "full_name": "Doe, John",
+                "uuid": "94fc2b0a-dc17-42c2-bae3-ca0024079e51",
+                "curated_relation": True,
+                "record": {"$ref": "http://localhost:5000/api/authors/42"},
+            }
+        ]
+    }
+    record = create_record("lit", data=data)
+    signature_data = {
+        "publication_id": record["control_number"],
+        "signature_uuid": "94fc2b0a-dc17-42c2-bae3-ca0024079e51",
+    }
+    signature = link_signature_to_author(signature_data, 123)
+    assert signature is None
+
+
 def test_link_signature_to_author_with_curated_signature_but_no_ref(
     base_app, db, es_clear, create_record, redis
 ):


### PR DESCRIPTION
* Also avoids unnecessary touching the record, resulting in a new DB
  version, if there is no modification because the linked author is the
  same as previously.