### PR TITLE
facets: rename peer reviewed to published

### DIFF
--- a/backend/inspirehep/records/config.py
+++ b/backend/inspirehep/records/config.py
@@ -409,7 +409,17 @@ HEP_COMMON_AGGS = {
     },
     "doc_type": {
         "terms": {"field": "facet_inspire_doc_type", "size": 20},
-        "meta": {"title": "Document Type", "order": 6, "type": "checkbox"},
+        "meta": {
+            "title": "Document Type",
+            "order": 6,
+            "type": "checkbox",
+            "bucket_help": {
+                "published": {
+                    "text": "Published papers are believed to have undergone rigorous peer review.",
+                    "link": "https://inspirehep.net/info/faq/general#published",
+                }
+            },
+        },
     },
     "author_count": {
         "range": {
@@ -514,7 +524,7 @@ RECORDS_REST_SORT_OPTIONS = {
         },
     },
     "records-jobs": {
-        "mostrecent": {"title": "Most Recent", "fields": ["-_created"], "order": 1},
+        "mostrecent": {"title": "Most Recent", "fields": ["-_created"], "order": 1}
     },
 }
 

--- a/backend/inspirehep/records/marshmallow/literature/es.py
+++ b/backend/inspirehep/records/marshmallow/literature/es.py
@@ -62,7 +62,7 @@ class LiteratureElasticSearchSchema(ElasticSearchBaseSchema, LiteratureRawSchema
         result.extend(record.get("document_type", []))
         result.extend(record.get("publication_type", []))
         if "refereed" in record and record["refereed"]:
-            result.append("peer reviewed")
+            result.append("published")
         return result
 
     def get_facet_author_name(self, record):

--- a/backend/tests/integration/records/views/test_views_literature.py
+++ b/backend/tests/integration/records/views/test_views_literature.py
@@ -420,6 +420,29 @@ def test_literature_facets_arxiv(api_client, db, es_clear, create_record):
         assert expected_data_hits_source == source["_source"]
 
 
+def test_literature_facets_doc_type_has_bucket_help(
+    api_client, db, es_clear, create_record
+):
+    response = api_client.get("/literature/facets")
+    response_data = json.loads(response.data)
+    response_status_code = response.status_code
+    response_data_facet_bucket_help = (
+        response_data.get("aggregations").get("doc_type").get("meta").get("bucket_help")
+    )
+
+    expected_status_code = 200
+    expected_text = (
+        "Published papers are believed to have undergone rigorous peer review."
+    )
+    expected_link = "https://inspirehep.net/info/faq/general#published"
+
+    assert expected_status_code == response_status_code
+    assert "published" in response_data_facet_bucket_help
+    assert expected_text == response_data_facet_bucket_help["published"]["text"]
+    assert expected_link == response_data_facet_bucket_help["published"]["link"]
+    assert len(response_data["hits"]["hits"]) == 0
+
+
 def test_literature_facets_collaboration(api_client, db, es_clear, create_record):
     data_1 = {
         "$schema": "http://localhost:5000/schemas/records/hep.json",

--- a/ui/src/common/components/AggregationFilters.jsx
+++ b/ui/src/common/components/AggregationFilters.jsx
@@ -57,6 +57,7 @@ class AggregationFilters extends Component {
                       'buckets',
                     ])}
                     splitDisplayName={aggregation.getIn(['meta', 'split'])}
+                    bucketHelp={aggregation.getIn(['meta', 'bucket_help'])}
                     selections={query[aggregationKey]}
                     onChange={selections => {
                       onAggregationChange(aggregationKey, selections);

--- a/ui/src/common/components/CheckboxAggregation.jsx
+++ b/ui/src/common/components/CheckboxAggregation.jsx
@@ -8,6 +8,8 @@ import CheckboxItem from './CheckboxItem';
 import AggregationBox from './AggregationBox';
 import SecondaryButton from './SecondaryButton';
 import { forceArray } from '../utils';
+import HelpIconTooltip from './HelpIconTooltip';
+import ExternalLink from './ExternalLink';
 
 const BUCKET_CHUNK_SIZE = 10;
 export const BUCKET_NAME_SPLITTER = '_';
@@ -69,6 +71,31 @@ class CheckboxAggregation extends Component {
     });
   }
 
