### PR TITLE
ui: hotfix multiple citation summary requests

### DIFF
--- a/ui/src/actions/citations.js
+++ b/ui/src/actions/citations.js
@@ -33,21 +33,21 @@ function fetchCitationsError(error) {
   };
 }
 
-function fetchingCitationsSummary(query) {
+function fetchingCitationSummary(query) {
   return {
     type: CITATIONS_SUMMARY_REQUEST,
     payload: { query },
   };
 }
 
-function fetchCitationsSummarySuccess(result) {
+function fetchCitationSummarySuccess(result) {
   return {
     type: CITATIONS_SUMMARY_SUCCESS,
     payload: result,
   };
 }
 
-function fetchCitationsSummaryError(error) {
+function fetchCitationSummaryError(error) {
   return {
     type: CITATIONS_SUMMARY_ERROR,
     payload: error,
@@ -76,7 +76,7 @@ export function fetchCitations(recordId, newQuery = {}) {
 
 export function fetchCitationSummary(literatureSearchQuery) {
   return async (dispatch, getState, http) => {
-    dispatch(fetchingCitationsSummary(literatureSearchQuery));
+    dispatch(fetchingCitationSummary(literatureSearchQuery));
     try {
       const query = {
         ...literatureSearchQuery,
@@ -85,10 +85,10 @@ export function fetchCitationSummary(literatureSearchQuery) {
       const queryString = stringify(query, { indices: false });
       const url = `/literature/facets?${queryString}`;
       const response = await http.get(url);
-      dispatch(fetchCitationsSummarySuccess(response.data));
+      dispatch(fetchCitationSummarySuccess(response.data));
     } catch (error) {
       const payload = httpErrorToActionPayload(error);
-      dispatch(fetchCitationsSummaryError(payload));
+      dispatch(fetchCitationSummaryError(payload));
     }
   };
 }

--- a/ui/src/middlewares/keepPreviousUrl.js
+++ b/ui/src/middlewares/keepPreviousUrl.js
@@ -9,6 +9,7 @@ export default () => {
       location.previousUrl = previousUrl;
 
       const { pathname, search } = location;
+      // TODO: keep #hash
       previousUrl = `${pathname}${search}`;
     }
     return next(action);

--- a/ui/src/reducers/__tests__/search.test.js
+++ b/ui/src/reducers/__tests__/search.test.js
@@ -175,6 +175,11 @@ describe('search reducer', () => {
       namespaces: {
         [namespace]: {
           query: initialState.getIn(['namespaces', namespace, 'query']),
+          hasQueryBeenUpdatedAtLeastOnce: initialState.getIn([
+            'namespaces',
+            namespace,
+            'hasQueryBeenUpdatedAtLeastOnce',
+          ]),
         },
       },
     });
@@ -209,7 +214,7 @@ describe('search reducer', () => {
             sort: 'mostcited',
             page: 1,
           },
-          hasQueryBeenUpdatedAtLeastOnce: true
+          hasQueryBeenUpdatedAtLeastOnce: true,
         },
       },
     });

--- a/ui/src/reducers/search.js
+++ b/ui/src/reducers/search.js
@@ -270,10 +270,19 @@ const searchReducer = (state = initialState, action) => {
           true
         );
     case SEARCH_QUERY_RESET:
-      return state.setIn(
-        ['namespaces', namespace, 'query'],
-        initialState.getIn(['namespaces', namespace, 'query'])
-      );
+      return state
+        .setIn(
+          ['namespaces', namespace, 'query'],
+          initialState.getIn(['namespaces', namespace, 'query'])
+        )
+        .setIn(
+          ['namespaces', namespace, 'hasQueryBeenUpdatedAtLeastOnce'],
+          initialState.getIn([
+            'namespaces',
+            namespace,
+            'hasQueryBeenUpdatedAtLeastOnce',
+          ])
+        );
     case SEARCH_QUERY_UPDATE:
       const fullQuery = state
         .getIn(['namespaces', namespace, 'baseQuery'])


### PR DESCRIPTION
This one only removes the `fetchCitationSummary(emptySearchQuery)`,
there are still other bugs hence the request action is dispatched more
than once.

This only buys us time to fix citation summary issues, and possibly
together with other issues with dispatching fetch requests

INSPIR-3393