### PR TITLE
pidstore: make doi case insensitive

### DIFF
--- a/backend/inspirehep/pidstore/converters.py
+++ b/backend/inspirehep/pidstore/converters.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CERN.
+#
+# inspirehep is free software; you can redistribute it and/or modify it under
+# the terms of the MIT License; see LICENSE file for more details.
+import structlog
+from invenio_records_rest.utils import PIDConverter
+from werkzeug.routing import PathConverter
+
+LOGGER = structlog.getLogger()
+
+
+class DOIConverter(PIDConverter):
+    def to_python(self, value):
+        return super().to_python(value.lower())
+
+
+class DOIPathConverter(DOIConverter, PathConverter):
+    """DOIConverter with support for path-like (with slashes) DOI values."""
+
+
+class ArXivPathConverter(PIDConverter, PathConverter):
+    """DOIConverter with support for path-like (with slashes) DOI values."""

--- a/backend/inspirehep/pidstore/minters/doi.py
+++ b/backend/inspirehep/pidstore/minters/doi.py
@@ -12,3 +12,10 @@ from .base import Minter
 class DoiMinter(Minter):
     pid_value_path = "dois.value"
     pid_type = "doi"
+
+    def create(self, pid_value):
+        return super().create(pid_value.lower())
+
+    def get_pid_values(self):
+        pid_values = {str(pid_value).lower() for pid_value in super().get_pid_values()}
+        return pid_values

--- a/backend/inspirehep/records/config.py
+++ b/backend/inspirehep/records/config.py
@@ -137,7 +137,7 @@ LITERATURE_ARXIV = deepcopy(LITERATURE)
 LITERATURE_ARXIV.update(
     {
         "pid_type": "arxiv",
-        "item_route": '/arxiv/<pid(arxiv,record_class="inspirehep.records.api.LiteratureRecord"):pid_value>',
+        "item_route": '/arxiv/<arxivpath(arxiv,record_class="inspirehep.records.api.LiteratureRecord"):pid_value>',
     }
 )
 
@@ -146,7 +146,7 @@ DOI = deepcopy(LITERATURE)
 DOI.update(
     {
         "pid_type": "doi",
-        "item_route": '/doi/<pidpath(doi,record_class="inspirehep.records.api.InspireRecord"):pid_value>',
+        "item_route": '/doi/<doipath(doi,record_class="inspirehep.records.api.InspireRecord"):pid_value>',
     }
 )
 

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -74,6 +74,10 @@ setup(
             "inspirehep_records = inspirehep.records:InspireRecords",
             "inspirehep_rt = inspirehep.rt:InspireRtExt",
         ],
+        "invenio_base.api_converters": [
+            "doipath = inspirehep.pidstore.converters:DOIPathConverter",
+            "arxivpath = inspirehep.pidstore.converters:ArXivPathConverter",
+        ],
         "invenio_jsonschemas.schemas": ["inspirehep_records_schemas = inspire_schemas"],
         "invenio_search.mappings": ["records = inspirehep.search.mappings"],
         "invenio_db.models": [

--- a/backend/tests/integration-async/records/api/test_base.py
+++ b/backend/tests/integration-async/records/api/test_base.py
@@ -6,6 +6,7 @@
 # the terms of the MIT License; see LICENSE file for more details.
 
 import pytest
+from helpers.providers.faker import faker
 from invenio_db import db
 
 from inspirehep.records.api import LiteratureRecord

--- a/backend/tests/integration/pidstore/test_pidstore_api_base.py
+++ b/backend/tests/integration/pidstore/test_pidstore_api_base.py
@@ -21,3 +21,47 @@ def test_get_config_for_schema(appctx):
     pids_to_endpoints = PidStoreBase._get_config_pid_types_to_schema()
 
     assert pids_to_endpoints is not None
+
+
+def test_doi_resolve_ignores_case(app, api_client, create_record):
+    expected_response_code = 200
+    lowercase_doi = "10.1109/tpel.2019.2900393"
+    uppercase_doi = "10.1109/TPEL.2019.2900393"
+    data = {"dois": [{"value": uppercase_doi}]}
+    record = create_record("lit", data)
+    expected_control_number = record["control_number"]
+    response = api_client.get(f"api/doi/{uppercase_doi}")
+    assert expected_response_code == response.status_code
+    assert expected_control_number == response.json["metadata"]["control_number"]
+
+    response = api_client.get(f"api/doi/{lowercase_doi}")
+    assert expected_response_code == response.status_code
+    assert expected_control_number == response.json["metadata"]["control_number"]
+
+
+def test_arxiv_path_converter_works_for_all_arxiv_pid_values(
+    app, api_client, create_record
+):
+    data = {
+        "arxiv_eprints": [
+            {"value": "1607.06746", "categories": ["hep-th"]},
+            {"categories": ["hep-ph"], "value": "hep-ph/9709356"},
+        ]
+    }
+    record = create_record("lit", data)
+    expected_control_number = record["control_number"]
+    expected_status_code = 200
+    short_arxiv_number_respons = api_client.get("api/arxiv/1607.06746")
+    long_arxiv_number_response = api_client.get("api/arxiv/hep-ph/9709356")
+
+    assert expected_status_code == short_arxiv_number_respons.status_code
+    assert (
+        expected_control_number
+        == short_arxiv_number_respons.json["metadata"]["control_number"]
+    )
+
+    assert expected_status_code == long_arxiv_number_response.status_code
+    assert (
+        expected_control_number
+        == long_arxiv_number_response.json["metadata"]["control_number"]
+    )


### PR DESCRIPTION
* This commit requires to remove dois from pidstore and records migration. See: [INSPIR-2925](https://its.cern.ch/jira/browse/INSPIR-2925)
* INSPIR-2822