### PR TITLE
ui: improve initial assets load speed

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -6,7 +6,7 @@
   "bundlesize": [
     {
       "path": "./build/**/*.js",
-      "maxSize": "375 kB"
+      "maxSize": "900 kB"
     }
   ],
   "scripts": {
@@ -17,6 +17,7 @@
     "test:unit": "craco test",
     "test:unit:log": "craco test --verbose=false",
     "test:size": "bundlesize",
+    "analyze": "source-map-explorer 'build/static/js/*.js'",
     "eject": "react-scripts eject",
     "lint":
       "./node_modules/eslint/bin/eslint.js ./src --ext .js,.jsx --config .eslintrc"
@@ -89,6 +90,7 @@
     "react-test-renderer": "^16.2.0",
     "redux-logger": "^3.0.6",
     "redux-mock-store": "^1.5.1",
+    "source-map-explorer": "^2.3.1",
     "webpack-filter-warnings-plugin": "^1.2.1"
   },
   "browserslist": [">0.2%", "not dead", "not ie <= 11", "not op_mini all"]

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -28,50 +28,25 @@ import {
 import UserFeedback from './common/components/UserFeedback';
 import { setUserCategoryFromRoles } from './tracker';
 import { fetchLoggedInUser } from './actions/user';
+import Home from './home';
+import Literature from './literature';
+import Conferences from './conferences';
+import Authors from './authors';
+import Jobs from './jobs';
+import User from './user';
+import Errors from './errors';
 
 const Holdingpen$ = Loadable({
   loader: () => import('./holdingpen'),
-  loading: Loading,
-});
-const Literature$ = Loadable({
-  loader: () => import('./literature'),
-  loading: Loading,
-});
-const Authors$ = Loadable({
-  loader: () => import('./authors'),
-  loading: Loading,
-});
-const Jobs$ = Loadable({
-  loader: () => import('./jobs'),
-  loading: Loading,
-});
-const Conferences$ = Loadable({
-  loader: () => import('./conferences'),
-  loading: Loading,
-});
-const Home$ = Loadable({
-  loader: () => import('./home'),
-  loading: Loading,
-});
-const User$ = Loadable({
-  loader: () => import('./user'),
   loading: Loading,
 });
 const Submissions$ = Loadable({
   loader: () => import('./submissions'),
   loading: Loading,
 });
-const Errors$ = Loadable({
-  loader: () => import('./errors'),
-  loading: Loading,
-});
 
 function App({ userRoles, dispatch }) {
   const [headerHeight, setHeaderHeight] = useState(0);
-
-  useEffect(() => {
-    Loadable.preloadAll();
-  }, []);
 
   useEffect(
     () => {
@@ -92,15 +67,15 @@ function App({ userRoles, dispatch }) {
       <Header onHeightChange={setHeaderHeight} />
       <Layout.Content className="content" style={{ marginTop: headerHeight }}>
         <SafeSwitch id="main">
-          <Route exact path={HOME} component={Home$} />
-          <Route path={USER} component={User$} />
+          <Route exact path={HOME} component={Home} />
+          <Route path={USER} component={User} />
           <PrivateRoute path={HOLDINGPEN} component={Holdingpen$} />
-          <Route path={LITERATURE} component={Literature$} />
-          <Route path={AUTHORS} component={Authors$} />
-          <Route path={JOBS} component={Jobs$} />
-          <Route path={CONFERENCES} component={Conferences$} />
+          <Route path={LITERATURE} component={Literature} />
+          <Route path={AUTHORS} component={Authors} />
+          <Route path={JOBS} component={Jobs} />
+          <Route path={CONFERENCES} component={Conferences} />
           <PrivateRoute path={SUBMISSIONS} component={Submissions$} />
-          <Route path={ERRORS} component={Errors$} />
+          <Route path={ERRORS} component={Errors} />
         </SafeSwitch>
         <UserFeedback />
       </Layout.Content>

--- a/ui/src/__tests__/App.test.jsx
+++ b/ui/src/__tests__/App.test.jsx
@@ -3,6 +3,7 @@ import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { mount } from 'enzyme';
 import { fromJS, List } from 'immutable';
+import Loadable from 'react-loadable';
 
 import { getStore, getStoreWithState } from '../fixtures/store';
 import App from '../App';
@@ -63,7 +64,7 @@ describe('App', () => {
     expect(store.getActions()).toEqual(expectedActions);
   });
 
-  it('navigates to Holdingpen when /holdingpen if logged in', () => {
+  it('navigates to Holdingpen when /holdingpen if logged in', async () => {
     const store = getStoreWithState({
       user: fromJS({
         loggedIn: true,
@@ -79,10 +80,12 @@ describe('App', () => {
         </MemoryRouter>
       </Provider>
     );
+    await Loadable.preloadAll();
+    wrapper.update();
     expect(wrapper.find(Holdingpen)).toExist();
   });
 
-  it('does not navigate to Holdingpen when /holdingpen if not logged in', () => {
+  it('does not navigate to Holdingpen when /holdingpen if not logged in', async () => {
     const store = getStoreWithState({
       user: fromJS({
         loggedIn: false,
@@ -98,6 +101,8 @@ describe('App', () => {
         </MemoryRouter>
       </Provider>
     );
+    await Loadable.preloadAll();
+    wrapper.update();
     expect(wrapper.find(Holdingpen)).not.toExist();
   });
 
@@ -145,7 +150,7 @@ describe('App', () => {
     expect(wrapper.find(Conferences)).toExist();
   });
 
-  it('navigates to Submissions when /submissions if logged in', () => {
+  it('navigates to Submissions when /submissions if logged in', async () => {
     const store = getStoreWithState({
       user: fromJS({
         loggedIn: true,
@@ -161,10 +166,12 @@ describe('App', () => {
         </MemoryRouter>
       </Provider>
     );
+    await Loadable.preloadAll();
+    wrapper.update();
     expect(wrapper.find(Submissions)).toExist();
   });
 
-  it('navigates to Submissions when /submissions if not logged in', () => {
+  it('navigates to Submissions when /submissions if not logged in', async () => {
     const store = getStoreWithState({
       user: fromJS({
         loggedIn: false,
@@ -180,6 +187,8 @@ describe('App', () => {
         </MemoryRouter>
       </Provider>
     );
+    await Loadable.preloadAll();
+    wrapper.update();
     expect(wrapper.find(Submissions)).not.toExist();
   });
 

--- a/ui/src/authors/index.jsx
+++ b/ui/src/authors/index.jsx
@@ -1,26 +1,17 @@
 import React, { Component } from 'react';
 import { Route } from 'react-router-dom';
-import Loadable from 'react-loadable';
 
 import { AUTHORS } from '../common/routes';
-import Loading from '../common/components/Loading';
 import './index.scss';
-
-const SearchPage$ = Loadable({
-  loader: () => import('./containers/SearchPageContainer'),
-  loading: Loading,
-});
-const DetailPage$ = Loadable({
-  loader: () => import('./containers/DetailPageContainer'),
-  loading: Loading,
-});
+import SearchPageContainer from './containers/SearchPageContainer';
+import DetailPageContainer from './containers/DetailPageContainer';
 
 class Authors extends Component {
   render() {
     return (
       <div className="__Authors__">
-        <Route exact path={AUTHORS} component={SearchPage$} />
-        <Route exact path={`${AUTHORS}/:id`} component={DetailPage$} />
+        <Route exact path={AUTHORS} component={SearchPageContainer} />
+        <Route exact path={`${AUTHORS}/:id`} component={DetailPageContainer} />
       </div>
     );
   }

--- a/ui/src/common/VerticalDivider/VerticalDivider.scss
+++ b/ui/src/common/VerticalDivider/VerticalDivider.scss
@@ -1,4 +1,4 @@
 .__VerticalDivider__ {
-  background: $text-color;
-  margin-left: $padding-md - 1px;
+  background: $text-color !important;
+  margin-left: $padding-md - 1px !important;
 }

--- a/ui/src/conferences/index.jsx
+++ b/ui/src/conferences/index.jsx
@@ -1,25 +1,21 @@
 import React, { Component } from 'react';
 import { Route } from 'react-router-dom';
-import Loadable from 'react-loadable';
 
 import { CONFERENCES } from '../common/routes';
-import Loading from '../common/components/Loading';
 
-const SearchPage$ = Loadable({
-  loader: () => import('./containers/SearchPageContainer'),
-  loading: Loading,
-});
-const DetailPage$ = Loadable({
-  loader: () => import('./containers/DetailPageContainer'),
-  loading: Loading,
-});
+import SearchPageContainer from './containers/SearchPageContainer';
+import DetailPageContainer from './containers/DetailPageContainer';
 
 class Conferences extends Component {
   render() {
     return (
       <div className="w-100">
-        <Route exact path={CONFERENCES} component={SearchPage$} />
-        <Route exact path={`${CONFERENCES}/:id`} component={DetailPage$} />
+        <Route exact path={CONFERENCES} component={SearchPageContainer} />
+        <Route
+          exact
+          path={`${CONFERENCES}/:id`}
+          component={DetailPageContainer}
+        />
       </div>
     );
   }

--- a/ui/src/jobs/index.jsx
+++ b/ui/src/jobs/index.jsx
@@ -1,26 +1,17 @@
 import React, { Component } from 'react';
 import { Route } from 'react-router-dom';
-import Loadable from 'react-loadable';
 
 import { JOBS } from '../common/routes';
-import Loading from '../common/components/Loading';
 import './index.scss';
-
-const SearchPage$ = Loadable({
-  loader: () => import('./containers/SearchPageContainer'),
-  loading: Loading,
-});
-const DetailPage$ = Loadable({
-  loader: () => import('./containers/DetailPageContainer'),
-  loading: Loading,
-});
+import SearchPageContainer from './containers/SearchPageContainer';
+import DetailPageContainer from './containers/DetailPageContainer';
 
 class Jobs extends Component {
   render() {
     return (
       <div className="__Jobs__">
-        <Route exact path={JOBS} component={SearchPage$} />
-        <Route exact path={`${JOBS}/:id`} component={DetailPage$} />
+        <Route exact path={JOBS} component={SearchPageContainer} />
+        <Route exact path={`${JOBS}/:id`} component={DetailPageContainer} />
       </div>
     );
   }

--- a/ui/src/literature/index.jsx
+++ b/ui/src/literature/index.jsx
@@ -1,26 +1,21 @@
 import React, { Component } from 'react';
 import { Route } from 'react-router-dom';
-import Loadable from 'react-loadable';
 
-import Loading from '../common/components/Loading';
 import './index.scss';
 import { LITERATURE } from '../common/routes';
-
-const SearchPage$ = Loadable({
-  loader: () => import('./containers/SearchPage'),
-  loading: Loading,
-});
-const DetailPage$ = Loadable({
-  loader: () => import('./containers/DetailPageContainer'),
-  loading: Loading,
-});
+import SearchPage from './containers/SearchPage';
+import DetailPageContainer from './containers/DetailPageContainer';
 
 class Literature extends Component {
   render() {
     return (
       <div className="__Literature__">
-        <Route exact path={LITERATURE} component={SearchPage$} />
-        <Route exact path={`${LITERATURE}/:id`} component={DetailPage$} />
+        <Route exact path={LITERATURE} component={SearchPage} />
+        <Route
+          exact
+          path={`${LITERATURE}/:id`}
+          component={DetailPageContainer}
+        />
       </div>
     );
   }

--- a/ui/src/submissions/index.jsx
+++ b/ui/src/submissions/index.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { Route, Redirect } from 'react-router-dom';
-import Loadable from 'react-loadable';
 
 import {
   SUBMISSIONS_AUTHOR,
@@ -11,58 +10,17 @@ import {
   SUBMISSION_SUCCESS,
 } from '../common/routes';
 
-import Loading from '../common/components/Loading';
 import SafeSwitch from '../common/components/SafeSwitch';
 import DocumentHead from '../common/components/DocumentHead';
-
-const AuthorSubmissionPage$ = Loadable({
-  loader: () => import('./authors/containers/AuthorSubmissionPageContainer'),
-  loading: Loading,
-});
-
-const AuthorUpdateSubmissionPage$ = Loadable({
-  loader: () =>
-    import('./authors/containers/AuthorUpdateSubmissionPageContainer'),
-  loading: Loading,
-});
-
-const LiteratureSubmissionPage$ = Loadable({
-  loader: () =>
-    import('./literature/containers/LiteratureSubmissionPageContainer'),
-  loading: Loading,
-});
-
-const JobSubmissionPage$ = Loadable({
-  loader: () => import('./jobs/containers/JobSubmissionPageContainer'),
-  loading: Loading,
-});
-
-const JobUpdateSubmissionPage$ = Loadable({
-  loader: () => import('./jobs/containers/JobUpdateSubmissionPageContainer'),
-  loading: Loading,
-});
-
-const SubmissionSuccessPage$ = Loadable({
-  loader: () => import('./common/components/SubmissionSuccessPage'),
-  loading: Loading,
-});
-
-const JobUpdateSubmissionSuccessPage$ = Loadable({
-  loader: () => import('./jobs/components/JobUpdateSubmissionSuccessPage'),
-  loading: Loading,
-});
-
-const ConferenceSubmissionPage$ = Loadable({
-  loader: () =>
-    import('./conferences/containers/ConferenceSubmissionPageContainer'),
-  loading: Loading,
-});
-
-const ConferenceSubmissionsSuccessPage$ = Loadable({
-  loader: () =>
-    import('./conferences/containers/ConferenceSubmissionSuccessPageContainer'),
-  loading: Loading,
-});
+import AuthorSubmissionPageContainer from './authors/containers/AuthorSubmissionPageContainer';
+import AuthorUpdateSubmissionPageContainer from './authors/containers/AuthorUpdateSubmissionPageContainer';
+import LiteratureSubmissionPageContainer from './literature/containers/LiteratureSubmissionPageContainer';
+import JobSubmissionPageContainer from './jobs/containers/JobSubmissionPageContainer';
+import JobUpdateSubmissionPageContainer from './jobs/containers/JobUpdateSubmissionPageContainer';
+import ConferenceSubmissionPageContainer from './conferences/containers/ConferenceSubmissionPageContainer';
+import JobUpdateSubmissionSuccessPage from './jobs/components/JobUpdateSubmissionSuccessPage';
+import ConferenceSubmissionSuccessPageContainer from './conferences/containers/ConferenceSubmissionSuccessPageContainer';
+import SubmissionSuccessPage from './common/components/SubmissionSuccessPage';
 
 class Submissions extends Component {
   render() {
@@ -75,33 +33,33 @@ class Submissions extends Component {
             <Route
               exact
               path={SUBMISSIONS_AUTHOR}
-              component={AuthorSubmissionPage$}
+              component={AuthorSubmissionPageContainer}
             />
             <Route
               exact
               path={`${SUBMISSIONS_AUTHOR}/:id`}
-              component={AuthorUpdateSubmissionPage$}
+              component={AuthorUpdateSubmissionPageContainer}
             />
 
             <Route
               exact
               path={SUBMISSIONS_LITERATURE}
-              component={LiteratureSubmissionPage$}
+              component={LiteratureSubmissionPageContainer}
             />
             <Route
               exact
               path={SUBMISSIONS_JOB}
-              component={JobSubmissionPage$}
+              component={JobSubmissionPageContainer}
             />
             <Route
               exact
               path={`${SUBMISSIONS_JOB}/:id`}
-              component={JobUpdateSubmissionPage$}
+              component={JobUpdateSubmissionPageContainer}
             />
             <Route
               exact
               path={SUBMISSIONS_CONFERENCE}
-              component={ConferenceSubmissionPage$}
+              component={ConferenceSubmissionPageContainer}
             />
             <Redirect
               exact
@@ -126,18 +84,18 @@ class Submissions extends Component {
             <Route
               exact
               path={`${SUBMISSIONS_JOB}/:id/success`}
-              component={JobUpdateSubmissionSuccessPage$}
+              component={JobUpdateSubmissionSuccessPage}
             />
             <Route
               exact
               path={`${SUBMISSIONS_CONFERENCE}/new/success`}
-              component={ConferenceSubmissionsSuccessPage$}
+              component={ConferenceSubmissionSuccessPageContainer}
             />
 
             <Route
               exact
               path={SUBMISSION_SUCCESS}
-              component={SubmissionSuccessPage$}
+              component={SubmissionSuccessPage}
             />
           </SafeSwitch>
         </div>

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -816,6 +816,11 @@
     "@svgr/core" "^2.4.1"
     loader-utils "^1.1.0"
 
+"@types/color-name@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
+  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
 "@types/node@*":
   version "10.12.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.10.tgz#4fa76e6598b7de3f0cb6ec3abacc4f59e5b3a2ce"
@@ -1101,6 +1106,11 @@ ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
 
+ansi-regex@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
+  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -1110,6 +1120,14 @@ ansi-styles@^3.1.0, ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   dependencies:
     color-convert "^1.9.0"
+
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
+  integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
+  dependencies:
+    "@types/color-name" "^1.1.1"
+    color-convert "^2.0.1"
 
 antd@^3.4.1:
   version "3.20.3"
@@ -1902,6 +1920,11 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
+btoa@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/btoa/-/btoa-1.2.1.tgz#01a9909f8b2c93f6bf680ba26131eb30f7fa3d73"
+  integrity sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==
+
 buffer-alloc-unsafe@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
@@ -2128,6 +2151,14 @@ chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
+  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -2244,6 +2275,15 @@ cliui@^4.0.0:
     strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
 
+cliui@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"
+  integrity sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^6.2.0"
+
 clone-deep@^0.2.4:
   version "0.2.4"
   resolved "http://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz#4e73dd09e9fb971cc38670c5dced9c1896481cc6"
@@ -2294,9 +2334,21 @@ color-convert@^1.9.0, color-convert@^1.9.1:
   dependencies:
     color-name "1.1.3"
 
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
 color-name@1.1.3, color-name@^1.0.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 color-string@^1.5.2:
   version "1.5.3"
@@ -2439,6 +2491,13 @@ content-type@~1.0.4:
 convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.5.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
+  dependencies:
+    safe-buffer "~5.1.1"
+
+convert-source-map@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
+  integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
   dependencies:
     safe-buffer "~5.1.1"
 
@@ -2950,7 +3009,7 @@ debug@^4.1.0:
   dependencies:
     ms "^2.1.1"
 
-decamelize@^1.1.1, decamelize@^1.1.2:
+decamelize@^1.1.1, decamelize@^1.1.2, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
@@ -3291,6 +3350,11 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
+ejs@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.0.1.tgz#30c8f6ee9948502cc32e85c37a3f8b39b5a614a5"
+  integrity sha512-cuIMtJwxvzumSAkqaaoGY/L6Fc/t6YvoP9/VIaK0V/CyqKLEQ8sqODmYfy/cjXEdZ9+OOL8TecbJu+1RsofGDw==
+
 electron-to-chromium@^1.3.62, electron-to-chromium@^1.3.82:
   version "1.3.85"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.85.tgz#5c46f790aa96445cabc57eb9d17346b1e46476fe"
@@ -3310,6 +3374,11 @@ elliptic@^6.0.0:
 emoji-regex@^6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.5.1.tgz#9baea929b155565c11ea41c6626eaa65cef992c2"
+
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
 emojis-list@^2.0.0:
   version "2.1.0"
@@ -3468,7 +3537,7 @@ es-to-primitive@^1.1.1, es-to-primitive@^1.2.0:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-escape-html@~1.0.3:
+escape-html@^1.0.3, escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
@@ -4077,6 +4146,14 @@ find-up@^2.0.0, find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
+find-up@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
+  integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
+  dependencies:
+    locate-path "^5.0.0"
+    path-exists "^4.0.0"
+
 flat-cache@^1.2.1:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.4.tgz#2c2ef77525cc2929007dfffa1dd314aa9c9dee6f"
@@ -4295,6 +4372,11 @@ get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
 
+get-caller-file@^2.0.1:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz#b877b49a5c16aefac3655f2ed2ea5b684df8d203"
@@ -4358,6 +4440,18 @@ glob-to-regexp@^0.3.0:
 glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@~7.1.1:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.6:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -4456,6 +4550,14 @@ gzip-size@^4.0.0:
     duplexer "^0.1.1"
     pify "^3.0.0"
 
+gzip-size@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-5.1.1.tgz#cb9bee692f87c0612b232840a873904e4c135274"
+  integrity sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==
+  dependencies:
+    duplexer "^0.1.1"
+    pify "^4.0.1"
+
 h2x-core@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/h2x-core/-/h2x-core-1.1.1.tgz#7fb31ab28e30ebf11818e3c7d183487ecf489f9f"
@@ -4544,6 +4646,11 @@ has-flag@^2.0.0:
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
 has-symbols@^1.0.0:
   version "1.0.0"
@@ -5093,6 +5200,11 @@ is-directory@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
 
+is-docker@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.0.0.tgz#2cb0df0e75e2d064fe1864c37cdeacb7b2dcf25b"
+  integrity sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==
+
 is-dotfile@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
@@ -5136,6 +5248,11 @@ is-fullwidth-code-point@^1.0.0:
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
 is-generator-fn@^1.0.0:
   version "1.0.0"
@@ -5281,6 +5398,11 @@ is-windows@^1.0.1, is-windows@^1.0.2:
 is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
+
+is-wsl@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.1.1.tgz#4a1c152d429df3d441669498e2486d3596ebaf1d"
+  integrity sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==
 
 isarray@0.0.1:
   version "0.0.1"
@@ -6059,6 +6181,13 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
+locate-path@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
+  integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
+  dependencies:
+    p-locate "^4.1.0"
+
 lodash-es@^4.17.14:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
@@ -6218,7 +6347,7 @@ lodash@^4.16.5, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
   integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
 
-lodash@^4.17.14:
+lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -7026,6 +7155,14 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+open@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.0.2.tgz#fb3681f11f157f2361d2392307548ca1792960e8"
+  integrity sha512-70E/pFTPr7nZ9nLDPNTcj3IVqnNvKuP4VsBmoKV9YGTnChe0mlS3C4qM7qKarhZ8rGaHKLfo+vBTHXDp6ZSyLQ==
+  dependencies:
+    is-docker "^2.0.0"
+    is-wsl "^2.1.1"
+
 opn@5.4.0, opn@^5.1.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.4.0.tgz#cb545e7aab78562beb11aa3bfabc7042e1761035"
@@ -7128,6 +7265,13 @@ p-limit@^2.0.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^2.2.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.2.tgz#61279b67721f5287aa1c13a9a7fbbc48c9291b1e"
+  integrity sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -7139,6 +7283,13 @@ p-locate@^3.0.0:
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
   dependencies:
     p-limit "^2.0.0"
+
+p-locate@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
+  integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
+  dependencies:
+    p-limit "^2.2.0"
 
 p-map@^1.1.1:
   version "1.2.0"
@@ -7246,6 +7397,11 @@ path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
 
+path-exists@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
+  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+
 path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
@@ -7319,6 +7475,11 @@ pify@^2.0.0:
 pify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
+
+pify@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
+  integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
 pinkie-promise@^2.0.0:
   version "2.0.1"
@@ -9335,6 +9496,11 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
+require-main-filename@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
+  integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
 require-uncached@^1.0.3:
   version "1.0.3"
   resolved "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
@@ -9826,6 +9992,24 @@ source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
 
+source-map-explorer@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/source-map-explorer/-/source-map-explorer-2.3.1.tgz#d91615a19ad1f4e08d05616bee6e30ddb770ae70"
+  integrity sha512-l3WQUCwaqia5x7EBnNp4GYwhXnROMz3NqKM2QMwQ3ADgjekp+enP+PHkjjbjoVX6WJ2G5mbvM6TjeE/q7fnIFw==
+  dependencies:
+    btoa "^1.2.1"
+    chalk "^3.0.0"
+    convert-source-map "^1.7.0"
+    ejs "^3.0.1"
+    escape-html "^1.0.3"
+    glob "^7.1.6"
+    gzip-size "^5.1.1"
+    lodash "^4.17.15"
+    open "^7.0.2"
+    source-map "^0.7.3"
+    temp "^0.9.1"
+    yargs "^15.1.0"
+
 source-map-resolve@^0.5.0:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
@@ -9866,6 +10050,11 @@ source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7:
 source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+
+source-map@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
+  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 spdx-correct@^3.0.0:
   version "3.0.2"
@@ -10039,6 +10228,15 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string-width@^4.1.0, string-width@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
+  integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.0"
+
 string.prototype.trim@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz#d04de2c89e137f4d7d206f086b5ed2fae6be8cea"
@@ -10092,6 +10290,13 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   resolved "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
+  integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
+  dependencies:
+    ansi-regex "^5.0.0"
 
 strip-bom@3.0.0, strip-bom@^3.0.0:
   version "3.0.0"
@@ -10167,6 +10372,13 @@ supports-color@^5.1.0, supports-color@^5.3.0, supports-color@^5.4.0, supports-co
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   dependencies:
     has-flag "^3.0.0"
+
+supports-color@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
+  integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
+  dependencies:
+    has-flag "^4.0.0"
 
 svgo@^1.0.0, svgo@^1.0.5:
   version "1.1.1"
@@ -10259,6 +10471,13 @@ tar@^4:
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
+
+temp@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/temp/-/temp-0.9.1.tgz#2d666114fafa26966cd4065996d7ceedd4dd4697"
+  integrity sha512-WMuOgiua1xb5R56lE0eH6ivpVmg/lq2OHm4+LtT/xtEtPQ+sz6N3bBM6WZ5FvO1lO4IKIOb43qnhoc4qxP5OeA==
+  dependencies:
+    rimraf "~2.6.2"
 
 terser-webpack-plugin@1.1.0:
   version "1.1.0"
@@ -11056,6 +11275,15 @@ wrap-ansi@^2.0.0:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
 
+wrap-ansi@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -11110,6 +11338,14 @@ yargs-parser@^10.1.0:
   dependencies:
     camelcase "^4.1.0"
 
+yargs-parser@^16.1.0:
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-16.1.0.tgz#73747d53ae187e7b8dbe333f95714c76ea00ecf1"
+  integrity sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-5.0.0.tgz#275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a"
@@ -11155,6 +11391,23 @@ yargs@^11.0.0:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
+
+yargs@^15.1.0:
+  version "15.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.1.0.tgz#e111381f5830e863a89550bd4b136bb6a5f37219"
+  integrity sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^16.1.0"
 
 yargs@^7.0.0:
   version "7.1.0"


### PR DESCRIPTION
Does not split code into chunks, based on routes anymore. Since this
ends up a lot of dependencies duplicated in multiple bundles. Although
in theory this increases size of assets that need to be downloaded
to render a route, in practice, our preloading strategy does not work
as inteded so browsers ends up downloading most of assets for a route.

So for now admin route and submissions routes are async, others are
not. And there is no preloading as of now, but planned to be introduce
in the future.

(Also adds `yarn analyze` to see report for generated bundle by `yarn
build`)

INSPIR-3232