### PR TITLE
pid: return deleted pids if authorized

### DIFF
--- a/backend/inspirehep/pidstore/converters.py
+++ b/backend/inspirehep/pidstore/converters.py
@@ -4,11 +4,36 @@
 #
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
+
+from functools import partial
+
 import structlog
-from invenio_records_rest.utils import PIDConverter
+from invenio_records.api import Record
+from invenio_records_rest.utils import PIDConverter, obj_or_import_string
 from werkzeug.routing import PathConverter
 
+from .resolvers import InspireResolver
+
 LOGGER = structlog.getLogger()
+
+
+class InspirePIDConverter(PIDConverter):
+    """Just to use our own Resolver class"""
+
+    def __init__(
+        self, url_map, pid_type, getter=None, record_class=None, object_type="rec"
+    ):
+        super(PIDConverter, self).__init__(url_map)
+        getter = obj_or_import_string(
+            getter,
+            default=partial(
+                obj_or_import_string(record_class, default=Record).get_record,
+                with_deleted=True,
+            ),
+        )
+        self.resolver = InspireResolver(
+            pid_type=pid_type, object_type=object_type, getter=getter
+        )
 
 
 class DOIConverter(PIDConverter):

--- a/backend/inspirehep/pidstore/resolvers.py
+++ b/backend/inspirehep/pidstore/resolvers.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# inspirehep is free software; you can redistribute it and/or modify it under
+# the terms of the MIT License; see LICENSE file for more details.
+
+from invenio_pidstore.errors import (
+    PIDDeletedError,
+    PIDMissingObjectError,
+    PIDRedirectedError,
+    PIDUnregistered,
+)
+from invenio_pidstore.models import PersistentIdentifier
+from invenio_pidstore.resolver import Resolver
+from sqlalchemy.orm.exc import NoResultFound
+
+from inspirehep.accounts.api import is_superuser_or_cataloger_logged_in
+
+
+class InspireResolver(Resolver):
+    def resolve(self, pid_value):
+        """Override the `pid.is_deleted` case
+        Now if user is cataloger or superuser, PIDDeletedError is not raised
+        """
+        pid = PersistentIdentifier.get(self.pid_type, pid_value)
+
+        if pid.is_new() or pid.is_reserved():
+            raise PIDUnregistered(pid)
+
+        if pid.is_deleted() and not is_superuser_or_cataloger_logged_in():
+            obj_id = pid.get_assigned_object(object_type=self.object_type)
+            try:
+                obj = self.object_getter(obj_id) if obj_id else None
+            except NoResultFound:
+                obj = None
+            raise PIDDeletedError(pid, obj)
+
+        if pid.is_redirected():
+            raise PIDRedirectedError(pid, pid.get_redirect())
+
+        obj_id = pid.get_assigned_object(object_type=self.object_type)
+        if not obj_id:
+            raise PIDMissingObjectError(self.pid_type, pid_value)
+
+        return pid, self.object_getter(obj_id)

--- a/backend/inspirehep/records/config.py
+++ b/backend/inspirehep/records/config.py
@@ -96,7 +96,7 @@ LITERATURE.update(
             "application/vnd+inspire.latex.us+x-latex": f"{INSPIRE_SERIALIZERS}:literature_latex_us_response_search",
         },
         "list_route": "/literature/",
