### PR TITLE
travis: enable caching for poetry virtualenv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ cache:
   directories:
     - "$HOME/.cache/pypoetry"
     - "$HOME/.cache/pre-commit"
+    - "$HOME/virtualenv/"
 
 services:
   - docker


### PR DESCRIPTION
* this should speedup travis tests by ~5 minutes on every PR and on every merge to master except first run on every branch.