### PR TITLE
ui: fix conference series search link

### DIFF
--- a/ui/src/conferences/components/ConferenceSeries.jsx
+++ b/ui/src/conferences/components/ConferenceSeries.jsx
@@ -16,7 +16,9 @@ function ConferenceSeries({ series }) {
         <span>Conference</span>
       )}
       {' in the '}
-      <Link to={`${CONFERENCES}?q=series.name:${name}`}>{name}</Link>
+      <Link to={`${CONFERENCES}?q=series.name:${name}&start_date=all`}>
+        {name}
+      </Link>
       {' series'}
     </span>
   );

--- a/ui/src/conferences/components/__tests__/__snapshots__/ConferenceSeries.test.jsx.snap
+++ b/ui/src/conferences/components/__tests__/__snapshots__/ConferenceSeries.test.jsx.snap
@@ -9,7 +9,7 @@ exports[`ConferenceSeries renders with name and number 1`] = `
    in the 
   <Link
     replace={false}
-    to="/conferences?q=series.name:Conference Name"
+    to="/conferences?q=series.name:Conference Name&start_date=all"
   >
     Conference Name
   </Link>
@@ -25,7 +25,7 @@ exports[`ConferenceSeries renders with only name 1`] = `
    in the 
   <Link
     replace={false}
-    to="/conferences?q=series.name:Conference Name"
+    to="/conferences?q=series.name:Conference Name&start_date=all"
   >
     Conference Name
   </Link>


### PR DESCRIPTION
Link to conference series search in conferece detail pages is fixed to
search in all comforerences, not only upcoming.