### PR TITLE
logger: emit JSON also for stdlib logging

### DIFF
--- a/backend/inspirehep/config.py
+++ b/backend/inspirehep/config.py
@@ -159,8 +159,6 @@ SERVER_NAME = "localhost:8000"
 #: Switches off incept of redirects by Flask-DebugToolbar.
 DEBUG_TB_INTERCEPT_REDIRECTS = False
 
-PIDSTORE_RECID_FIELD = "control_number"
-
 # Files
 # =====
 BASE_FILES_LOCATION = os.path.join(sys.prefix, "var/data")
@@ -181,6 +179,7 @@ FILES_REST_STORAGE_PATH_DIMENSIONS = 0
 # Pidstore
 # ========
 PIDSTORE_RECID_FIELD = "control_number"
+PIDSTORE_APP_LOGGER_HANDLERS = False
 
 # Invenio-App
 # ===========

--- a/backend/inspirehep/logger/config.py
+++ b/backend/inspirehep/logger/config.py
@@ -32,31 +32,40 @@ PROMETHEUS_ENABLE_EXPORTER_FLASK = False
 Enable Flask metrics, using https://github.com/rycus86/prometheus_flask_exporter
 """
 
-# Logging config
-# ==============
-logging.basicConfig(format="%(message)s", stream=sys.stdout, level=logging.INFO)
-
 # Structlog
 # =========
+shared_processors = [
+    structlog.threadlocal.merge_threadlocal_context,
+    structlog.stdlib.add_logger_name,
+    structlog.stdlib.add_log_level,
+    structlog.stdlib.PositionalArgumentsFormatter(),
+    structlog.processors.TimeStamper(fmt="iso"),
+    structlog.processors.StackInfoRenderer(),
+    structlog.processors.format_exc_info,
+    SentryJsonProcessor(level=logging.ERROR, tag_keys="__all__"),
+    structlog.processors.UnicodeDecoder(),
+]
 structlog.configure(
-    processors=[
-        structlog.threadlocal.merge_threadlocal_context,
-        structlog.stdlib.filter_by_level,
-        structlog.stdlib.add_logger_name,
-        structlog.stdlib.add_log_level,
-        structlog.stdlib.PositionalArgumentsFormatter(),
-        structlog.processors.TimeStamper(fmt="iso"),
-        structlog.processors.StackInfoRenderer(),
-        structlog.processors.format_exc_info,
-        structlog.processors.UnicodeDecoder(),
-        SentryJsonProcessor(level=logging.ERROR, tag_keys="__all__"),
-        structlog.processors.JSONRenderer(),
-    ],
+    processors=[structlog.stdlib.filter_by_level]
+    + shared_processors
+    + [structlog.stdlib.ProcessorFormatter.wrap_for_formatter],
     context_class=dict,
     logger_factory=structlog.stdlib.LoggerFactory(),
     wrapper_class=structlog.stdlib.BoundLogger,
     cache_logger_on_first_use=True,
 )
+
+# Logging config
+# ==============
+formatter = structlog.stdlib.ProcessorFormatter(
+    processor=structlog.processors.JSONRenderer(), foreign_pre_chain=shared_processors
+)
+handler = logging.StreamHandler()
+handler.setFormatter(formatter)
+
+root_logger = logging.getLogger()
+root_logger.addHandler(handler)
+root_logger.setLevel(logging.INFO)
 
 # Celery logging
 # ==============

--- a/backend/inspirehep/pidstore/api/base.py
+++ b/backend/inspirehep/pidstore/api/base.py
@@ -52,9 +52,7 @@ class PidStoreBase(object):
         try:
             LOGGER.info("Deleting external PIDs", uuid=str(self.object_uuid))
             return PersistentIdentifier.query.filter_by(
-                object_type="rec",
-                object_uuid=str(self.object_uuid),
-                pid_provider="external",
+                object_type="rec", object_uuid=self.object_uuid, pid_provider="external"
             ).delete()
         except PIDDoesNotExistError:
             LOGGER.warning("Pids ``external`` not found", uuid=str(self.object_uuid))

--- a/backend/inspirehep/pidstore/minters/base.py
+++ b/backend/inspirehep/pidstore/minters/base.py
@@ -93,8 +93,8 @@ class ControlNumberMinter(Minter):
         if "control_number" in data:
             pid_value = data["control_number"]
 
-        record_id_provider = minter.create(pid_value)
-        data["control_number"] = record_id_provider.pid.pid_value
+        record_id_provider = minter.create(str(pid_value) if pid_value else None)
+        data["control_number"] = int(record_id_provider.pid.pid_value)
 
         return minter
 

--- a/backend/inspirehep/pidstore/providers/recid.py
+++ b/backend/inspirehep/pidstore/providers/recid.py
@@ -46,7 +46,7 @@ class InspireRecordIdProvider(BaseProvider):
                 LOGGER.info("Control number from legacy", recid=kwargs["pid_value"])
                 RecordIdentifier.insert(kwargs["pid_value"])
             else:
-                kwargs["pid_value"] = RecordIdentifier.next()
+                kwargs["pid_value"] = str(RecordIdentifier.next())
                 LOGGER.info(
                     "Control number from RecordIdentifier", recid=kwargs["pid_value"]
                 )


### PR DESCRIPTION
* This causes all logging in the application to go through structlog and
  be rendered as JSON.

Example output:
```json
{"event": "Received task: inspirehep.migrator.tasks.migrate_recids_from_mirror[79ca42a8-60fc-41d5-ab93-6ee5aa0d8265]  ", "logger": "celery.worker.strategy", "level": "info", "timestamp": "2019-11-15T15:32:03.517783Z", "sentry": "skipped"}
{"task_id": "79ca42a8-60fc-41d5-ab93-6ee5aa0d8265", "task": "inspirehep.migrator.tasks.migrate_recids_from_mirror", "event": "Task inspirehep.migrator.tasks.migrate_recids_from_mirror[79ca42a8-60fc-41d5-ab93-6ee5aa0d8265] succeeded in 0.000743832002626732s: None", "logger": "celery.app.trace", "level": "info", "timestamp": "2019-11-15T15:32:03.519666Z", "sentry": "skipped"}
{"event": "Received task: inspirehep.records.indexer.tasks.index_record[f215019c-2129-4c76-871f-0dd03a755f9b]  ", "logger": "celery.worker.strategy", "level": "info", "timestamp": "2019-11-15T15:42:38.133486Z", "sentry": "skipped"}
{"task_id": "f215019c-2129-4c76-871f-0dd03a755f9b", "task": "inspirehep.records.indexer.tasks.index_record", "event": "PUT http://es:9200/records-hep/hep/f55795f3-a49d-4ca5-9399-b3f0b064e6ff?version=31&version_type=external_gte [status:200 request:0.028s]", "logger": "elasticsearch", "level": "info", "timestamp": "2019-11-15T15:42:38.269758Z", "sentry": "skipped"}
{"task_id": "f215019c-2129-4c76-871f-0dd03a755f9b", "task": "inspirehep.records.indexer.tasks.index_record", "uuid": "f55795f3-a49d-4ca5-9399-b3f0b064e6ff", "event": "No references changed", "logger": "inspirehep.records.indexer.tasks", "level": "info", "timestamp": "2019-11-15T15:42:38.291477Z", "sentry": "skipped"}
{"task_id": "f215019c-2129-4c76-871f-0dd03a755f9b", "task": "inspirehep.records.indexer.tasks.index_record", "event": "Task inspirehep.records.indexer.tasks.index_record[f215019c-2129-4c76-871f-0dd03a755f9b] succeeded in 0.15817748799963738s: None", "logger": "celery.app.trace", "level": "info", "timestamp": "2019-11-15T15:42:38.292695Z", "sentry": "skipped"}
{"event": "Received task: inspirehep.records.indexer.tasks.index_record[2ea39e41-ab5e-46c6-b8a8-d3c356e4840e]  ", "logger": "celery.worker.strategy", "level": "info", "timestamp": "2019-11-15T15:43:39.179133Z", "sentry": "skipped"}
{"task_id": "2ea39e41-ab5e-46c6-b8a8-d3c356e4840e", "task": "inspirehep.records.indexer.tasks.index_record", "event": "PUT http://es:9200/records-hep/hep/f55795f3-a49d-4ca5-9399-b3f0b064e6ff?version=33&version_type=external_gte [status:200 request:0.026s]", "logger": "elasticsearch", "level": "info", "timestamp": "2019-11-15T15:43:39.325435Z", "sentry": "skipped"}
{"task_id": "2ea39e41-ab5e-46c6-b8a8-d3c356e4840e", "task": "inspirehep.records.indexer.tasks.index_record", "uuid": "f55795f3-a49d-4ca5-9399-b3f0b064e6ff", "event": "No references changed", "logger": "inspirehep.records.indexer.tasks", "level": "info", "timestamp": "2019-11-15T15:43:39.345819Z", "sentry": "skipped"}
{"task_id": "2ea39e41-ab5e-46c6-b8a8-d3c356e4840e", "task": "inspirehep.records.indexer.tasks.index_record", "event": "Task inspirehep.records.indexer.tasks.index_record[2ea39e41-ab5e-46c6-b8a8-d3c356e4840e] succeeded in 0.16658169599759276s: None", "logger": "celery.app.trace", "level": "info", "timestamp": "2019-11-15T15:43:39.346954Z", "sentry": "skipped"}
{"event": "Received task: inspirehep.records.indexer.tasks.index_record[f7c59a3a-3972-49ae-8a89-7f9f83afffca]  ", "logger": "celery.worker.strategy", "level": "info", "timestamp": "2019-11-15T16:04:39.469270Z", "sentry": "skipped"}
{"task_id": "f7c59a3a-3972-49ae-8a89-7f9f83afffca", "task": "inspirehep.records.indexer.tasks.index_record", "event": "PUT http://es:9200/records-hep/hep/f55795f3-a49d-4ca5-9399-b3f0b064e6ff?version=35&version_type=external_gte [status:200 request:0.020s]", "logger": "elasticsearch", "level": "info", "timestamp": "2019-11-15T16:04:39.557641Z", "sentry": "skipped"}
{"task_id": "f7c59a3a-3972-49ae-8a89-7f9f83afffca", "task": "inspirehep.records.indexer.tasks.index_record", "uuid": "f55795f3-a49d-4ca5-9399-b3f0b064e6ff", "event": "No references changed", "logger": "inspirehep.records.indexer.tasks", "level": "info", "timestamp": "2019-11-15T16:04:39.575770Z", "sentry": "skipped"}
{"task_id": "f7c59a3a-3972-49ae-8a89-7f9f83afffca", "task": "inspirehep.records.indexer.tasks.index_record", "event": "Task inspirehep.records.indexer.tasks.index_record[f7c59a3a-3972-49ae-8a89-7f9f83afffca] succeeded in 0.10665912399781519s: None", "logger": "celery.app.trace", "level": "info", "timestamp": "2019-11-15T16:04:39.576919Z", "sentry": "skipped"}
```