### PR TITLE
tests: don't remove all tables, just remove content

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -32,3 +32,13 @@ def vcr_config():
         ),
         "record_mode": "once",
     }
+
+
+@pytest.fixture(scope="module")
+def es(appctx):
+    """Setup all registered Elasticsearch indices."""
+    from invenio_search import current_search, current_search_client
+
+    list(current_search.create(ignore=[400]))
+    list(current_search.put_templates(ignore=[400]))
+    yield current_search_client

--- a/backend/tests/helpers/cleanups.py
+++ b/backend/tests/helpers/cleanups.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CERN.
+#
+# inspirehep is free software; you can redistribute it and/or modify it under
+# the terms of the MIT License; see LICENSE file for more details.
+
+import elasticsearch
+from pytest_invenio.fixtures import _es_create_indexes, _es_delete_indexes
+from sqlalchemy_utils import create_database, database_exists
+
+
+def es_cleanup(es):
+    """Removes all data from es indexes
+
+    There is ES error on version 5, when you try to remove records
+    using delete_by_query and record have internal visioning and
+    it's current version is 0 it's failing. So in this case only way is to
+    remove index but invenio 1.1.1 allows to remove all indexes only
+    After upgrading to invenio 1.2 we will be able
+    to remove only specified index
+    """
+    from invenio_search import current_search, current_search_client
+
+    es.indices.refresh()
+    try:
+        for index in es.indices.stats()["indices"].keys():
+            es.delete_by_query(index, "{}")
+    except elasticsearch.exceptions.RequestError:
+        _es_delete_indexes(current_search)
+        _es_create_indexes(current_search, current_search_client)
+    es.indices.refresh()
+
+
+def db_cleanup(db_):
+    """Truncate tables."""
+    if not database_exists(str(db_.engine.url)):
+        create_database(str(db_.engine.url))
+    db_.session.remove()
+    db_.create_all()
+    all_tables = db_.metadata.tables
+    for table_name, table_object in all_tables.items():
+        db_.session.execute(f"ALTER TABLE {table_name} DISABLE TRIGGER ALL;")
+        db_.session.execute(table_object.delete())
+        db_.session.execute(f"ALTER TABLE {table_name} ENABLE TRIGGER ALL;")
+    db_.session.commit()

--- a/backend/tests/integration/alembic/test_alembic.py
+++ b/backend/tests/integration/alembic/test_alembic.py
@@ -9,172 +9,189 @@ from flask_alembic import Alembic
 from sqlalchemy import text
 
 
-def test_downgrade(base_app, db, es):
+def test_downgrade(base_app, database):
     alembic = Alembic(base_app)
-
     alembic.downgrade("e5e43ad8f861")
     assert "enum_conference_to_literature_relationship_type" not in _get_custom_enums(
-        db
+        database
     )
-    assert "conference_literature" not in _get_table_names(db)
+    assert "conference_literature" not in _get_table_names(database)
     assert "ix_conference_literature_literature_uuid" not in _get_indexes(
-        "conference_literature", db
+        "conference_literature", database
     )
     assert "ix_conference_literature_conference_uuid" not in _get_indexes(
-        "conference_literature", db
+        "conference_literature", database
     )
 
     alembic.downgrade(target="788a3a61a635")
-    assert "ix_files_object_key_head" not in _get_indexes("files_object", db)
+    assert "ix_files_object_key_head" not in _get_indexes("files_object", database)
 
-    assert "idx_pid_provider" not in _get_indexes("pidstore_pid", db)
+    assert "idx_pid_provider" not in _get_indexes("pidstore_pid", database)
 
     alembic.downgrade(target="dc1ae5abe9d6")
 
-    assert "idx_pid_provider" in _get_indexes("pidstore_pid", db)
+    assert "idx_pid_provider" in _get_indexes("pidstore_pid", database)
 
     alembic.downgrade(target="c6570e49b7b2")
 
-    assert "records_citations" in _get_table_names(db)
-    assert "ix_records_citations_cited_id" in _get_indexes("records_citations", db)
+    assert "records_citations" in _get_table_names(database)
+    assert "ix_records_citations_cited_id" in _get_indexes(
+        "records_citations", database
+    )
 
     alembic.downgrade(target="5ce9ef759ace")
 
