### PR TITLE
ui: move citation summary visibility state to url

### DIFF
--- a/ui/src/actions/__tests__/router.test.js
+++ b/ui/src/actions/__tests__/router.test.js
@@ -1,0 +1,23 @@
+import { replace } from 'connected-react-router';
+
+import { getStoreWithState } from '../../fixtures/store';
+import { setHash } from '../router';
+
+
+describe('router', () => {
+  it('create router.replace with new hash', () => {
+    const currentLocation = { pathname: '/pathname', search: '?param=value', hash: '#whatever' };
+    const store = getStoreWithState({
+      router: {
+        location: currentLocation
+      }
+    });
+    const hash = '#hash';
+    const expectedActions = [
+      replace({ ...currentLocation, hash })
+    ];
+
+    store.dispatch(setHash(hash));
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+});

--- a/ui/src/actions/__tests__/search.test.js
+++ b/ui/src/actions/__tests__/search.test.js
@@ -32,6 +32,9 @@ describe('search - action creators', () => {
       const namespace = LITERATURE_NS;
       const pathname = LITERATURE;
       const store = getStoreWithState({
+        router: {
+          location: { hash: '#hash' }
+        },
         search: fromJS({
           namespaces: {
             [namespace]: {
@@ -51,7 +54,7 @@ describe('search - action creators', () => {
 
       const expectedActions = [
         { type: types.SEARCH_REQUEST, payload: { namespace } },
-        push(url),
+        push(`${url}#hash`),
         { type: types.SEARCH_SUCCESS, payload: { namespace, data } },
       ];
       expect(store.getActions()).toEqual(expectedActions);
@@ -64,6 +67,7 @@ describe('search - action creators', () => {
         router: {
           location: {
             query: { q: 'test' },
+            hash: ''
           },
         },
         search: fromJS({

--- a/ui/src/actions/router.js
+++ b/ui/src/actions/router.js
@@ -1,0 +1,9 @@
+import { replace } from "connected-react-router"
+
+export function setHash(hash) {
+  return (dispatch, getState) => {
+    const { router } = getState();
+    const newLocation = { ...router.location, hash }
+    dispatch(replace(newLocation));
+  }
+}

--- a/ui/src/actions/search.js
+++ b/ui/src/actions/search.js
@@ -78,11 +78,13 @@ export function searchForCurrentQuery(namespace) {
     const url = `${pathname}?${queryString}`;
 
     if (!isEmbedded(namespace, state)) {
+      // for search pages, hash is used to carry UI state in search urls, like citation summary visibility
+      const urlWithHash = `${url}${state.router.location.hash}`
       if (isCurrentUrlOnlyMissingBaseQuery(namespace, state, queryString)) {
         // in order to allow going out of redirect loop of url <=> url + base query
-        dispatch(replace(url));
+        dispatch(replace(urlWithHash));
       } else {
-        dispatch(push(url));
+        dispatch(push(urlWithHash));
       }
     }
 

--- a/ui/src/literature/containers/CitationSummarySwitchContainer.jsx
+++ b/ui/src/literature/containers/CitationSummarySwitchContainer.jsx
@@ -1,0 +1,23 @@
+import { connect } from 'react-redux';
+
+import CitationSummarySwitch from '../components/CitationSummarySwitch';
+import { setHash } from '../../actions/router';
+
+export const WITH_CITATION_SUMMARY = '#with-citation-summary';
+
+export function isCitationSummaryEnabled(state) {
+  return state.router.location.hash === WITH_CITATION_SUMMARY;
+}
+
+const stateToProps = state => ({
+  checked: isCitationSummaryEnabled(state)
+});
+
+const dispatchToProps = dispatch => ({
+  onChange(isEnabled) {
+    const hash = isEnabled ? WITH_CITATION_SUMMARY : ''
+    dispatch(setHash(hash));
+  },
+});
+
+export default connect(stateToProps, dispatchToProps)(CitationSummarySwitch);

--- a/ui/src/literature/containers/LiteratureSearchContainer.jsx
+++ b/ui/src/literature/containers/LiteratureSearchContainer.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Row, Col } from 'antd';
 import { connect } from 'react-redux';
@@ -18,7 +18,7 @@ import VerticalDivider from '../../common/VerticalDivider';
 import { searchBaseQueriesUpdate } from '../../actions/search';
 import EmptyOrChildren from '../../common/components/EmptyOrChildren';
 import CitationSummaryBoxContainer from './CitationSummaryBoxContainer';
-import CitationSummarySwitch from '../components/CitationSummarySwitch';
+import CitationSummarySwitchContainer, { isCitationSummaryEnabled } from './CitationSummarySwitchContainer';
 
 function renderLiteratureItem(result, rank) {
   return <LiteratureItem metadata={result.get('metadata')} searchRank={rank} />;
@@ -35,6 +35,7 @@ function LiteratureSearch({
   noResultsTitle,
   noResultsDescription,
   isMainLiteratureSearch,
+  isCitationSummaryVisible,
 }) {
   const renderAggregations = useCallback(
     () => (
@@ -57,10 +58,6 @@ function LiteratureSearch({
     [namespace, baseQuery, baseAggregationsQuery, onBaseQueriesChange]
   );
 
-  const [isCitationSummaryVisible, setCitationSummaryVisible] = useState(false);
-  const onCitationSummarySwitchChange = useCallback(checked => {
-    setCitationSummaryVisible(checked);
-  }, []);
   return (
     <Row className="mt3" gutter={32} type="flex" justify="center">
       <EmptyOrChildren
@@ -92,10 +89,7 @@ function LiteratureSearch({
               <Col className="tr" span={16}>
                 {isMainLiteratureSearch && (
                   <span className="mr2">
-                    <CitationSummarySwitch
-                      checked={isCitationSummaryVisible}
-                      onChange={onCitationSummarySwitchChange}
-                    />
+                    <CitationSummarySwitchContainer />
                   </span>
                 )}
                 <SortByContainer namespace={namespace} />
@@ -135,6 +129,7 @@ LiteratureSearch.propTypes = {
   noResultsTitle: PropTypes.string,
   noResultsDescription: PropTypes.node,
   isMainLiteratureSearch: PropTypes.bool.isRequired,
+  isCitationSummaryVisible: PropTypes.bool.isRequired,
 };
 
 const stateToProps = (state, { namespace }) => ({
@@ -150,6 +145,7 @@ const stateToProps = (state, { namespace }) => ({
     namespace,
     'embedded',
   ]),
+  isCitationSummaryVisible: isCitationSummaryEnabled(state),
 });
 
 const dispatchToProps = dispatch => ({

--- a/ui/src/literature/containers/__tests__/CitationSummarySwitchContainer.test.jsx
+++ b/ui/src/literature/containers/__tests__/CitationSummarySwitchContainer.test.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+
+import { getStore, getStoreWithState } from '../../../fixtures/store';
+import CitationSummarySwitchContainer, { WITH_CITATION_SUMMARY } from '../CitationSummarySwitchContainer';
+import CitationSummarySwitch from '../../components/CitationSummarySwitch';
+import { setHash } from '../../../actions/router';
+
+jest.mock('../../../actions/router');
+
+
+describe('CitationSummarySwitchContainer', () => {
+  it('sets with-citation-summary hash to url when switch is enabled', () => {
+    setHash.mockImplementation(() => jest.fn());
+    const store = getStore();
+    const wrapper = mount(
+      <Provider store={store}>
+        <CitationSummarySwitchContainer />
+      </Provider>
+    );
+    const onSwitchChange = wrapper.find(CitationSummarySwitch).prop('onChange');
+    onSwitchChange(true);
+
+    expect(setHash).toHaveBeenCalledWith(WITH_CITATION_SUMMARY)
+  });
+
+  it('set checked if hash is set', () => {
+    const store = getStoreWithState({
+      router: {
+        location: { hash: WITH_CITATION_SUMMARY }
+      }
+    });
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <CitationSummarySwitchContainer />
+      </Provider>
+    );
+    expect(wrapper.find(CitationSummarySwitch)).toHaveProp({
+      checked: true
+    });
+  });
+
+  it('set unchecked if hash is not set', () => {
+    const store = getStoreWithState({
+      router: {
+        location: { hash: '' }
+      }
+    });
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <CitationSummarySwitchContainer />
+      </Provider>
+    );
+    expect(wrapper.find(CitationSummarySwitch)).toHaveProp({
+      checked: false
+    });
+  });
+});


### PR DESCRIPTION
Since we use location.search strictly for search query in search pages,
using location.hash was the only solution. Otherwise it would mess up
search code unnecessarily too much.

INSPIR-3124