### PR TITLE
Fix two bugs in literature form

### DIFF
--- a/backend/inspirehep/submissions/marshmallow/literature.py
+++ b/backend/inspirehep/submissions/marshmallow/literature.py
@@ -169,7 +169,10 @@ class Literature(Schema):
         literature.add_url(data.get("additional_link"))
 
         literature.add_title(data["title"], source="submitter")
-        literature.add_language(data.get("language"))
+
+        language = data.get("language")
+        literature.add_language(language if language != "en" else None)
+
         literature.add_inspire_categories(data.get("subjects"))
 
         for author in data.get("authors", []):

--- a/backend/tests/unit/submissions/test_literature.py
+++ b/backend/tests/unit/submissions/test_literature.py
@@ -300,6 +300,24 @@ def test_dump_institution():
     assert result == expected
 
 
+def test_load_language():
+    form = {**DEFAULT_DATA_TO_LOAD, "language": "fr"}
+
+    expected = {**DEFAULT_LOAD, "languages": ["fr"]}
+    result = Literature().load(form).data
+
+    assert result == expected
+
+
+def test_load_language_ignores_en():
+    form = {**DEFAULT_DATA_TO_LOAD, "language": "en"}
+
+    expected = {**DEFAULT_LOAD}
+    result = Literature().load(form).data
+
+    assert result == expected
+
+
 def test_load_document_type():
     form = {**DEFAULT_DATA_TO_LOAD, "document_type": "book"}
 

--- a/e2e/tests/submissions/literature.test.js
+++ b/e2e/tests/submissions/literature.test.js
@@ -124,7 +124,6 @@ describe('literature submissions', () => {
       },
     ]);
     expect(metadata.authors).toEqual([{ full_name: 'Urhan, Harun' }]);
-    expect(metadata.languages).toEqual(['en']);
     expect(metadata.inspire_categories).toEqual([{ term: 'Accelerators' }]);
     expect(metadata.imprints).toEqual([
       {
@@ -197,7 +196,6 @@ describe('literature submissions', () => {
         inspire_roles: ['supervisor'],
       },
     ]);
-    expect(metadata.languages).toEqual(['en']);
     expect(metadata.inspire_categories).toEqual([
       { term: 'Accelerators' },
       { term: 'Experiment-HEP' },
@@ -270,7 +268,6 @@ describe('literature submissions', () => {
       { affiliations: [{ value: 'CERN' }], full_name: 'Urhan, Harun' },
       { full_name: 'Urhan, Ahmet' },
     ]);
-    expect(metadata.languages).toEqual(['en']);
     expect(metadata.inspire_categories).toEqual([
       { term: 'Accelerators' },
       { term: 'Experiment-Nucl' },

--- a/ui/src/submissions/literature/schemas/constants.js
+++ b/ui/src/submissions/literature/schemas/constants.js
@@ -27,5 +27,8 @@ export const subjectOptions = [
   { value: 'Lattice' },
   { value: 'Math and Math Physics' },
   { value: 'Other' },
+  { value: 'Phenomenology-HEP' },
+  { value: 'Theory-HEP' },
+  { value: 'Theory-Nucl' },
 ];
 export const subjectValues = subjectOptions.map(getValue);


### PR DESCRIPTION
* Adds missing INSPIRE categories
* Ignores English language (it's the default, shouldn't usually be present in records)