### PR TITLE
files: properly handle DownloadFileError in migration

### DIFF
--- a/backend/inspirehep/migrator/utils.py
+++ b/backend/inspirehep/migrator/utils.py
@@ -114,6 +114,8 @@ def replace_afs_file_locations_with_local(record):
 
 def remove_cached_afs_file_locations(original_urls):
     redis = StrictRedis.from_url(current_app.config["CACHE_REDIS_URL"])
+    if not original_urls:
+        return None
     return redis.hdel("afs_file_locations", *original_urls)
 
 


### PR DESCRIPTION
* handle DownloadFileError in the migration so that if the error is not caused by invalid cache and not being able to download local file, the error will be logged properly (instead of throwing hdel is not receiving all arguments) and the error will be on the mirror record too