### PR TITLE
Travis deploy changes

### DIFF
--- a/build-and-deploy.sh
+++ b/build-and-deploy.sh
@@ -56,6 +56,7 @@ sentryQA() {
   export SENTRY_AUTH_TOKEN=${SENTRY_QA_AUTH_TOKEN}
   export SENTRY_URL="https://sentry.inspirebeta.net"
   export SENTRY_ORG="inspire-qa"
+  sentry-cli releases new -p "ui" -p "hep" ${TAG}
   sentry-cli releases set-commits --auto ${TAG}
 }
 

--- a/build-and-deploy.sh
+++ b/build-and-deploy.sh
@@ -23,11 +23,22 @@ buildPush() {
   context="${1}"
   image="${2}"
   echo "Building docker image for ${context}"
+  retry docker pull "${image}"
+  if docker pull "${image}:build-stage"; then
+    retry docker build \
+    --build-arg VERSION="${TAG}" \
+    -t "${image}:build-stage" \
+    "${context}" \
+    --cache-from "${image}:build-stage" \
+    --target "build-stage" 
+    retry docker push "${image}:build-stage"
+  fi
   retry docker build \
     --build-arg VERSION="${TAG}" \
     -t "${image}:${TAG}" \
     -t "${image}" \
-    "${context}"
+    "${context}" \
+    --cache-from "${image}"
 
   echo "Pushing image to ${image}:${TAG}"
   retry docker push "${image}:${TAG}"

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,4 +1,3 @@
-ARG VERSION
 
 FROM node:lts-jessie as build-stage
 
@@ -7,6 +6,7 @@ ENV PATH /usr/src/app/node_modules/.bin:$PATH
 COPY package.json yarn.lock /usr/src/app/
 RUN yarn install
 COPY . /usr/src/app
+ARG VERSION
 ENV REACT_APP_VERSION="${VERSION}"
 RUN yarn run build
 
@@ -16,4 +16,5 @@ FROM nginx:1.17-alpine
 EXPOSE 8080
 COPY docker/nginx/config/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build-stage /usr/src/app/build /usr/share/nginx/html
+ARG VERSION
 ENV VERSION="${VERSION}"


### PR DESCRIPTION
* explicitly create sentry releases
* use the current images as docker build cache