-    assert "record_citations" in _get_table_names(db)
-    assert "records_citations" not in _get_table_names(db)
-    assert "ix_records_citations_cited_id" not in _get_indexes("record_citations", db)
-    assert "idx_citations_cited" in _get_indexes("record_citations", db)
+    assert "record_citations" in _get_table_names(database)
+    assert "records_citations" not in _get_table_names(database)
+    assert "ix_records_citations_cited_id" not in _get_indexes(
+        "record_citations", database
+    )
+    assert "idx_citations_cited" in _get_indexes("record_citations", database)
 
     alembic.downgrade(target="b646d3592dd5")
     assert "ix_legacy_records_mirror_last_updated" not in _get_indexes(
-        "legacy_records_mirror", db
+        "legacy_records_mirror", database
     )
     assert "ix_legacy_records_mirror_valid_collection" not in _get_indexes(
-        "legacy_records_mirror", db
+        "legacy_records_mirror", database
     )
-    assert "legacy_records_mirror" not in _get_table_names(db)
+    assert "legacy_records_mirror" not in _get_table_names(database)
 
     alembic.downgrade(target="7be4c8b5c5e8")
-    assert "idx_citations_cited" not in _get_indexes("record_citations", db)
+    assert "idx_citations_cited" not in _get_indexes("record_citations", database)
 
-    assert "record_citations" not in _get_table_names(db)
+    assert "record_citations" not in _get_table_names(database)
 
     # test 7be4c8b5c5e8
     alembic.downgrade(target="b5be5fda2ee7")
     alembic.downgrade(1)
 
     assert "ix_records_metadata_json_referenced_records_2_0" not in _get_indexes(
-        "records_metadata", db
+        "records_metadata", database
     )
 
-    assert "workflows_record_sources" not in _get_table_names(db)
-    assert "workflows_pending_record" not in _get_table_names(db)
-    assert "crawler_workflows_object" not in _get_table_names(db)
-    assert "crawler_job" not in _get_table_names(db)
-    assert "workflows_audit_logging" not in _get_table_names(db)
-    assert "workflows_buckets" not in _get_table_names(db)
-    assert "workflows_object" not in _get_table_names(db)
-    assert "workflows_workflow" not in _get_table_names(db)
+    assert "workflows_record_sources" not in _get_table_names(database)
+    assert "workflows_pending_record" not in _get_table_names(database)
+    assert "crawler_workflows_object" not in _get_table_names(database)
+    assert "crawler_job" not in _get_table_names(database)
+    assert "workflows_audit_logging" not in _get_table_names(database)
+    assert "workflows_buckets" not in _get_table_names(database)
+    assert "workflows_object" not in _get_table_names(database)
+    assert "workflows_workflow" not in _get_table_names(database)
 
-    assert "ix_crawler_job_job_id" not in _get_indexes("crawler_job", db)
-    assert "ix_crawler_job_scheduled" not in _get_indexes("crawler_job", db)
-    assert "ix_crawler_job_spider" not in _get_indexes("crawler_job", db)
-    assert "ix_crawler_job_workflow" not in _get_indexes("crawler_job", db)
+    assert "ix_crawler_job_job_id" not in _get_indexes("crawler_job", database)
+    assert "ix_crawler_job_scheduled" not in _get_indexes("crawler_job", database)
+    assert "ix_crawler_job_spider" not in _get_indexes("crawler_job", database)
+    assert "ix_crawler_job_workflow" not in _get_indexes("crawler_job", database)
     assert "ix_workflows_audit_logging_object_id" not in _get_indexes(
-        "workflows_audit_logging", db
+        "workflows_audit_logging", database
     )
     assert "ix_workflows_audit_logging_user_id" not in _get_indexes(
-        "workflows_audit_logging", db
+        "workflows_audit_logging", database
     )
