### PR TITLE
ui: hot fix for lit citation summary bug

### DIFF
--- a/ui/src/literature/components/CitationSummaryBox.jsx
+++ b/ui/src/literature/components/CitationSummaryBox.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { Col, Row } from 'antd';
 import PropTypes from 'prop-types';
+import { Map } from 'immutable';
 
 import ContentBox from '../../common/components/ContentBox';
 import { LITERATURE_NS } from '../../reducers/search';
@@ -33,7 +34,7 @@ function CitationSummaryBox({ query, onQueryChange }) {
 }
 
 CitationSummaryBox.propTypes = {
-  query: PropTypes.object.isRequired,
+  query: PropTypes.instanceOf(Map),
   onQueryChange: PropTypes.func.isRequired,
 };
 

--- a/ui/src/literature/components/__tests__/CitationSummaryBox.test.jsx
+++ b/ui/src/literature/components/__tests__/CitationSummaryBox.test.jsx
@@ -1,12 +1,16 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { fromJS } from 'immutable';
 
 import CitationSummaryBox from '../CitationSummaryBox';
 
 describe('CitationSummaryBox', () => {
   it('renders', () => {
     const wrapper = shallow(
-      <CitationSummaryBox query={{ q: 'cern' }} onQueryChange={jest.fn()} />
+      <CitationSummaryBox
+        query={fromJS({ q: 'cern' })}
+        onQueryChange={jest.fn()}
+      />
     );
     expect(wrapper).toMatchSnapshot();
   });
@@ -14,11 +18,11 @@ describe('CitationSummaryBox', () => {
   // TODO: enable after https://github.com/airbnb/enzyme/issues/2086
   xit('calls onQueryChange initially and when query is different', () => {
     const onQueryChange = jest.fn();
-    const initialQuery = { q: 'cern' };
+    const initialQuery = fromJS({ q: 'cern' });
     const wrapper = shallow(
       <CitationSummaryBox query={initialQuery} onQueryChange={onQueryChange} />
     );
-    const newQuery = { experiment: 'cms' };
+    const newQuery = fromJS({ experiment: 'cms' });
 
     wrapper.setProps({ query: newQuery });
 

--- a/ui/src/literature/containers/CitationSummaryBoxContainer.jsx
+++ b/ui/src/literature/containers/CitationSummaryBoxContainer.jsx
@@ -2,7 +2,6 @@ import { connect } from 'react-redux';
 
 import { LITERATURE_NS } from '../../reducers/search';
 import CitationSummaryBox from '../components/CitationSummaryBox';
-import { convertAllImmutablePropsToJS } from '../../common/immutableToJS';
 import { fetchCitationSummary } from '../../actions/citations';
 
 const stateToProps = state => ({
@@ -11,10 +10,8 @@ const stateToProps = state => ({
 
 const dispatchToProps = dispatch => ({
   onQueryChange(query) {
-    dispatch(fetchCitationSummary(query));
+    dispatch(fetchCitationSummary(query.toJS()));
   },
 });
 
-export default connect(stateToProps, dispatchToProps)(
-  convertAllImmutablePropsToJS(CitationSummaryBox)
-);
+export default connect(stateToProps, dispatchToProps)(CitationSummaryBox);

--- a/ui/src/literature/containers/__tests__/CitationSummaryBoxContainer.test.jsx
+++ b/ui/src/literature/containers/__tests__/CitationSummaryBoxContainer.test.jsx
@@ -11,11 +11,12 @@ import { CITATIONS_SUMMARY_REQUEST } from '../../../actions/actionTypes';
 
 describe('CitationSummaryBoxContainer', () => {
   it('passes literature query', () => {
+    const query = fromJS({ sort: 'mostcited', q: 'query' });
     const store = getStoreWithState({
       search: fromJS({
         namespaces: {
           [LITERATURE_NS]: {
-            query: { sort: 'mostcited', q: 'query' },
+            query,
           },
         },
       }),
@@ -26,7 +27,7 @@ describe('CitationSummaryBoxContainer', () => {
       </Provider>
     );
     expect(wrapper.find(CitationSummaryBox)).toHaveProp({
-      query: { sort: 'mostcited', q: 'query' },
+      query,
     });
   });
 
@@ -52,7 +53,7 @@ describe('CitationSummaryBoxContainer', () => {
     const onQueryChange = wrapper
       .find(CitationSummaryBox)
       .prop('onQueryChange');
-    onQueryChange(newQuery);
+    onQueryChange(fromJS(newQuery));
 
     const expectedActions = [
       {


### PR DESCRIPTION
CitationSummaryBoxContainer keeps getting rerendering for some reason
(it will be investigated further) when user is logged in. This
rerendering was triggering endless fetch loop.