### PR TITLE
ui: change rich text editor's text block tag.

### DIFF
--- a/e2e/tests/submissions/job.test.js
+++ b/e2e/tests/submissions/job.test.js
@@ -85,7 +85,7 @@ describe('job submissions', () => {
         emails: ['references@yahoo.com'],
         urls: [{ value: 'https://uploadReferences.com' }],
       },
-      description: '<p>This is my description</p>',
+      description: 'This is my description',
     };
     const { metadata } = await jobResponse.json();
 

--- a/ui/src/submissions/common/components/RichTextEditor/RichTextEditor.jsx
+++ b/ui/src/submissions/common/components/RichTextEditor/RichTextEditor.jsx
@@ -1,9 +1,14 @@
 import React, { Component } from 'react';
-import QuillEditor from 'react-quill';
+import QuillEditor, { Quill } from 'react-quill';
 
 import 'react-quill/dist/quill.snow.css';
 import './RichTextEditor.scss';
 import EditorToolbar from './EditorToolbar';
+
+// change default text default (`P`)
+const Block = Quill.import('blots/block');
+Block.tagName = 'DIV';
+Quill.register(Block, true);
 
 const QUILL_MODULES = {
   toolbar: '#toolbar',


### PR DESCRIPTION
Quill's default tag after the line break is `p` which has overriden
style inside quill editor, no bottom margin 1em which is a web default
and exist everywhere including job detail page. Since we don't want to
break a web standard by removing margin for `p` inside job description,
this PR changes `P` tag to `DIV` instead, which has consistent
behaviour everywhere.

Note that adding margin back to P tag for Quill instead of changing whole
tag, has a limitation. It doesn't allow linebreaks without spaces.

* INSPIR-2799