-    assert "ix_workflows_object_data_type" not in _get_indexes("workflows_object", db)
-    assert "ix_workflows_object_id_parent" not in _get_indexes("workflows_object", db)
-    assert "ix_workflows_object_id_workflow" not in _get_indexes("workflows_object", db)
-    assert "ix_workflows_object_status" not in _get_indexes("workflows_object", db)
+    assert "ix_workflows_object_data_type" not in _get_indexes(
+        "workflows_object", database
+    )
+    assert "ix_workflows_object_id_parent" not in _get_indexes(
+        "workflows_object", database
+    )
+    assert "ix_workflows_object_id_workflow" not in _get_indexes(
+        "workflows_object", database
+    )
+    assert "ix_workflows_object_status" not in _get_indexes(
+        "workflows_object", database
+    )
 
 
-def test_upgrade(base_app, db, es):
+def test_upgrade(base_app, database):
     alembic = Alembic(base_app)
     # go down to first migration
     alembic.downgrade(target="b5be5fda2ee7")
 
     alembic.upgrade(target="7be4c8b5c5e8")
 
-    assert "workflows_record_sources" in _get_table_names(db)
-    assert "workflows_pending_record" in _get_table_names(db)
-    assert "crawler_workflows_object" in _get_table_names(db)
-    assert "crawler_job" in _get_table_names(db)
-    assert "workflows_audit_logging" in _get_table_names(db)
-    assert "workflows_buckets" in _get_table_names(db)
-    assert "workflows_object" in _get_table_names(db)
-    assert "workflows_workflow" in _get_table_names(db)
+    assert "workflows_record_sources" in _get_table_names(database)
+    assert "workflows_pending_record" in _get_table_names(database)
+    assert "crawler_workflows_object" in _get_table_names(database)
+    assert "crawler_job" in _get_table_names(database)
+    assert "workflows_audit_logging" in _get_table_names(database)
+    assert "workflows_buckets" in _get_table_names(database)
+    assert "workflows_object" in _get_table_names(database)
+    assert "workflows_workflow" in _get_table_names(database)
 
-    assert "ix_crawler_job_job_id" in _get_indexes("crawler_job", db)
-    assert "ix_crawler_job_scheduled" in _get_indexes("crawler_job", db)
-    assert "ix_crawler_job_spider" in _get_indexes("crawler_job", db)
-    assert "ix_crawler_job_workflow" in _get_indexes("crawler_job", db)
+    assert "ix_crawler_job_job_id" in _get_indexes("crawler_job", database)
+    assert "ix_crawler_job_scheduled" in _get_indexes("crawler_job", database)
+    assert "ix_crawler_job_spider" in _get_indexes("crawler_job", database)
+    assert "ix_crawler_job_workflow" in _get_indexes("crawler_job", database)
     assert "ix_workflows_audit_logging_object_id" in _get_indexes(
-        "workflows_audit_logging", db
+        "workflows_audit_logging", database
     )
     assert "ix_workflows_audit_logging_user_id" in _get_indexes(
-        "workflows_audit_logging", db
+        "workflows_audit_logging", database
     )
-    assert "ix_workflows_object_data_type" in _get_indexes("workflows_object", db)
-    assert "ix_workflows_object_id_parent" in _get_indexes("workflows_object", db)
-    assert "ix_workflows_object_id_workflow" in _get_indexes("workflows_object", db)
-    assert "ix_workflows_object_status" in _get_indexes("workflows_object", db)
+    assert "ix_workflows_object_data_type" in _get_indexes("workflows_object", database)
+    assert "ix_workflows_object_id_parent" in _get_indexes("workflows_object", database)
+    assert "ix_workflows_object_id_workflow" in _get_indexes(
+        "workflows_object", database
+    )
+    assert "ix_workflows_object_status" in _get_indexes("workflows_object", database)
 
     assert "ix_records_metadata_json_referenced_records_2_0" in _get_indexes(
-        "records_metadata", db
+        "records_metadata", database
     )
 
     alembic.upgrade(target="b646d3592dd5")
 
-    assert "idx_citations_cited" in _get_indexes("record_citations", db)
+    assert "idx_citations_cited" in _get_indexes("record_citations", database)
 
