### PR TITLE
ui: fix typo in subject options in literature form

### DIFF
--- a/ui/src/submissions/literature/schemas/constants.js
+++ b/ui/src/submissions/literature/schemas/constants.js
@@ -23,7 +23,7 @@ export const subjectOptions = [
   { value: 'Experiment-Nucl' },
   { value: 'General Physics' },
   { value: 'Gravitation and Cosmology' },
-  { value: 'Instumentation' },
+  { value: 'Instrumentation' },
   { value: 'Lattice' },
   { value: 'Math and Math Physics' },
   { value: 'Other' },


### PR DESCRIPTION
* INSPIR-2657

There was a validation error caused by a typo in one of the categories in the dropdown