### PR TITLE
ui: fix search-history for beta collections

### DIFF
--- a/ui/src/common/components/SearchScopeSelect.jsx
+++ b/ui/src/common/components/SearchScopeSelect.jsx
@@ -2,9 +2,11 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import SelectBox from './SelectBox';
-import { SEARCH_BOX_NAMESPACES } from '../../reducers/search';
+import { SEARCH_BOX_NAMESPACES, INSTITUTIONS_NS } from '../../reducers/search';
 
-const SCOPE_OPTIONS = SEARCH_BOX_NAMESPACES.map(value => ({ value }));
+const SCOPE_OPTIONS = SEARCH_BOX_NAMESPACES.filter(
+  value => value !== INSTITUTIONS_NS
+).map(value => ({ value }));
 
 class SearchScopeSelect extends Component {
   render() {

--- a/ui/src/reducers/search.js
+++ b/ui/src/reducers/search.js
@@ -186,7 +186,6 @@ export const SEARCHABLE_COLLECTION_PATHNAMES = nonEmbeddedNamespaces
 export const SEARCH_BOX_NAMESPACES = nonEmbeddedNamespaces
   .sortBy(namespace => namespace.get('order'))
   .map((_, namespace) => namespace)
-  .filter(namespace => namespace !== INSTITUTIONS_NS)
   .valueSeq()
   .toArray();
 


### PR DESCRIPTION
Goes back to hiding beta collections in ui component level (SearchScopeSelect)