-    assert "record_citations" in _get_table_names(db)
+    assert "record_citations" in _get_table_names(database)
 
     alembic.upgrade(target="5ce9ef759ace")
 
     assert "ix_legacy_records_mirror_last_updated" in _get_indexes(
-        "legacy_records_mirror", db
+        "legacy_records_mirror", database
     )
     assert "ix_legacy_records_mirror_valid_collection" in _get_indexes(
-        "legacy_records_mirror", db
+        "legacy_records_mirror", database
     )
-    assert "legacy_records_mirror" in _get_table_names(db)
+    assert "legacy_records_mirror" in _get_table_names(database)
 
     alembic.upgrade(target="c6570e49b7b2")
 
-    assert "records_citations" in _get_table_names(db)
-    assert "record_citations" not in _get_table_names(db)
+    assert "records_citations" in _get_table_names(database)
+    assert "record_citations" not in _get_table_names(database)
 
-    assert "ix_records_citations_cited_id" in _get_indexes("records_citations", db)
-    assert "idx_citations_cited" not in _get_indexes("records_citations", db)
+    assert "ix_records_citations_cited_id" in _get_indexes(
+        "records_citations", database
+    )
+    assert "idx_citations_cited" not in _get_indexes("records_citations", database)
 
     alembic.upgrade(target="dc1ae5abe9d6")
 
-    assert "idx_pid_provider" in _get_indexes("pidstore_pid", db)
+    assert "idx_pid_provider" in _get_indexes("pidstore_pid", database)
 
     alembic.upgrade(target="788a3a61a635")
 
-    assert "idx_pid_provider" not in _get_indexes("pidstore_pid", db)
+    assert "idx_pid_provider" not in _get_indexes("pidstore_pid", database)
 
     alembic.upgrade(target="e5e43ad8f861")
-    assert "ix_files_object_key_head" in _get_indexes("files_object", db)
+    assert "ix_files_object_key_head" in _get_indexes("files_object", database)
 
     alembic.upgrade(target="f563233434cd")
 
-    assert "conference_literature" in _get_table_names(db)
+    assert "conference_literature" in _get_table_names(database)
     assert "ix_conference_literature_literature_uuid" in _get_indexes(
-        "conference_literature", db
+        "conference_literature", database
     )
     assert "ix_conference_literature_conference_uuid" in _get_indexes(
-        "conference_literature", db
+        "conference_literature", database
     )
-    assert "enum_conference_to_literature_relationship_type" in _get_custom_enums(db)
+    assert "enum_conference_to_literature_relationship_type" in _get_custom_enums(
+        database
+    )
 
 
-def _get_indexes(tablename, db):
+def _get_indexes(tablename, db_alembic):
     query = text(
         """
         SELECT indexname
@@ -183,10 +200,10 @@ def _get_indexes(tablename, db):
     """
     ).bindparams(tablename=tablename)
 
-    return [el.indexname for el in db.session.execute(query)]
+    return [el.indexname for el in db_alembic.session.execute(query)]
 
 
-def _get_sequences(db):
+def _get_sequences(db_alembic):
     query = text(
         """
         SELECT relname
@@ -195,17 +212,17 @@ def _get_sequences(db):
     """
     )
 
-    return [el.relname for el in db.session.execute(query)]
+    return [el.relname for el in db_alembic.session.execute(query)]
 
 
-def _get_table_names(db):
-    return db.engine.table_names()
+def _get_table_names(db_alembic):
+    return db_alembic.engine.table_names()
 
 
-def _get_custom_enums(db):
+def _get_custom_enums(db_alembic):
     query = """ SELECT pg_type.typname AS enumtype,  
         pg_enum.enumlabel AS enumlabel 
         FROM pg_type  
         JOIN pg_enum  
             ON pg_enum.enumtypid = pg_type.oid;"""
-    return set([a[0] for a in db.session.execute(query)])
+    return set([a[0] for a in db_alembic.session.execute(query)])


### PR DESCRIPTION
 * don't remove indexes from ES only remove data
 * There is ES error on version 5, when you try to remove records using delete_by_query and record have external visioning and it's current version is 0 it's failing. So in this case only way is to remove index. invenio 1.1.1 allows to remove all indexes only. After upgrading to invenio 1.2 we will be able to remove only specified index