### PR TITLE
conferences: auth update view via session

### DIFF
--- a/backend/inspirehep/access_control.py
+++ b/backend/inspirehep/access_control.py
@@ -7,6 +7,9 @@
 
 from invenio_oauth2server import require_api_auth
 
+from inspirehep.accounts.decorators import login_required_with_roles
+from inspirehep.accounts.roles import Roles
+
 
 def check_oauth2(can_method):
     """Base permission factory that check OAuth2 scope.
@@ -30,3 +33,13 @@ def check_oauth2(can_method):
 
 
 api_access_permission_check = check_oauth2(lambda self: True)
+
+
+class SessionCatalogerPermission:
+    @login_required_with_roles([Roles.cataloger.value])
+    def can(self):
+        return True
+
+
+def session_cataloger_permission_factory(*args, **kwargs):
+    return SessionCatalogerPermission()

--- a/backend/inspirehep/accounts/decorators.py
+++ b/backend/inspirehep/accounts/decorators.py
@@ -37,7 +37,7 @@ def login_required_with_roles(roles=None):
                 user_roles = {role.name for role in current_user.roles}
                 has_access = user_roles & set(roles)
                 if not has_access:
-                    abort(401)
+                    abort(403)
             return func(*args, **kwargs)
 
         return wrapped_function

--- a/backend/inspirehep/records/config.py
+++ b/backend/inspirehep/records/config.py
@@ -19,7 +19,10 @@ from invenio_indexer.api import RecordIndexer
 from invenio_records_rest.facets import range_filter, terms_filter
 from invenio_records_rest.utils import allow_all, deny_all
 
-from inspirehep.access_control import api_access_permission_check
+from inspirehep.access_control import (
+    api_access_permission_check,
+    session_cataloger_permission_factory,
+)
 from inspirehep.search.api import (
     AuthorsSearch,
     ConferencesSearch,
@@ -305,7 +308,7 @@ CONFERENCES.update(
                 "completion": {"field": "conferenceautocomplete"},
             }
         },
-        "update_permission_factory_imp": api_access_permission_check,
+        "update_permission_factory_imp": session_cataloger_permission_factory,
         "search_serializers": {
             "application/json": INSPIRE_SERIALIZERS
             + ":conferences_json_response_search",

--- a/backend/tests/integration/accounts/test_decorators.py
+++ b/backend/tests/integration/accounts/test_decorators.py
@@ -9,7 +9,7 @@
 
 import pytest
 from mock import Mock, patch
-from werkzeug.exceptions import Unauthorized
+from werkzeug.exceptions import Forbidden, Unauthorized
 
 from inspirehep.accounts.decorators import login_required_with_roles
 
@@ -65,6 +65,6 @@ def test_login_required_with_roles_unauthorized(
 ):
     func = Mock()
     decorated_func = login_required_with_roles(["role_a"])(func)
-    with pytest.raises(Unauthorized):
+    with pytest.raises(Forbidden):
         decorated_func()
         assert func.called

--- a/backend/tests/integration/records/views/test_views_conferences.py
+++ b/backend/tests/integration/records/views/test_views_conferences.py
@@ -4,6 +4,8 @@
 #
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
+import json
+
 from invenio_accounts.testutils import login_user_via_session
 
 from inspirehep.accounts.roles import Roles
@@ -15,17 +17,6 @@ def test_conferences_application_json_get(api_client, db, es, create_record_fact
 
     expected_status_code = 200
     response = api_client.get(f"/conferences/{record_control_number}")
-    response_status_code = response.status_code
-
-    assert expected_status_code == response_status_code
-
-
-def test_conferences_application_json_put(api_client, db, es, create_record_factory):
-    record = create_record_factory("con", with_indexing=True)
-    record_control_number = record.json["control_number"]
-
-    expected_status_code = 401
-    response = api_client.put(f"/conferences/{record_control_number}")
     response_status_code = response.status_code
 
     assert expected_status_code == response_status_code
@@ -115,3 +106,56 @@ def test_conferences_contribution_filters(api_client, db, es, create_record):
     expected_subject_aggregation_buckets = [{"key": "Computing", "doc_count": 1}]
 
     assert expected_subject_aggregation_buckets == response_subject_aggregation_buckets
+
+
+def test_conferences_application_json_put_without_auth(
+    api_client, db, es_clear, create_record
+):
+    record = create_record("con")
+    record_control_number = record["control_number"]
+
+    expected_status_code = 401
+    response = api_client.put(f"/conferences/{record_control_number}")
+    response_status_code = response.status_code
+
+    assert expected_status_code == response_status_code
+
+
+def test_conferences_application_json_put_without_cataloger_logged_in(
+    api_client, db, es_clear, create_user, create_record
+):
+    user = create_user()
+    login_user_via_session(api_client, email=user.email)
+
+    record = create_record("con")
+    record_control_number = record["control_number"]
+
+    expected_status_code = 403
+    response = api_client.put(f"/conferences/{record_control_number}")
+    response_status_code = response.status_code
+
+    assert expected_status_code == response_status_code
+
+
+def test_conferences_application_json_put_with_cataloger_logged_in(
+    api_client, db, es_clear, create_user, create_record
+):
+    cataloger = create_user(role=Roles.cataloger.value)
+    login_user_via_session(api_client, email=cataloger.email)
+    record = create_record("con")
+    record_control_number = record["control_number"]
+
+    expected_status_code = 200
+    response = api_client.put(
+        "/conferences/{}".format(record_control_number),
+        content_type="application/json",
+        data=json.dumps(
+            {
+                "$schema": "http://localhost:5000/schemas/records/conferences.json",
+                "_collections": ["Conferences"],
+            }
+        ),
+    )
+    response_status_code = response.status_code
+
+    assert expected_status_code == response_status_code


### PR DESCRIPTION
* PUT is only allowed if request has session of a cataloger.

* Also fixes login_required_with_roles to return `403` when user is
logged in but do not have access for the resource.

INSPIR-2854