### PR TITLE
celery: don't fail acks_late tasks on worker crash

### DIFF
--- a/backend/inspirehep/config.py
+++ b/backend/inspirehep/config.py
@@ -124,6 +124,16 @@ CELERY_BEAT_SCHEDULE = {
     # },
 }
 
+
+class Annotator:
+    def annotate(self, task):
+        if task.acks_late:
+            # avoid failing tasks when worker gets killed
+            return {"reject_on_worker_lost": True}
+
+
+CELERY_TASK_ANNOTATIONS = [Annotator()]
+
 # Database
 # ========
 #: Database URI including user and password

--- a/backend/tests/integration/test_celery.py
+++ b/backend/tests/integration/test_celery.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CERN.
+#
+# inspirehep is free software; you can redistribute it and/or modify it under
+# the terms of the MIT License; see LICENSE file for more details.
+
+from inspirehep.celery import celery
+
+
+def test_celery_annotations():
+    task = celery.tasks["inspirehep.migrator.tasks.create_records_from_mirror_recids"]
+
+    assert task.acks_late is True
+    assert task.reject_on_worker_lost is True


### PR DESCRIPTION
* Tasks having `acks_late` set to true automatically retry when they are
  interrupted due to a worker crash. However, this doesn't happen by
  default when the worker is killed, unless `reject_on_worker_lost` is
  also set to true. To ensure this is always the case, this commit uses
  the Celery task annotations machinery to automatically annotate tasks
  having the former option with the latter.

Note that this won't solve the issue when a task in the head of the chord fails until https://github.com/celery/celery/pull/5700 gets released.