### PR TITLE
serializers: use actual record in metadata for serializers

### DIFF
--- a/backend/inspirehep/records/marshmallow/conferences/base.py
+++ b/backend/inspirehep/records/marshmallow/conferences/base.py
@@ -18,6 +18,8 @@ LOGGER = structlog.getLogger()
 
 
 class ConferencesRawSchema(RecordBaseSchema):
+    # These are attributes on a mixin that is used by ConferenceRecord class
+    # therefore can't be included by default RecordBaseSchema.include_original_fields
     number_of_contributions = fields.Raw()
     proceedings = fields.Nested(ProceedingInfoItemSchemaV1, many=True, dump_only=True)
     addresses = fields.Method("get_addresses")

--- a/backend/inspirehep/serializers.py
+++ b/backend/inspirehep/serializers.py
@@ -7,6 +7,7 @@
 
 import json
 
+import pytz
 from flask import current_app
 from invenio_records_rest.serializers.json import (
     JSONSerializer as InvenioJSONSerializer,
@@ -17,6 +18,25 @@ class JSONSerializer(InvenioJSONSerializer):
     def __init__(self, schema_class=None, index_name=None, **kwargs):
         self.index_name = index_name
         super().__init__(schema_class, **kwargs)
+
+    def preprocess_record(self, pid, record, links_factory=None, **kwargs):
+        """Prepare a record and persistent identifier for serialization.
+        We are overriding it to put the actual record in the metadata instead of a dict."""
+        return dict(
+            pid=pid,
+            metadata=record,
+            revision=record.revision_id,
+            created=(
+                pytz.utc.localize(record.created).isoformat()
+                if record.created
+                else None
+            ),
+            updated=(
+                pytz.utc.localize(record.updated).isoformat()
+                if record.updated
+                else None
+            ),
+        )
 
     def serialize_search(
         self, pid_fetcher, search_result, links=None, item_links_factory=None, **kwargs

--- a/backend/tests/integration/records/serializers/json/test_literature.py
+++ b/backend/tests/integration/records/serializers/json/test_literature.py
@@ -96,6 +96,7 @@ def test_literature_json_without_login(api_client, db, es, create_record):
         "report_numbers": [{"value": "PUBLIC", "hidden": False}],
         "documents": [{"key": "public", "url": "https://url.to/public/document"}],
         "_bucket": str(record._bucket),
+        "citation_count": 0,
     }
     expected_id = record["control_number"]
 
@@ -174,6 +175,7 @@ def test_literature_json_with_logged_in_cataloger(
             {"key": "public", "url": "https://url.to/public/document"},
         ],
         "_bucket": str(record._bucket),
+        "citation_count": 0,
     }
 
     response = api_client.get(f"/literature/{record_control_number}", headers=headers)
@@ -345,6 +347,7 @@ def test_literature_detail(api_client, db, es, create_record):
         "preprint_date": "2001-01-01",
         "date": "Jan 1, 2001",
         "_bucket": str(record._bucket),
+        "citation_count": 0,
     }
     response = api_client.get(f"/literature/{record_control_number}", headers=headers)
 


### PR DESCRIPTION
* This fixes missing properties from serializers because we were getting a dict before
* INSPIR-2946