-        "item_route": '/literature/<pid(lit,record_class="inspirehep.records.api.LiteratureRecord"):pid_value>',
+        "item_route": '/literature/<inspirepid(lit,record_class="inspirehep.records.api.LiteratureRecord"):pid_value>',
         "create_permission_factory_imp": api_access_permission_check,
         "update_permission_factory_imp": api_access_permission_check,
         "suggesters": {
@@ -129,7 +129,7 @@ LITERATURE_AUTHORS.update(
         "search_factory_imp": "inspirehep.search.factories.search:search_factory_only_with_aggs",
         "pid_type": "lit",
         "list_route": "/literature/authors/",
-        "item_route": '/literature/<pid(lit,record_class="inspirehep.records.api.LiteratureRecord"):pid_value>/authors',
+        "item_route": '/literature/<inspirepid(lit,record_class="inspirehep.records.api.LiteratureRecord"):pid_value>/authors',
         "record_serializers": {
             "application/json": f"{INSPIRE_SERIALIZERS}:literature_authors_json_response"
         },
@@ -180,7 +180,7 @@ AUTHORS.update(
             }
         },
         "list_route": "/authors/",
-        "item_route": '/authors/<pid(aut,record_class="inspirehep.records.api:AuthorsRecord"):pid_value>',
+        "item_route": '/authors/<inspirepid(aut,record_class="inspirehep.records.api:AuthorsRecord"):pid_value>',
         "record_class": "inspirehep.records.api:AuthorsRecord",
         "search_factory_imp": "inspirehep.search.factories.search:search_factory_with_aggs",
         "create_permission_factory_imp": api_access_permission_check,
@@ -204,7 +204,7 @@ JOBS.update(
         "search_class": JobsSearch,
         "search_index": "records-jobs",
         "list_route": "/jobs/",
-        "item_route": '/jobs/<pid(job,record_class="inspirehep.records.api:JobsRecord"):pid_value>',
+        "item_route": '/jobs/<inspirepid(job,record_class="inspirehep.records.api:JobsRecord"):pid_value>',
         "record_class": "inspirehep.records.api:JobsRecord",
         "search_factory_imp": "inspirehep.search.factories.search:search_factory_with_aggs",
         "search_serializers": {
@@ -239,7 +239,7 @@ JOURNALS.update(
         "search_class": JournalsSearch,
         "search_index": "records-journals",
         "list_route": "/journals/",
-        "item_route": '/journals/<pid(jou,record_class="inspirehep.records.api:JournalsRecord"):pid_value>',
+        "item_route": '/journals/<inspirepid(jou,record_class="inspirehep.records.api:JournalsRecord"):pid_value>',
         "record_class": "inspirehep.records.api:JournalsRecord",
         "search_factory_imp": "inspirehep.search.factories.search:search_factory_with_aggs",
         "suggesters": {
@@ -265,7 +265,7 @@ EXPERIMENTS.update(
         "search_class": ExperimentsSearch,
         "search_index": "records-experiments",
         "list_route": "/experiments/",
-        "item_route": '/experiments/<pid(exp,record_class="inspirehep.records.api:ExperimentsRecord"):pid_value>',
+        "item_route": '/experiments/<inspirepid(exp,record_class="inspirehep.records.api:ExperimentsRecord"):pid_value>',
         "record_class": "inspirehep.records.api:ExperimentsRecord",
         "search_factory_imp": "inspirehep.search.factories.search:search_factory_with_aggs",
         "suggesters": {
@@ -292,7 +292,7 @@ CONFERENCES.update(
         "search_class": ConferencesSearch,
         "search_index": "records-conferences",
         "list_route": "/conferences/",
-        "item_route": '/conferences/<pid(con,record_class="inspirehep.records.api:ConferencesRecord"):pid_value>',
+        "item_route": '/conferences/<inspirepid(con,record_class="inspirehep.records.api:ConferencesRecord"):pid_value>',
         "record_class": "inspirehep.records.api:ConferencesRecord",
         "search_factory_imp": "inspirehep.search.factories.search:search_factory_with_aggs",
         "suggesters": {
@@ -348,7 +348,7 @@ DATA.update(
         "search_class": DataSearch,
         "search_index": "records-data",
         "list_route": "/data/",
-        "item_route": '/data/<pid(dat,record_class="inspirehep.records.api:DataRecord"):pid_value>',
+        "item_route": '/data/<inspirepid(dat,record_class="inspirehep.records.api:DataRecord"):pid_value>',
         "record_class": "inspirehep.records.api:DataRecord",
         "search_factory_imp": "inspirehep.search.factories.search:search_factory_with_aggs",
     }
@@ -362,7 +362,7 @@ INSTITUTIONS.update(
         "search_class": InstitutionsSearch,
         "search_index": "records-institutions",
         "list_route": "/institutions/",
-        "item_route": '/institutions/<pid(ins,record_class="inspirehep.records.api:InstitutionsRecord"):pid_value>',
+        "item_route": '/institutions/<inspirepid(ins,record_class="inspirehep.records.api:InstitutionsRecord"):pid_value>',
         "record_class": "inspirehep.records.api:InstitutionsRecord",
         "search_factory_imp": "inspirehep.search.factories.search:search_factory_with_aggs",
         "suggesters": {

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -77,6 +77,7 @@ setup(
         "invenio_base.api_converters": [
             "doipath = inspirehep.pidstore.converters:DOIPathConverter",
             "arxivpath = inspirehep.pidstore.converters:ArXivPathConverter",
+            "inspirepid = inspirehep.pidstore.converters:InspirePIDConverter",
         ],
         "invenio_jsonschemas.schemas": ["inspirehep_records_schemas = inspire_schemas"],
         "invenio_search.mappings": ["records = inspirehep.search.mappings"],


### PR DESCRIPTION
Now superuser and catalogers can display records that are marked
`deleted: true`.

* INSPIR-3068