### PR TITLE
files: change the original_url logic 

### DIFF
--- a/backend/inspirehep/files/api/s3.py
+++ b/backend/inspirehep/files/api/s3.py
@@ -131,3 +131,12 @@ class S3:
             else:
                 LOGGER.warning(exc=e, key=key)
                 raise
+
+    @staticmethod
+    def is_s3_url(url):
+        """Checks if the url is an S3 url.
+
+        :param url: the given url.
+        :return: boolean
+        """
+        return url.startswith(current_app.config.get("S3_HOSTNAME"))

--- a/backend/inspirehep/records/api/literature.py
+++ b/backend/inspirehep/records/api/literature.py
@@ -325,14 +325,20 @@ class LiteratureRecord(
             current_s3_instance.upload_file(
                 BytesIO(file_data), new_key, filename, mimetype, acl
             )
-        return {
+        result = {
             "key": new_key,
-            "original_url": original_url or url,
             "filename": filename,
             "url": current_s3_instance.get_file_url(new_key),
             "mimetype": mimetype,
             "size": size,
         }
+        if (
+            url.startswith("http")
+            and not current_s3_instance.is_s3_url(url)
+            and not original_url
+        ):
+            result["original_url"] = url
+        return result
 
 
 def import_article(identifier):

--- a/backend/inspirehep/records/config.py
+++ b/backend/inspirehep/records/config.py
@@ -583,9 +583,3 @@ LITERATURE_SOURCE_EXCLUDES_BY_CONTENT_TYPE = {
         "_bibtex_display",
     ]
 }
-
-FILES_REST_PERMISSION_FACTORY = allow_all
-
-FILES_API_PREFIX = "/api/files"
-
-FILES_DOWNLOAD_MAX_RETRIES = 2

--- a/backend/inspirehep/records/utils.py
+++ b/backend/inspirehep/records/utils.py
@@ -80,10 +80,14 @@ def requests_retry_session(retries=3):
 def download_file_from_url(url):
     download_url = url if url.startswith("http") else f"{get_inspirehep_url()}{url}"
     max_retries = current_app.config.get("FILES_DOWNLOAD_MAX_RETRIES", 3)
-    request = requests_retry_session(retries=max_retries).get(download_url, stream=True)
-    if not request:
+    try:
+        request = requests_retry_session(retries=max_retries).get(
+            download_url, stream=True
+        )
+        request.raise_for_status()
+    except requests.exceptions.RequestException as exc:
         raise DownloadFileError(
-            f"Cannot download file from url {download_url}. Status_code: {request.status_code}. Reason: {request.reason}"
+            f"Cannot download file from url {download_url}. Reason: {exc}"
         )
     return request.content
 

--- a/backend/tests/integration/files/test_api_s3.py
+++ b/backend/tests/integration/files/test_api_s3.py
@@ -77,14 +77,13 @@ def test_file_exists_when_file_is_missing(base_app, appctx, s3, create_s3_bucket
     assert result == expected_result
 
 
-def test_file_exists_when_error_occurs(base_app, appctx):
-    with patch.object(current_s3_instance, "resource") as mock_resource:
-        error_response = {"Error": {"Code": "500", "Message": "Error"}}
-        mock_resource.Object(
-            current_s3_instance.get_bucket(KEY), KEY
-        ).load.side_effect = ClientError(error_response, "load")
-        with pytest.raises(ClientError):
-            current_s3_instance.file_exists(KEY)
+@patch(
+    "inspirehep.files.api.current_s3_instance.client.head_object",
+    side_effect=ClientError({"Error": {"Code": "500", "Message": "Error"}}, "load"),
+)
+def test_file_exists_when_error_occurs(mock_client_head_object, base_app, appctx):
+    with pytest.raises(ClientError):
+        current_s3_instance.file_exists(KEY)
 
 
 def test_file_exists_when_file_is_there(

--- a/backend/tests/integration/migrator/cassettes/test_migrate_record_from_mirror_invalidates_local_file_cache_if_no_local_file.yaml
+++ b/backend/tests/integration/migrator/cassettes/test_migrate_record_from_mirror_invalidates_local_file_cache_if_no_local_file.yaml
@@ -33337,22 +33337,22 @@ interactions:
         NDcgMCBSIC9Sb290IDM2NDYgMCBSIC9TaXplIDM2NTEgPj4Kc3RhcnR4cmVmCjE4MjYxNjgKJSVF
         T0YK
     headers:
+      Accept-Ranges:
+      - bytes
       Connection:
       - keep-alive
+      Content-Length:
+      - '1899357'
       Content-Type:
       - application/octet-stream
       Date:
-      - Fri, 08 Nov 2019 17:11:25 GMT
+      - Wed, 05 Feb 2020 15:37:24 GMT
       ETag:
-      - W/"54b33476-1cfb5d"
+      - '"54b33476-1cfb5d"'
       Last-Modified:
       - Mon, 12 Jan 2015 02:41:58 GMT
       Server:
       - nginx/1.16.1
-      Transfer-Encoding:
-      - chunked
-      content-length:
-      - '1899357'
     status:
       code: 200
       message: OK

--- a/backend/tests/integration/records/api/cassettes/test_adding_record_with_documents_with_full_url_without_original_url.yaml
+++ b/backend/tests/integration/records/api/cassettes/test_adding_record_with_documents_with_full_url_without_original_url.yaml
@@ -12421,7 +12421,7 @@ interactions:
       Content-Type:
       - application/pdf
       Date:
-      - Tue, 28 Jan 2020 11:28:43 GMT
+      - Wed, 05 Feb 2020 14:24:37 GMT
       ETag:
       - '"7f046e70-ac7ed-583d5233c9980"'
       Keep-Alive:
@@ -12432,7 +12432,7 @@ interactions:
       - Apache
       Set-Cookie:
       - INVENIOSESSIONstub=NO; path=/; HttpOnly
-      - INVENIOSESSION=483c924fb94167cfcd8e7533eb002352; path=/; HttpOnly
+      - INVENIOSESSION=24c622fddd5ca68c5c128b172a998509; path=/; HttpOnly
       Vary:
       - Cookie,ETag,Cache-Control,User-Agent
     status:


### PR DESCRIPTION
* Populate original_url with url only if it is not already populated and if it url is not an s3 url and the url is not relative
* Populating the original_url is used in the afs cache in the migration