### PR TITLE
self-citations: quick update for self-citations

### DIFF
--- a/backend/inspirehep/alembic/8ba47044154a_add_indexed_to_records_citations_on_is_.py
+++ b/backend/inspirehep/alembic/8ba47044154a_add_indexed_to_records_citations_on_is_.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CERN.
+#
+# inspirehep is free software; you can redistribute it and/or modify it under
+# the terms of the MIT License; see LICENSE file for more details.
+
+"""Add indexed to records_citations on is_self_citation column"""
+
+from alembic import op
+
+revision = "8ba47044154a"
+down_revision = "5a0e2405b624"
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    """Upgrade database."""
+    op.create_index(
+        "ix_records_citations_cited_id_citation_type",
+        "records_citations",
+        ["cited_id", "is_self_citation"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_records_citations_citer_id_citation_type",
+        "records_citations",
+        ["citer_id", "is_self_citation"],
+        unique=False,
+    )
+
+
+def downgrade():
+    """Downgrade database."""
+    op.drop_index(
+        "ix_records_citations_citer_id_citation_type", table_name="records_citations"
+    )
+    op.drop_index(
+        "ix_records_citations_cited_id_citation_type", table_name="records_citations"
+    )

--- a/backend/inspirehep/records/models.py
+++ b/backend/inspirehep/records/models.py
@@ -23,6 +23,16 @@ class RecordCitations(db.Model):
 
     __table_args__ = (
         db.Index("ix_records_citations_cited_id_citer_id", "cited_id", "citer_id"),
+        db.Index(
+            "ix_records_citations_cited_id_citation_type",
+            "cited_id",
+            "is_self_citation",
+        ),
+        db.Index(
+            "ix_records_citations_citer_id_citation_type",
+            "citer_id",
+            "is_self_citation",
+        ),
     )
 
     citer_id = db.Column(

--- a/backend/tests/integration/alembic/test_alembic.py
+++ b/backend/tests/integration/alembic/test_alembic.py
@@ -13,6 +13,14 @@ from sqlalchemy.engine import reflection
 def test_downgrade(base_app, database):
     alembic = Alembic(base_app)
 
+    alembic.downgrade(target="5a0e2405b624")
+    assert "ix_records_citations_cited_id_citation_type" not in _get_indexes(
+        "records_citations", database
+    )
+    assert "ix_records_citations_citer_id_citation_type" not in _get_indexes(
+        "records_citations", database
+    )
+
     alembic.downgrade(target="595c36d68964")
     assert (
         _check_column_in_table(database, "records_citations", "is_self_citation")
@@ -181,6 +189,14 @@ def test_upgrade(base_app, database):
     assert (
         _check_column_in_table(database, "records_citations", "is_self_citation")
         is True
+    )
+
+    alembic.upgrade(target="8ba47044154a")
+    assert "ix_records_citations_cited_id_citation_type" in _get_indexes(
+        "records_citations", database
+    )
+    assert "ix_records_citations_citer_id_citation_type" in _get_indexes(
+        "records_citations", database
     )
 
 

--- a/backend/tests/unit/records/indexer/test_base.py
+++ b/backend/tests/unit/records/indexer/test_base.py
@@ -24,7 +24,9 @@ from inspirehep.records.api import LiteratureRecord
 @mock.patch("inspirehep.indexer.base.before_record_index")
 @mock.patch("inspirehep.indexer.base.current_app")
 @mock.patch("inspirehep.records.api.base.RecordMetadata")
+@mock.patch("inspirehep.records.api.mixins.current_app")
 def test_indexer_prepare_record(
+    mixins_current_app_mock,
     record_metadata_mock,
     current_app_mock,
     receiver_mock,


### PR DESCRIPTION
 *Added indexes for is_self_citation column in records_citations table
 *Fix: When feature flag for self-citations is disabled, ignore self-citations queries to speedup migration.
 *Removed unnecessary flag from _citations_by_year method