### PR TITLE
tests: ressult not assigned error fix

### DIFF
--- a/backend/tests/integration-async/conftest.py
+++ b/backend/tests/integration-async/conftest.py
@@ -127,7 +127,7 @@ def retry_until_matched():
                 try:
                     result = _fun(*_args, **_kwargs)
                 except:
-                    pass
+                    break
                 _current_result = deepcopy(result)
                 if _expected_result:
                     if (


### PR DESCRIPTION
 * Fix for old error which was making async tests to fail randomly