### PR TITLE
conferences: fix bugs

### DIFF
--- a/backend/inspirehep/records/config.py
+++ b/backend/inspirehep/records/config.py
@@ -533,7 +533,7 @@ RECORDS_REST_SORT_OPTIONS = {
         "mostrecent": {"title": "Most Recent", "fields": ["-_created"], "order": 1}
     },
     "records-conferences": {
-        "mostrecent": {"title": "Most Recent", "fields": ["-opening_date"], "order": 1}
+        "mostrecent": {"title": "Most Recent", "fields": ["opening_date"], "order": 1}
     },
 }
 

--- a/backend/inspirehep/records/marshmallow/conferences/common/proceeding_info_item.py
+++ b/backend/inspirehep/records/marshmallow/conferences/common/proceeding_info_item.py
@@ -11,4 +11,4 @@ from inspirehep.records.marshmallow.literature.common import PublicationInfoItem
 
 class ProceedingInfoItemSchemaV1(Schema):
     publication_info = fields.Nested(PublicationInfoItemSchemaV1, many=True)
-    record = fields.Raw(attribute="self")
+    control_number = fields.Raw(attribute="control_number")

--- a/backend/tests/unit/records/marshmallow/conferences/common/test_proceeding_info_item.py
+++ b/backend/tests/unit/records/marshmallow/conferences/common/test_proceeding_info_item.py
@@ -11,7 +11,7 @@ from inspirehep.records.marshmallow.conferences.common.proceeding_info_item impo
 
 def test_proceeding_info_item():
     expected_result = {
-        "record": {"$ref": "http://labs.inspirehep.net/api/literature/601055"},
+        "control_number": "601055",
         "publication_info": [
             {
                 "pubinfo_freetext": "Geneva, Switzerland: CERN (2002) 401 p",
@@ -22,6 +22,7 @@ def test_proceeding_info_item():
     }
 
     data = {
+        "control_number": "601055",
         "core": True,
         "self": {"$ref": "http://labs.inspirehep.net/api/literature/601055"},
         "publication_info": [

--- a/backend/tests/unit/records/marshmallow/conferences/test_base.py
+++ b/backend/tests/unit/records/marshmallow/conferences/test_base.py
@@ -45,7 +45,7 @@ def test_base_schema_proceedings():
                 "publication_info": [
                     {"pubinfo_freetext": "Geneva, Switzerland: CERN (2002) 401 p"}
                 ],
-                "record": {"$ref": "http://labs.inspirehep.net/api/literature/601055"},
+                "control_number": "601055",
             }
         ]
     }
@@ -54,6 +54,7 @@ def test_base_schema_proceedings():
         "proceedings": [
             {
                 "self": {"$ref": "http://labs.inspirehep.net/api/literature/601055"},
+                "control_number": "601055",
                 "publication_info": [
                     {
                         "cnum": "C01-08-26",

--- a/ui/src/actions/conferences.js
+++ b/ui/src/actions/conferences.js
@@ -3,6 +3,7 @@ import {
   CONFERENCE_SUCCESS,
   CONFERENCE_ERROR,
 } from './actionTypes';
+import { UI_SERIALIZER_REQUEST_OPTIONS } from '../common/http';
 import { httpErrorToActionPayload } from '../common/utils';
 
 function fetchingConference(recordId) {
@@ -31,7 +32,10 @@ function fetchConference(recordId) {
   return async (dispatch, getState, http) => {
     dispatch(fetchingConference(recordId));
     try {
-      const response = await http.get(`/conferences/${recordId}`);
+      const response = await http.get(
+        `/conferences/${recordId}`,
+        UI_SERIALIZER_REQUEST_OPTIONS
+      );
       dispatch(fetchConferenceSuccess(response.data));
     } catch (error) {
       const payload = httpErrorToActionPayload(error);

--- a/ui/src/conferences/components/ProceedingsAction.jsx
+++ b/ui/src/conferences/components/ProceedingsAction.jsx
@@ -7,13 +7,18 @@ import ExternalLink from '../../common/components/ExternalLink';
 import ActionsDropdownOrAction from '../../common/components/ActionsDropdownOrAction';
 import IconText from '../../common/components/IconText';
 import JournalInfo from '../../common/components/JournalInfo';
+import { LITERATURE } from '../../common/routes';
+
+function getProceedingHref(recordId) {
+  return `${LITERATURE}/${recordId}`;
+}
 
 function renderProceedingsDropdownAction(proceeding, index) {
-  const href = proceeding.getIn(['record', '$ref']);
+  const recordId = proceeding.get('control_number');
   const publicationInfo = proceeding.getIn(['publication_info', 0], Map());
   return (
-    <Menu.Item key={href}>
-      <ExternalLink href={href}>
+    <Menu.Item key={recordId}>
+      <ExternalLink href={getProceedingHref(recordId)}>
         {publicationInfo.has('journal_title') ? (
           <JournalInfo info={publicationInfo} />
         ) : (
@@ -25,8 +30,10 @@ function renderProceedingsDropdownAction(proceeding, index) {
 }
 
 function renderProceedingAction(proceeding, title) {
-  const href = proceeding.getIn(['record', '$ref']);
-  return <ExternalLink href={href}>{title}</ExternalLink>;
+  const recordId = proceeding.get('control_number');
+  return (
+    <ExternalLink href={getProceedingHref(recordId)}>{title}</ExternalLink>
+  );
 }
 
 const ACTION_TITLE = <IconText text="proceedings" type="book" />;

--- a/ui/src/conferences/components/__tests__/ProceedingsAction.test.jsx
+++ b/ui/src/conferences/components/__tests__/ProceedingsAction.test.jsx
@@ -7,9 +7,9 @@ import ProceedingsAction from '../ProceedingsAction';
 describe('ProceedingsAction', () => {
   it('renders proceedings', () => {
     const proceedings = fromJS([
-      { record: { $ref: 'https://localhost:3000/api/literature/12345' } },
+      { control_number: '12345' },
       {
-        record: { $ref: 'https://localhost:3000/api/literature/54321' },
+        control_number: '54321',
         publication_info: [{ journal_title: 'Journal 1' }],
       },
     ]);
@@ -18,9 +18,7 @@ describe('ProceedingsAction', () => {
   });
 
   it('renders single item', () => {
-    const proceedings = fromJS([
-      { record: { $ref: 'https://localhost:3000/literature/12345' } },
-    ]);
+    const proceedings = fromJS([{ control_number: '12345' }]);
     const wrapper = shallow(<ProceedingsAction proceedings={proceedings} />);
     expect(wrapper.dive()).toMatchSnapshot();
   });

--- a/ui/src/conferences/components/__tests__/__snapshots__/ProceedingsAction.test.jsx.snap
+++ b/ui/src/conferences/components/__tests__/__snapshots__/ProceedingsAction.test.jsx.snap
@@ -19,10 +19,10 @@ exports[`ProceedingsAction renders proceedings 1`] = `
     }
   >
     <MenuItem
-      key="https://localhost:3000/api/literature/12345"
+      key="12345"
     >
       <ExternalLink
-        href="https://localhost:3000/api/literature/12345"
+        href="/literature/12345"
       >
         <span>
           Proceedings 
@@ -31,10 +31,10 @@ exports[`ProceedingsAction renders proceedings 1`] = `
       </ExternalLink>
     </MenuItem>
     <MenuItem
-      key="https://localhost:3000/api/literature/54321"
+      key="54321"
     >
       <ExternalLink
-        href="https://localhost:3000/api/literature/54321"
+        href="/literature/54321"
       >
         <JournalInfo
           info={
@@ -52,7 +52,7 @@ exports[`ProceedingsAction renders proceedings 1`] = `
 exports[`ProceedingsAction renders single item 1`] = `
 <ListItemAction>
   <ExternalLink
-    href="https://localhost:3000/literature/12345"
+    href="/literature/12345"
   >
     <IconText
       text="proceedings"


### PR DESCRIPTION
* Fix bugs related to conferences ordering, using ui headers for conference detail call and sending control number in the proceedings
* INSPIR-2938, INSPIR-2947, INSPIR-2942