+  static renderBucketHelpTooltip(bucketHelpKey) {
+    if (!bucketHelpKey) {
+      return null;
+    }
+
+    const bucketText = bucketHelpKey.get('text');
+    const bucketLink = bucketHelpKey.get('link');
+
+    return (
+      <>
+        {' '}
+        <HelpIconTooltip
+          help={
+            <>
+              {bucketText}{' '}
+              {bucketLink && (
+                <ExternalLink href={bucketLink}>Learn More</ExternalLink>
+              )}
+            </>
+          }
+        />
+      </>
+    );
+  }
+
   renderShowMore() {
     const { buckets } = this.props;
     const { maxBucketCountToDisplay } = this.state;
@@ -88,9 +115,9 @@ class CheckboxAggregation extends Component {
 
   renderBucket(bucket) {
     const { selectionMap } = this.state;
-    const { splitDisplayName } = this.props;
-
+    const { splitDisplayName, bucketHelp } = this.props;
     const bucketKey = bucket.get('key');
+
     return (
       <Row className="mb2" type="flex" justify="space-between" key={bucketKey}>
         <Col>
@@ -103,6 +130,10 @@ class CheckboxAggregation extends Component {
             {splitDisplayName
               ? bucketKey.split(BUCKET_NAME_SPLITTER)[1]
               : bucketKey}
+            {bucketHelp &&
+              CheckboxAggregation.renderBucketHelpTooltip(
+                bucketHelp.get(bucketKey)
+              )}
           </CheckboxItem>
         </Col>
         <Col>
@@ -129,6 +160,7 @@ CheckboxAggregation.propTypes = {
   buckets: PropTypes.instanceOf(Immutable.List).isRequired,
   name: PropTypes.string.isRequired,
   splitDisplayName: PropTypes.bool,
+  bucketHelp: PropTypes.object,
   selections: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.string),
     PropTypes.string,

--- a/ui/src/common/components/__tests__/AggregationFilters.test.jsx
+++ b/ui/src/common/components/__tests__/AggregationFilters.test.jsx
@@ -35,6 +35,27 @@ describe('AggregationFilters', () => {
           type: 'checkbox',
         },
       },
+      agg3: {
+        buckets: [
+          {
+            key: 'foo_3',
+            doc_count: 1,
+          },
+        ],
+        meta: {
+          title: 'Aggregation 3',
+          order: 3,
+          split: true,
+          type: 'checkbox',
+          bucket_help: {
+            published: {
+              text:
+                'Published papers are believed to have undergone rigorous peer review.',
+              link: 'https://inspirehep.net/info/faq/general#published',
+            },
+          },
+        },
+      },
     });
     const initialAggregations = fromJS({
       agg1: {

--- a/ui/src/common/components/__tests__/CheckboxAggregation.test.jsx
+++ b/ui/src/common/components/__tests__/CheckboxAggregation.test.jsx
@@ -31,6 +31,51 @@ describe('CheckboxAggregation', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('render initial state with bucketHelp', () => {
+    const keyBucket1 = `prefix${BUCKET_NAME_SPLITTER}bucket1`;
+    const keyBucket2 = `prefix${BUCKET_NAME_SPLITTER}bucket2`;
+    const keyBucket3 = `prefix${BUCKET_NAME_SPLITTER}bucket3`;
+    const buckets = fromJS([
+      {
+        key: keyBucket1,
+        doc_count: 1,
+      },
+      {
+        key: keyBucket2,
+        doc_count: 2,
+      },
+      {
+        key: keyBucket3,
+        doc_count: 3,
+      },
+    ]);
+    const bucketHelp = fromJS({
+      [keyBucket1]: {
+        text:
+          'Published papers are believed to have undergone rigorous peer review.',
+        link: 'https://inspirehep.net/info/faq/general#published',
+      },
+      [keyBucket2]: {
+        text:
+          'Published papers are believed to have undergone rigorous peer review.',
+      },
+      [keyBucket3]: {
+        link: 'https://inspirehep.net/info/faq/general#published',
+      },
+    });
+    const wrapper = shallow(
+      <CheckboxAggregation
+        onChange={jest.fn()}
+        buckets={buckets}
+        bucketHelp={bucketHelp}
+        name="Test"
+        selections="bucket1"
+        splitDisplayName
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it('render initial state without splitDisplayName', () => {
     const buckets = fromJS([
       {

--- a/ui/src/common/components/__tests__/__snapshots__/AggregationFilters.test.jsx.snap
+++ b/ui/src/common/components/__tests__/__snapshots__/AggregationFilters.test.jsx.snap
@@ -226,5 +226,41 @@ exports[`AggregationFilters renders with all props set 1`] = `
       />
     </EventTracker>
   </Col>
+  <Col
+    className=""
+    gutter={32}
+    key="agg3"
+    lg={24}
+    xs={24}
+  >
+    <EventTracker
+      eventId="Facet-Aggregation 3"
+      eventPropName="onChange"
+      extractEventArgsToForward={null}
+    >
+      <AggregationFilter
+        aggregationType="checkbox"
+        bucketHelp={
+          Immutable.Map {
+            "published": Immutable.Map {
+              "text": "Published papers are believed to have undergone rigorous peer review.",
+              "link": "https://inspirehep.net/info/faq/general#published",
+            },
+          }
+        }
+        buckets={
+          Immutable.List [
+            Immutable.Map {
+              "key": "foo_3",
+              "doc_count": 1,
+            },
+          ]
+        }
+        name="Aggregation 3"
+        onChange={[Function]}
+        splitDisplayName={true}
+      />
+    </EventTracker>
+  </Col>
 </Row>
 `;

--- a/ui/src/common/components/__tests__/__snapshots__/CheckboxAggregation.test.jsx.snap
+++ b/ui/src/common/components/__tests__/__snapshots__/CheckboxAggregation.test.jsx.snap
@@ -50,6 +50,113 @@ exports[`CheckboxAggregation render initial state with all props set 1`] = `
 </AggregationBox>
 `;
 
+exports[`CheckboxAggregation render initial state with bucketHelp 1`] = `
+<AggregationBox
+  headerAction={null}
+  name="Test"
+>
+  <Row
+    className="mb2"
+    gutter={0}
+    justify="space-between"
+    key="prefix_bucket1"
+    type="flex"
+  >
+    <Col>
+      <CheckboxItem
+        checked={false}
+        onChange={[Function]}
+      >
+        bucket1
+         
+        <HelpIconTooltip
+          help={
+            <React.Fragment>
+              Published papers are believed to have undergone rigorous peer review.
+               
+              <ExternalLink
+                href="https://inspirehep.net/info/faq/general#published"
+              >
+                Learn More
+              </ExternalLink>
+            </React.Fragment>
+          }
+        />
+      </CheckboxItem>
+    </Col>
+    <Col>
+      <UnclickableTag>
+        1
+      </UnclickableTag>
+    </Col>
+  </Row>
+  <Row
+    className="mb2"
+    gutter={0}
+    justify="space-between"
+    key="prefix_bucket2"
+    type="flex"
+  >
+    <Col>
+      <CheckboxItem
+        checked={false}
+        onChange={[Function]}
+      >
+        bucket2
+         
+        <HelpIconTooltip
+          help={
+            <React.Fragment>
+              Published papers are believed to have undergone rigorous peer review.
+               
+            </React.Fragment>
+          }
+        />
+      </CheckboxItem>
+    </Col>
+    <Col>
+      <UnclickableTag>
+        2
+      </UnclickableTag>
+    </Col>
+  </Row>
+  <Row
+    className="mb2"
+    gutter={0}
+    justify="space-between"
+    key="prefix_bucket3"
+    type="flex"
+  >
+    <Col>
+      <CheckboxItem
+        checked={false}
+        onChange={[Function]}
+      >
+        bucket3
+         
+        <HelpIconTooltip
+          help={
+            <React.Fragment>
+               
+              <ExternalLink
+                href="https://inspirehep.net/info/faq/general#published"
+              >
+                Learn More
+              </ExternalLink>
+            </React.Fragment>
+          }
+        />
+      </CheckboxItem>
+    </Col>
+    <Col>
+      <UnclickableTag>
+        3
+      </UnclickableTag>
+    </Col>
+  </Row>
+</AggregationBox>
+`;
+
 exports[`CheckboxAggregation render initial state without splitDisplayName 1`] = `
 <AggregationBox
   headerAction={null}

--- a/ui/ui-tests/server.js
+++ b/ui/ui-tests/server.js
@@ -6,10 +6,7 @@ const proxy = require('http-proxy-middleware');
 const app = express();
 
 // necessary for recording api responses when running tests locally (for the first time or ondemand)
-const {
-  UI_TESTS_HOST = 'localhost:8081',
-  UI_TESTS_HTTP_SCHEME = 'http',
-} = process.env;
+const { UI_TESTS_HOST, UI_TESTS_HTTP_SCHEME } = process.env;
 app.use(
   '/api',
   proxy({


### PR DESCRIPTION
* INSPIR-2363

Note: server.js has been modified since the previous default values are not being read at the time of generating the recordings for the UI tests. The url and http schema have to be set via environmental variables.