### PR TITLE
setup: upgrade lxml

### DIFF
--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -2282,13 +2282,13 @@ description = "Powerful and Pythonic XML processing library combining libxml2/li
 name = "lxml"
 optional = false
 python-versions = "*"
-version = "4.3.5"
+version = "4.4.0"
 
 [package.extras]
 cssselect = ["cssselect (>=0.7)"]
 html5 = ["html5lib"]
 htmlsoup = ["beautifulsoup4"]
-source = ["Cython (>=0.29.1)"]
+source = ["Cython (>=0.29.7)"]
 
 [[package]]
 category = "main"
@@ -3970,7 +3970,7 @@ test = ["zope.event"]
 testing = ["coverage", "nose", "zope.event"]
 
 [metadata]
-content-hash = "591803a454b4519896d2504b56c5957b540a73a1d5a6c35ce9476bf4cbd158d7"
+content-hash = "5bd008803e0334510cb6bc1d4c1aab54b558a1e17220dedf280517981b2febdc"
 python-versions = ">=3.6,<3.8"
 
 [metadata.files]
@@ -4671,30 +4671,28 @@ linkheader = [
     {file = "LinkHeader-0.4.3.tar.gz", hash = "sha256:7fbbc35c0ba3fbbc530571db7e1c886e7db3d718b29b345848ac9686f21b50c3"},
 ]
 lxml = [
-    {file = "lxml-4.3.5-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:9595ddceb8ea33899760e3c64750aa49ea6111ae86d91e262f0957fc25f7f45a"},
-    {file = "lxml-4.3.5-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:007f17642a338c4db6107a9bc129fb9fa8cf3d5389b61679014a17db31f814f1"},
-    {file = "lxml-4.3.5-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:729b3858425e4ac695772bb41b455f7c4862f9e4579775debc781fffd8e7e8f2"},
-    {file = "lxml-4.3.5-cp27-cp27m-win32.whl", hash = "sha256:628e5f8cfa1d34c78fb713a813be23669622ea3d538b9b43f4f66f56c647de34"},
-    {file = "lxml-4.3.5-cp27-cp27m-win_amd64.whl", hash = "sha256:930364d203138054d70708a662782e8bb6649c4682adc6a32e6c9c7acca1624a"},
-    {file = "lxml-4.3.5-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:d7db4f58fc1bc80ccf2b23bb1e0e6a176044b804e40dffb40c7995bd07046fdf"},
-    {file = "lxml-4.3.5-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:2b0bb7cd10686fd21d3360780f5d410ddb506377cf17823b4858951d53c92283"},
-    {file = "lxml-4.3.5-cp34-cp34m-manylinux1_i686.whl", hash = "sha256:7e6a735d2f910ee9e505eed09fd444f9ce0799c03e9657a4bf546ac132b8176b"},
-    {file = "lxml-4.3.5-cp34-cp34m-manylinux1_x86_64.whl", hash = "sha256:a61a4cd53d9af8403185697e54b7fc2870c4aaab5c17d5732c320eab4e534ab4"},
-    {file = "lxml-4.3.5-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:0a2e54e9b6c597cb8aa0935b47c73e22857d5a6f12013675478ed2b49fb560f2"},
-    {file = "lxml-4.3.5-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:161e945ebdeac9a7641b1623004e6e7c24b303172dfe6324c89e40c700d41a6a"},
-    {file = "lxml-4.3.5-cp35-cp35m-win32.whl", hash = "sha256:0be67a53aac192390958dcc83fc200cbba552c11be3f2e1a46b895fcc8c259c7"},
-    {file = "lxml-4.3.5-cp35-cp35m-win_amd64.whl", hash = "sha256:85cb9c6d8fd7e7385900a7d573639c72354b812212649e4be6956acaa2effa3a"},
-    {file = "lxml-4.3.5-cp36-cp36m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:a5f62b84704b6d21fbc827535845f4830f669dd3983730b8cdd305233355dd00"},
-    {file = "lxml-4.3.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:77c4425a5e1b9bb3b545061fe5261b20e4db4c4f395aba1455459f837da2ab8f"},
-    {file = "lxml-4.3.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:2b160c1ef64c23c3206e8741d16343d8e780663a7b4521c14fd2de8772d581c0"},
-    {file = "lxml-4.3.5-cp36-cp36m-win32.whl", hash = "sha256:d1525c941d34677d64b219255613fd0e871890f9ebd933936069d50dd2ea0967"},
-    {file = "lxml-4.3.5-cp36-cp36m-win_amd64.whl", hash = "sha256:f1161af10ff61dcaacc2d669e577b48a39d5fb21e4cc8f87c9f034eebc076faa"},
-    {file = "lxml-4.3.5-cp37-cp37m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:b39ea490516253e25e68ec6556e4dd2c2dbc3b612b74fca6c00a7c1c66ff0aaf"},
-    {file = "lxml-4.3.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:b26f1aba578f0ddbcb7fcc54b66baf3b510a9702251239038839dc547e07f6b6"},
-    {file = "lxml-4.3.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:92c7e1496672f9cd978888da8364bc3e16781b115e05db9ba593b706e749a68a"},
-    {file = "lxml-4.3.5-cp37-cp37m-win32.whl", hash = "sha256:e2d2d7038c068c3d8a4ab858306ba959b014b203b7063ceb6b75f2ff8b32ee5f"},
-    {file = "lxml-4.3.5-cp37-cp37m-win_amd64.whl", hash = "sha256:7133831d22e315bff2ca3bab9a2cbe7eb12b3c70773bfa64636fbcc7aebf93ab"},
-    {file = "lxml-4.3.5.tar.gz", hash = "sha256:738862e9724d201f1aa8394cb666d8136d666198e97d6e1e5c9876ad884a86b3"},
+    {file = "lxml-4.4.0-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:06e5599b9c54f797a3c0f384c67705a0d621031007aa2400a6c7d17300fdb995"},
+    {file = "lxml-4.4.0-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:b33ec641309bcea40c76c1b105f988e4e8f9a2f1ee1486aa5c0eeef33956c9bb"},
+    {file = "lxml-4.4.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:092237cfe4ece074401b75001a2e525fa6e1fb9d40fee8b7b132b1947d3bd2f8"},
+    {file = "lxml-4.4.0-cp27-cp27m-win32.whl", hash = "sha256:d1135dc0ac197242028ede085b693ba1f2bff7f0f9b91080e2540348312bfa53"},
+    {file = "lxml-4.4.0-cp27-cp27m-win_amd64.whl", hash = "sha256:350333190052bbfbc3222b1805b59b7979d7276e57af2257367e15a2db27082d"},
+    {file = "lxml-4.4.0-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:0b6d49d0a26fe8207df8dd27c40b75be4deb2277173903aa76ec3e82df77cbe7"},
+    {file = "lxml-4.4.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:db2794bad21b7b30b6849b4e1537171cae8a7087711d958d69c233470dc612e7"},
+    {file = "lxml-4.4.0-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:2f163c8844db4ed06a230ef092e2461ad01830972a896b8f3cf8b5bac70ae85d"},
+    {file = "lxml-4.4.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f1c2f67df727034f94ccb590142d1d110f3dd38f638a4f1567fdd9f39892ba05"},
+    {file = "lxml-4.4.0-cp35-cp35m-win32.whl", hash = "sha256:7720174604c7647e357566ac9e4d135c137caed5e7b01223551a4c81c8dc8b9a"},
+    {file = "lxml-4.4.0-cp35-cp35m-win_amd64.whl", hash = "sha256:0f77061c20b4f32b1cf39e8f661c74e966344084c996e7b23c3a94e472461df0"},
+    {file = "lxml-4.4.0-cp36-cp36m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:5033cf606a7cb559db967689b1b2e743994000f783607ba4c484e90917395ad7"},
+    {file = "lxml-4.4.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:75d731af05bf40f808d7716e0d26b4b02913402f861c032ce8c36efca350ae72"},
+    {file = "lxml-4.4.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:43dac60d10341d3e56be089cd0798b70e70d45ce32279f4c3190d8cbd71350e4"},
+    {file = "lxml-4.4.0-cp36-cp36m-win32.whl", hash = "sha256:4665ee84ac8ba11d58f1ed517e29ea8536b4ae4e0c6fb6c7d3dce70abcd279f0"},
+    {file = "lxml-4.4.0-cp36-cp36m-win_amd64.whl", hash = "sha256:da5c48ec9f8d8b5df42d328b6d1fb8d9413cd664a2367ef4f6f7cc48ee5b82c0"},
+    {file = "lxml-4.4.0-cp37-cp37m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:0fef86edfa2f146b4b0ae2c6c05c3e4a8f3388b3655eafbc4aab3247f4dabb24"},
+    {file = "lxml-4.4.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:f840dddded8b046edc774c88ed8d2442cdb231a68894c42c74e3a809450fae76"},
+    {file = "lxml-4.4.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d5a61e9c2322b45f259909a02b76bc98c4641214e22a37191d00c151aa9cdb9a"},
+    {file = "lxml-4.4.0-cp37-cp37m-win32.whl", hash = "sha256:da22c4b17bc17dad9c8faf6d94c8fe568ac71c867a56631ab874da418fc7f8f7"},
+    {file = "lxml-4.4.0-cp37-cp37m-win_amd64.whl", hash = "sha256:3e86e5df4a8edd6f725f3c76f1d45e046d4f3aa40478092e4f5f373ad1f526e2"},
+    {file = "lxml-4.4.0.tar.gz", hash = "sha256:3b57dc5ed7b6a7d852c961f2389ca99404c2b59fd2088baec6fbaca02f688be4"},
 ]
 mako = [
     {file = "Mako-1.1.1.tar.gz", hash = "sha256:2984a6733e1d472796ceef37ad48c26f4a984bb18119bb2dbc37a44d8f6e75a4"},

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -51,8 +51,7 @@ pybtex = "*"
 cryptography = "<2.6"
 flask-kvsession = {git = "https://github.com/inspirehep/flask-kvsession.git"}
 python-redis-lock = "^3.3"
-# FIXME: orcid tests are failing with `4.4` because of OrderedDict changes
-lxml = "~=4.3,<4.4"
+lxml = "~=4.4"
 fqn-decorators = "~=1.2,>=1.2.3"
 editdistance = "^0.5.3"
 munkres = "^1.0"

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPushTask.test_push_new_work_already_existing.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPushTask.test_push_new_work_already_existing.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\"><work:title><common:title>Some Results Arising\
       \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{45,\n\
       \    author = \"Rossoni, A.\",\n    doi = \"10.1000/test.orcid.push\",\n   \
       \ month = \"5\",\n    title = \"{Some Results Arising from the Study of ORCID\
@@ -24,7 +24,7 @@ interactions:
     body:
       string: '{"response-code":409,"developer-message":"409 Conflict: You have already
         added this activity (matched by external identifiers), please see element
-        with put-code 71114448. If you are trying to edit the item, please use PUT
+        with put-code 73087602. If you are trying to edit the item, please use PUT
         instead of POST.","user-message":"There was an error when updating the record.
         Please try again. If the error persists, please contact INSPIRE-HEP for assistance.","error-code":9021,"more-info":"https://members.orcid.org/api/resources/troubleshooting"}'
     headers:
@@ -39,7 +39,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Thu, 26 Mar 2020 15:05:51 GMT
+      - Wed, 29 Apr 2020 15:29:59 GMT
       Expires:
       - '0'
       Pragma:
@@ -68,8 +68,8 @@ interactions:
     uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/works
   response:
     body:
-      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1585235127502\n  },\n\
-        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1585235127502\n\
+      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1588174197849\n  },\n\
+        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1588174197849\n\
         \    },\n    \"external-ids\" : {\n      \"external-id\" : [ {\n        \"\
         external-id-type\" : \"doi\",\n        \"external-id-value\" : \"10.1000/test.orcid.push\"\
         ,\n        \"external-id-url\" : {\n          \"value\" : \"http://dx.doi.org/10.1000/test.orcid.push\"\
@@ -77,9 +77,9 @@ interactions:
         \        \"external-id-type\" : \"other-id\",\n        \"external-id-value\"\
         \ : \"45\",\n        \"external-id-url\" : {\n          \"value\" : \"http://inspirehep.net/record/45\"\
         \n        },\n        \"external-id-relationship\" : \"SELF\"\n      } ]\n\
-        \    },\n    \"work-summary\" : [ {\n      \"put-code\" : 71114448,\n    \
-        \  \"created-date\" : {\n        \"value\" : 1585235127502\n      },\n   \
-        \   \"last-modified-date\" : {\n        \"value\" : 1585235127502\n      },\n\
+        \    },\n    \"work-summary\" : [ {\n      \"put-code\" : 73087602,\n    \
+        \  \"created-date\" : {\n        \"value\" : 1588174197849\n      },\n   \
+        \   \"last-modified-date\" : {\n        \"value\" : 1588174197849\n      },\n\
         \      \"source\" : {\n        \"source-orcid\" : null,\n        \"source-client-id\"\
         \ : {\n          \"uri\" : \"http://orcid.org/client/0000-0001-8607-8906\"\
         ,\n          \"path\" : \"0000-0001-8607-8906\",\n          \"host\" : \"\
@@ -96,7 +96,7 @@ interactions:
         external-id-url\" : {\n            \"value\" : \"http://dx.doi.org/10.1000/test.orcid.push\"\
         \n          },\n          \"external-id-relationship\" : \"SELF\"\n      \
         \  } ]\n      },\n      \"type\" : \"JOURNAL_ARTICLE\",\n      \"publication-date\"\
-        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/71114448\"\
+        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/73087602\"\
         ,\n      \"display-index\" : \"0\"\n    } ]\n  } ],\n  \"path\" : \"/0000-0003-1134-6827/works\"\
         \n}"
     headers:
@@ -109,7 +109,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Thu, 26 Mar 2020 15:05:52 GMT
+      - Wed, 29 Apr 2020 15:30:00 GMT
       Expires:
       - '0'
       Pragma:
@@ -130,8 +130,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\" put-code=\"71114448\"><work:title><common:title>Some\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\" put-code=\"73087602\"><work:title><common:title>Some\
       \ Results Arising from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{45,\n\
       \    author = \"Rossoni, A.\",\n    doi = \"10.1000/test.orcid.push\",\n   \
       \ month = \"5\",\n    title = \"{Some Results Arising from the Study of ORCID\
@@ -149,16 +149,16 @@ interactions:
       Content-Type:
       - application/orcid+xml
     method: PUT
-    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/71114448
+    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/73087602
   response:
     body:
-      string: "{\n  \"created-date\" : {\n    \"value\" : 1585235127502\n  },\n  \"\
-        last-modified-date\" : {\n    \"value\" : 1585235127502\n  },\n  \"source\"\
+      string: "{\n  \"created-date\" : {\n    \"value\" : 1588174197849\n  },\n  \"\
+        last-modified-date\" : {\n    \"value\" : 1588174197849\n  },\n  \"source\"\
         \ : {\n    \"source-orcid\" : null,\n    \"source-client-id\" : {\n      \"\
         uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \"path\" :\
         \ \"0000-0001-8607-8906\",\n      \"host\" : \"orcid.org\"\n    },\n    \"\
         source-name\" : {\n      \"value\" : \"INSPIRE-HEP\"\n    }\n  },\n  \"put-code\"\
-        \ : 71114448,\n  \"path\" : null,\n  \"title\" : {\n    \"title\" : {\n  \
+        \ : 73087602,\n  \"path\" : null,\n  \"title\" : {\n    \"title\" : {\n  \
         \    \"value\" : \"Some Results Arising from the Study of ORCID push\"\n \
         \   },\n    \"subtitle\" : null,\n    \"translated-title\" : null\n  },\n\
         \  \"journal-title\" : null,\n  \"short-description\" : null,\n  \"citation\"\
@@ -191,7 +191,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Thu, 26 Mar 2020 15:05:53 GMT
+      - Wed, 29 Apr 2020 15:30:01 GMT
       Expires:
       - '0'
       Pragma:

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPushTask.test_push_new_work_happy_flow.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPushTask.test_push_new_work_happy_flow.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\"><work:title><common:title>Some Results Arising\
       \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{45,\n\
       \    author = \"Rossoni, A.\",\n    doi = \"10.1000/test.orcid.push\",\n   \
       \ month = \"5\",\n    title = \"{Some Results Arising from the Study of ORCID\
@@ -35,11 +35,11 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Thu, 26 Mar 2020 15:05:27 GMT
+      - Wed, 29 Apr 2020 15:29:57 GMT
       Expires:
       - '0'
       Location:
-      - http://api.orcid.org/v2.0/0000-0003-1134-6827/work/71114448
+      - http://api.orcid.org/v2.0/0000-0003-1134-6827/work/73087602
       Pragma:
       - no-cache
       Server:

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPushTask.test_push_new_work_invalid_data_orcid.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPushTask.test_push_new_work_invalid_data_orcid.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\"><work:title><common:title>Some Results Arising\
       \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{45,\n\
       \    author = \"Rossoni, A.\",\n    doi = \"10.1000/test.orcid.push\",\n   \
       \ month = \"5\",\n    title = \"{Some Results Arising from the Study of ORCID\
@@ -35,7 +35,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Thu, 26 Mar 2020 15:05:50 GMT
+      - Wed, 29 Apr 2020 15:29:58 GMT
       Expires:
       - '0'
       Pragma:

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherDeleteWork.test_delete_work_cache_hit.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherDeleteWork.test_delete_work_cache_hit.yaml
@@ -29,7 +29,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Thu, 26 Mar 2020 15:18:58 GMT
+      - Wed, 29 Apr 2020 15:08:56 GMT
       Expires:
       - '0'
       Pragma:

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherDeleteWork.test_delete_work_cache_miss.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherDeleteWork.test_delete_work_cache_miss.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Thu, 26 Mar 2020 15:18:57 GMT
+      - Wed, 29 Apr 2020 15:08:55 GMT
       Expires:
       - '0'
       Pragma:

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherDeleteWork.test_delete_work_cache_putcode_nonexisting.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherDeleteWork.test_delete_work_cache_putcode_nonexisting.yaml
@@ -29,7 +29,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Thu, 26 Mar 2020 15:18:59 GMT
+      - Wed, 29 Apr 2020 15:08:57 GMT
       Expires:
       - '0'
       Pragma:

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherDeleteWork.test_delete_work_force_delete.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherDeleteWork.test_delete_work_force_delete.yaml
@@ -29,7 +29,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Thu, 26 Mar 2020 15:19:00 GMT
+      - Wed, 29 Apr 2020 15:08:58 GMT
       Expires:
       - '0'
       Pragma:

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherDeleteWork.test_delete_work_invalid_token.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherDeleteWork.test_delete_work_invalid_token.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/orcid+json;charset=UTF-8
       Date:
-      - Thu, 26 Mar 2020 15:19:02 GMT
+      - Wed, 29 Apr 2020 15:08:59 GMT
       Pragma:
       - no-cache
       Server:

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherDuplicatedIdentifier.test_happy_flow_post.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherDuplicatedIdentifier.test_happy_flow_post.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\"><work:title><common:title>Some Results Arising\
       \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{666,\n\
       \    author = \"Rossoni, A.\",\n    doi = \"10.1111/test.orcid.push\",\n   \
       \ month = \"5\",\n    title = \"{Some Results Arising from the Study of ORCID\
@@ -35,11 +35,11 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Tue, 28 Apr 2020 14:30:59 GMT
+      - Wed, 29 Apr 2020 15:32:25 GMT
       Expires:
       - '0'
       Location:
-      - http://api.orcid.org/v2.0/0000-0003-1134-6827/work/72994839
+      - http://api.orcid.org/v2.0/0000-0003-1134-6827/work/73087696
       Pragma:
       - no-cache
       Server:

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherDuplicatedIdentifier.test_happy_flow_put.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherDuplicatedIdentifier.test_happy_flow_put.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\"><work:title><common:title>Some Results Arising\
       \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{999,\n\
       \    author = \"Rossoni, A.\",\n    month = \"5\",\n    title = \"{Some Results\
       \ Arising from the Study of ORCID push}\",\n    year = \"2017\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>999</common:external-id-value><common:external-id-url>http://inspirehep.net/record/999</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/999</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
@@ -34,11 +34,11 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Tue, 28 Apr 2020 14:31:00 GMT
+      - Wed, 29 Apr 2020 15:32:26 GMT
       Expires:
       - '0'
       Location:
-      - http://api.orcid.org/v2.0/0000-0003-1134-6827/work/72994840
+      - http://api.orcid.org/v2.0/0000-0003-1134-6827/work/73087697
       Pragma:
       - no-cache
       Server:
@@ -53,8 +53,8 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\" put-code=\"72994840\"><work:title><common:title>Some\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\" put-code=\"73087697\"><work:title><common:title>Some\
       \ Results Arising from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{999,\n\
       \    author = \"Rossoni, A.\",\n    doi = \"10.1111/test.orcid.push\",\n   \
       \ month = \"5\",\n    title = \"{Some Results Arising from the Study of ORCID\
@@ -72,12 +72,12 @@ interactions:
       Content-Type:
       - application/orcid+xml
     method: PUT
-    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/72994840
+    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/73087697
   response:
     body:
       string: '{"response-code":409,"developer-message":"409 Conflict: You have already
         added this activity (matched by external identifiers), please see element
-        with put-code 72994839. If you are trying to edit the item, please use PUT
+        with put-code 73087696. If you are trying to edit the item, please use PUT
         instead of POST.","user-message":"There was an error when updating the record.
         Please try again. If the error persists, please contact INSPIRE-HEP for assistance.","error-code":9021,"more-info":"https://members.orcid.org/api/resources/troubleshooting"}'
     headers:
@@ -92,7 +92,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Tue, 28 Apr 2020 14:31:00 GMT
+      - Wed, 29 Apr 2020 15:32:27 GMT
       Expires:
       - '0'
       Pragma:
@@ -121,8 +121,8 @@ interactions:
     uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/works
   response:
     body:
-      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1588084260038\n  },\n\
-        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1588084258857\n\
+      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1588174346279\n  },\n\
+        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1588174345433\n\
         \    },\n    \"external-ids\" : {\n      \"external-id\" : [ {\n        \"\
         external-id-type\" : \"other-id\",\n        \"external-id-value\" : \"666\"\
         ,\n        \"external-id-url\" : {\n          \"value\" : \"http://inspirehep.net/record/666\"\
@@ -131,9 +131,9 @@ interactions:
         \ \"10.1111/test.orcid.push\",\n        \"external-id-url\" : {\n        \
         \  \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\n        },\n\
         \        \"external-id-relationship\" : \"SELF\"\n      } ]\n    },\n    \"\
-        work-summary\" : [ {\n      \"put-code\" : 72994839,\n      \"created-date\"\
-        \ : {\n        \"value\" : 1588084258857\n      },\n      \"last-modified-date\"\
-        \ : {\n        \"value\" : 1588084258857\n      },\n      \"source\" : {\n\
+        work-summary\" : [ {\n      \"put-code\" : 73087696,\n      \"created-date\"\
+        \ : {\n        \"value\" : 1588174345433\n      },\n      \"last-modified-date\"\
+        \ : {\n        \"value\" : 1588174345433\n      },\n      \"source\" : {\n\
         \        \"source-orcid\" : null,\n        \"source-client-id\" : {\n    \
         \      \"uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \
         \    \"path\" : \"0000-0001-8607-8906\",\n          \"host\" : \"orcid.org\"\
@@ -150,16 +150,16 @@ interactions:
         external-id-url\" : {\n            \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\
         \n          },\n          \"external-id-relationship\" : \"SELF\"\n      \
         \  } ]\n      },\n      \"type\" : \"JOURNAL_ARTICLE\",\n      \"publication-date\"\
-        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/72994839\"\
+        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/73087696\"\
         ,\n      \"display-index\" : \"0\"\n    } ]\n  }, {\n    \"last-modified-date\"\
-        \ : {\n      \"value\" : 1588084260038\n    },\n    \"external-ids\" : {\n\
+        \ : {\n      \"value\" : 1588174346279\n    },\n    \"external-ids\" : {\n\
         \      \"external-id\" : [ {\n        \"external-id-type\" : \"other-id\"\
         ,\n        \"external-id-value\" : \"999\",\n        \"external-id-url\" :\
         \ {\n          \"value\" : \"http://inspirehep.net/record/999\"\n        },\n\
         \        \"external-id-relationship\" : \"SELF\"\n      } ]\n    },\n    \"\
-        work-summary\" : [ {\n      \"put-code\" : 72994840,\n      \"created-date\"\
-        \ : {\n        \"value\" : 1588084260038\n      },\n      \"last-modified-date\"\
-        \ : {\n        \"value\" : 1588084260038\n      },\n      \"source\" : {\n\
+        work-summary\" : [ {\n      \"put-code\" : 73087697,\n      \"created-date\"\
+        \ : {\n        \"value\" : 1588174346279\n      },\n      \"last-modified-date\"\
+        \ : {\n        \"value\" : 1588174346279\n      },\n      \"source\" : {\n\
         \        \"source-orcid\" : null,\n        \"source-client-id\" : {\n    \
         \      \"uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \
         \    \"path\" : \"0000-0001-8607-8906\",\n          \"host\" : \"orcid.org\"\
@@ -173,7 +173,7 @@ interactions:
         http://inspirehep.net/record/999\"\n          },\n          \"external-id-relationship\"\
         \ : \"SELF\"\n        } ]\n      },\n      \"type\" : \"JOURNAL_ARTICLE\"\
         ,\n      \"publication-date\" : null,\n      \"visibility\" : \"PUBLIC\",\n\
-        \      \"path\" : \"/0000-0003-1134-6827/work/72994840\",\n      \"display-index\"\
+        \      \"path\" : \"/0000-0003-1134-6827/work/73087697\",\n      \"display-index\"\
         \ : \"0\"\n    } ]\n  } ],\n  \"path\" : \"/0000-0003-1134-6827/works\"\n}"
     headers:
       Access-Control-Allow-Origin:
@@ -185,7 +185,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Tue, 28 Apr 2020 14:31:01 GMT
+      - Wed, 29 Apr 2020 15:32:27 GMT
       Expires:
       - '0'
       Pragma:
@@ -218,8 +218,8 @@ interactions:
     uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/works
   response:
     body:
-      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1588084260038\n  },\n\
-        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1588084258857\n\
+      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1588174346279\n  },\n\
+        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1588174345433\n\
         \    },\n    \"external-ids\" : {\n      \"external-id\" : [ {\n        \"\
         external-id-type\" : \"other-id\",\n        \"external-id-value\" : \"666\"\
         ,\n        \"external-id-url\" : {\n          \"value\" : \"http://inspirehep.net/record/666\"\
@@ -228,9 +228,9 @@ interactions:
         \ \"10.1111/test.orcid.push\",\n        \"external-id-url\" : {\n        \
         \  \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\n        },\n\
         \        \"external-id-relationship\" : \"SELF\"\n      } ]\n    },\n    \"\
-        work-summary\" : [ {\n      \"put-code\" : 72994839,\n      \"created-date\"\
-        \ : {\n        \"value\" : 1588084258857\n      },\n      \"last-modified-date\"\
-        \ : {\n        \"value\" : 1588084258857\n      },\n      \"source\" : {\n\
+        work-summary\" : [ {\n      \"put-code\" : 73087696,\n      \"created-date\"\
+        \ : {\n        \"value\" : 1588174345433\n      },\n      \"last-modified-date\"\
+        \ : {\n        \"value\" : 1588174345433\n      },\n      \"source\" : {\n\
         \        \"source-orcid\" : null,\n        \"source-client-id\" : {\n    \
         \      \"uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \
         \    \"path\" : \"0000-0001-8607-8906\",\n          \"host\" : \"orcid.org\"\
@@ -247,16 +247,16 @@ interactions:
         external-id-url\" : {\n            \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\
         \n          },\n          \"external-id-relationship\" : \"SELF\"\n      \
         \  } ]\n      },\n      \"type\" : \"JOURNAL_ARTICLE\",\n      \"publication-date\"\
-        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/72994839\"\
+        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/73087696\"\
         ,\n      \"display-index\" : \"0\"\n    } ]\n  }, {\n    \"last-modified-date\"\
-        \ : {\n      \"value\" : 1588084260038\n    },\n    \"external-ids\" : {\n\
+        \ : {\n      \"value\" : 1588174346279\n    },\n    \"external-ids\" : {\n\
         \      \"external-id\" : [ {\n        \"external-id-type\" : \"other-id\"\
         ,\n        \"external-id-value\" : \"999\",\n        \"external-id-url\" :\
         \ {\n          \"value\" : \"http://inspirehep.net/record/999\"\n        },\n\
         \        \"external-id-relationship\" : \"SELF\"\n      } ]\n    },\n    \"\
-        work-summary\" : [ {\n      \"put-code\" : 72994840,\n      \"created-date\"\
-        \ : {\n        \"value\" : 1588084260038\n      },\n      \"last-modified-date\"\
-        \ : {\n        \"value\" : 1588084260038\n      },\n      \"source\" : {\n\
+        work-summary\" : [ {\n      \"put-code\" : 73087697,\n      \"created-date\"\
+        \ : {\n        \"value\" : 1588174346279\n      },\n      \"last-modified-date\"\
+        \ : {\n        \"value\" : 1588174346279\n      },\n      \"source\" : {\n\
         \        \"source-orcid\" : null,\n        \"source-client-id\" : {\n    \
         \      \"uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \
         \    \"path\" : \"0000-0001-8607-8906\",\n          \"host\" : \"orcid.org\"\
@@ -270,7 +270,7 @@ interactions:
         http://inspirehep.net/record/999\"\n          },\n          \"external-id-relationship\"\
         \ : \"SELF\"\n        } ]\n      },\n      \"type\" : \"JOURNAL_ARTICLE\"\
         ,\n      \"publication-date\" : null,\n      \"visibility\" : \"PUBLIC\",\n\
-        \      \"path\" : \"/0000-0003-1134-6827/work/72994840\",\n      \"display-index\"\
+        \      \"path\" : \"/0000-0003-1134-6827/work/73087697\",\n      \"display-index\"\
         \ : \"0\"\n    } ]\n  } ],\n  \"path\" : \"/0000-0003-1134-6827/works\"\n}"
     headers:
       Access-Control-Allow-Origin:
@@ -282,7 +282,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Tue, 28 Apr 2020 14:31:02 GMT
+      - Wed, 29 Apr 2020 15:32:28 GMT
       Expires:
       - '0'
       Pragma:
@@ -316,7 +316,7 @@ interactions:
       Content-Type:
       - application/orcid+json
     method: DELETE
-    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/72994839
+    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/73087696
   response:
     body:
       string: ''
@@ -330,7 +330,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Tue, 28 Apr 2020 14:31:02 GMT
+      - Wed, 29 Apr 2020 15:32:29 GMT
       Expires:
       - '0'
       Pragma:
@@ -347,8 +347,8 @@ interactions:
       code: 204
       message: No Content
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\" put-code=\"72994840\"><work:title><common:title>Some\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\" put-code=\"73087697\"><work:title><common:title>Some\
       \ Results Arising from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{999,\n\
       \    author = \"Rossoni, A.\",\n    doi = \"10.1111/test.orcid.push\",\n   \
       \ month = \"5\",\n    title = \"{Some Results Arising from the Study of ORCID\
@@ -366,16 +366,16 @@ interactions:
       Content-Type:
       - application/orcid+xml
     method: PUT
-    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/72994840
+    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/73087697
   response:
     body:
-      string: "{\n  \"created-date\" : {\n    \"value\" : 1588084260038\n  },\n  \"\
-        last-modified-date\" : {\n    \"value\" : 1588084263343\n  },\n  \"source\"\
+      string: "{\n  \"created-date\" : {\n    \"value\" : 1588174346279\n  },\n  \"\
+        last-modified-date\" : {\n    \"value\" : 1588174349731\n  },\n  \"source\"\
         \ : {\n    \"source-orcid\" : null,\n    \"source-client-id\" : {\n      \"\
         uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \"path\" :\
         \ \"0000-0001-8607-8906\",\n      \"host\" : \"orcid.org\"\n    },\n    \"\
         source-name\" : {\n      \"value\" : \"INSPIRE-HEP\"\n    }\n  },\n  \"put-code\"\
-        \ : 72994840,\n  \"path\" : null,\n  \"title\" : {\n    \"title\" : {\n  \
+        \ : 73087697,\n  \"path\" : null,\n  \"title\" : {\n    \"title\" : {\n  \
         \    \"value\" : \"Some Results Arising from the Study of ORCID push\"\n \
         \   },\n    \"subtitle\" : null,\n    \"translated-title\" : null\n  },\n\
         \  \"journal-title\" : null,\n  \"short-description\" : null,\n  \"citation\"\
@@ -408,7 +408,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Tue, 28 Apr 2020 14:31:03 GMT
+      - Wed, 29 Apr 2020 15:32:29 GMT
       Expires:
       - '0'
       Pragma:

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherDuplicatedIdentifier.test_push_unhandled_duplicated_external_identifier_pusher_exception.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherDuplicatedIdentifier.test_push_unhandled_duplicated_external_identifier_pusher_exception.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\"><work:title><common:title>Some Results Arising\
       \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{999,\n\
       \    author = \"Rossoni, A.\",\n    doi = \"10.1111/test.orcid.push\",\n   \
       \ month = \"5\",\n    title = \"{Some Results Arising from the Study of ORCID\
@@ -24,7 +24,7 @@ interactions:
     body:
       string: '{"response-code":409,"developer-message":"409 Conflict: You have already
         added this activity (matched by external identifiers), please see element
-        with put-code 72994840. If you are trying to edit the item, please use PUT
+        with put-code 73087697. If you are trying to edit the item, please use PUT
         instead of POST.","user-message":"There was an error when updating the record.
         Please try again. If the error persists, please contact INSPIRE-HEP for assistance.","error-code":9021,"more-info":"https://members.orcid.org/api/resources/troubleshooting"}'
     headers:
@@ -39,7 +39,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Tue, 28 Apr 2020 14:31:04 GMT
+      - Wed, 29 Apr 2020 15:32:30 GMT
       Expires:
       - '0'
       Pragma:
@@ -68,8 +68,8 @@ interactions:
     uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/works
   response:
     body:
-      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1588084263343\n  },\n\
-        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1588084263343\n\
+      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1588174349731\n  },\n\
+        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1588174349731\n\
         \    },\n    \"external-ids\" : {\n      \"external-id\" : [ {\n        \"\
         external-id-type\" : \"other-id\",\n        \"external-id-value\" : \"999\"\
         ,\n        \"external-id-url\" : {\n          \"value\" : \"http://inspirehep.net/record/999\"\
@@ -78,9 +78,9 @@ interactions:
         \ \"10.1111/test.orcid.push\",\n        \"external-id-url\" : {\n        \
         \  \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\n        },\n\
         \        \"external-id-relationship\" : \"SELF\"\n      } ]\n    },\n    \"\
-        work-summary\" : [ {\n      \"put-code\" : 72994840,\n      \"created-date\"\
-        \ : {\n        \"value\" : 1588084260038\n      },\n      \"last-modified-date\"\
-        \ : {\n        \"value\" : 1588084263343\n      },\n      \"source\" : {\n\
+        work-summary\" : [ {\n      \"put-code\" : 73087697,\n      \"created-date\"\
+        \ : {\n        \"value\" : 1588174346279\n      },\n      \"last-modified-date\"\
+        \ : {\n        \"value\" : 1588174349731\n      },\n      \"source\" : {\n\
         \        \"source-orcid\" : null,\n        \"source-client-id\" : {\n    \
         \      \"uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \
         \    \"path\" : \"0000-0001-8607-8906\",\n          \"host\" : \"orcid.org\"\
@@ -97,7 +97,7 @@ interactions:
         external-id-url\" : {\n            \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\
         \n          },\n          \"external-id-relationship\" : \"SELF\"\n      \
         \  } ]\n      },\n      \"type\" : \"JOURNAL_ARTICLE\",\n      \"publication-date\"\
-        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/72994840\"\
+        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/73087697\"\
         ,\n      \"display-index\" : \"0\"\n    } ]\n  } ],\n  \"path\" : \"/0000-0003-1134-6827/works\"\
         \n}"
     headers:
@@ -110,7 +110,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Tue, 28 Apr 2020 14:31:05 GMT
+      - Wed, 29 Apr 2020 15:32:31 GMT
       Expires:
       - '0'
       Pragma:
@@ -131,8 +131,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\" put-code=\"72994840\"><work:title><common:title>Some\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\" put-code=\"73087697\"><work:title><common:title>Some\
       \ Results Arising from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{999,\n\
       \    author = \"Rossoni, A.\",\n    doi = \"10.1111/test.orcid.push\",\n   \
       \ month = \"5\",\n    title = \"{Some Results Arising from the Study of ORCID\
@@ -150,16 +150,16 @@ interactions:
       Content-Type:
       - application/orcid+xml
     method: PUT
-    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/72994840
+    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/73087697
   response:
     body:
-      string: "{\n  \"created-date\" : {\n    \"value\" : 1588084260038\n  },\n  \"\
-        last-modified-date\" : {\n    \"value\" : 1588084263343\n  },\n  \"source\"\
+      string: "{\n  \"created-date\" : {\n    \"value\" : 1588174346279\n  },\n  \"\
+        last-modified-date\" : {\n    \"value\" : 1588174349731\n  },\n  \"source\"\
         \ : {\n    \"source-orcid\" : null,\n    \"source-client-id\" : {\n      \"\
         uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \"path\" :\
         \ \"0000-0001-8607-8906\",\n      \"host\" : \"orcid.org\"\n    },\n    \"\
         source-name\" : {\n      \"value\" : \"INSPIRE-HEP\"\n    }\n  },\n  \"put-code\"\
-        \ : 72994840,\n  \"path\" : null,\n  \"title\" : {\n    \"title\" : {\n  \
+        \ : 73087697,\n  \"path\" : null,\n  \"title\" : {\n    \"title\" : {\n  \
         \    \"value\" : \"Some Results Arising from the Study of ORCID push\"\n \
         \   },\n    \"subtitle\" : null,\n    \"translated-title\" : null\n  },\n\
         \  \"journal-title\" : null,\n  \"short-description\" : null,\n  \"citation\"\
@@ -192,7 +192,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Tue, 28 Apr 2020 14:31:05 GMT
+      - Wed, 29 Apr 2020 15:32:32 GMT
       Expires:
       - '0'
       Pragma:
@@ -213,8 +213,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\"><work:title><common:title>title1</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{666,\n\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\"><work:title><common:title>title1</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{666,\n\
       \    author = \"Rossoni, A.\",\n    doi = \"10.1111/test.orcid.push\",\n   \
       \ month = \"5\",\n    title = \"{title1}\",\n    year = \"2017\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>666</common:external-id-value><common:external-id-url>http://inspirehep.net/record/666</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.1111/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.1111/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/666</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
       \ A.</work:credit-name><work:contributor-attributes><work:contributor-sequence>first</work:contributor-sequence><work:contributor-role>author</work:contributor-role></work:contributor-attributes></work:contributor></work:contributors></work:work>"
@@ -235,7 +235,7 @@ interactions:
     body:
       string: '{"response-code":409,"developer-message":"409 Conflict: You have already
         added this activity (matched by external identifiers), please see element
-        with put-code 72994840. If you are trying to edit the item, please use PUT
+        with put-code 73087697. If you are trying to edit the item, please use PUT
         instead of POST.","user-message":"There was an error when updating the record.
         Please try again. If the error persists, please contact INSPIRE-HEP for assistance.","error-code":9021,"more-info":"https://members.orcid.org/api/resources/troubleshooting"}'
     headers:
@@ -250,7 +250,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Tue, 28 Apr 2020 14:31:06 GMT
+      - Wed, 29 Apr 2020 15:32:32 GMT
       Expires:
       - '0'
       Pragma:
@@ -279,8 +279,8 @@ interactions:
     uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/works
   response:
     body:
-      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1588084263343\n  },\n\
-        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1588084263343\n\
+      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1588174349731\n  },\n\
+        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1588174349731\n\
         \    },\n    \"external-ids\" : {\n      \"external-id\" : [ {\n        \"\
         external-id-type\" : \"other-id\",\n        \"external-id-value\" : \"999\"\
         ,\n        \"external-id-url\" : {\n          \"value\" : \"http://inspirehep.net/record/999\"\
@@ -289,9 +289,9 @@ interactions:
         \ \"10.1111/test.orcid.push\",\n        \"external-id-url\" : {\n        \
         \  \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\n        },\n\
         \        \"external-id-relationship\" : \"SELF\"\n      } ]\n    },\n    \"\
-        work-summary\" : [ {\n      \"put-code\" : 72994840,\n      \"created-date\"\
-        \ : {\n        \"value\" : 1588084260038\n      },\n      \"last-modified-date\"\
-        \ : {\n        \"value\" : 1588084263343\n      },\n      \"source\" : {\n\
+        work-summary\" : [ {\n      \"put-code\" : 73087697,\n      \"created-date\"\
+        \ : {\n        \"value\" : 1588174346279\n      },\n      \"last-modified-date\"\
+        \ : {\n        \"value\" : 1588174349731\n      },\n      \"source\" : {\n\
         \        \"source-orcid\" : null,\n        \"source-client-id\" : {\n    \
         \      \"uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \
         \    \"path\" : \"0000-0001-8607-8906\",\n          \"host\" : \"orcid.org\"\
@@ -308,7 +308,7 @@ interactions:
         external-id-url\" : {\n            \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\
         \n          },\n          \"external-id-relationship\" : \"SELF\"\n      \
         \  } ]\n      },\n      \"type\" : \"JOURNAL_ARTICLE\",\n      \"publication-date\"\
-        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/72994840\"\
+        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/73087697\"\
         ,\n      \"display-index\" : \"0\"\n    } ]\n  } ],\n  \"path\" : \"/0000-0003-1134-6827/works\"\
         \n}"
     headers:
@@ -321,7 +321,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Tue, 28 Apr 2020 14:31:07 GMT
+      - Wed, 29 Apr 2020 15:32:33 GMT
       Expires:
       - '0'
       Pragma:
@@ -354,8 +354,8 @@ interactions:
     uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/works
   response:
     body:
-      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1588084263343\n  },\n\
-        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1588084263343\n\
+      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1588174349731\n  },\n\
+        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1588174349731\n\
         \    },\n    \"external-ids\" : {\n      \"external-id\" : [ {\n        \"\
         external-id-type\" : \"other-id\",\n        \"external-id-value\" : \"999\"\
         ,\n        \"external-id-url\" : {\n          \"value\" : \"http://inspirehep.net/record/999\"\
@@ -364,9 +364,9 @@ interactions:
         \ \"10.1111/test.orcid.push\",\n        \"external-id-url\" : {\n        \
         \  \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\n        },\n\
         \        \"external-id-relationship\" : \"SELF\"\n      } ]\n    },\n    \"\
-        work-summary\" : [ {\n      \"put-code\" : 72994840,\n      \"created-date\"\
-        \ : {\n        \"value\" : 1588084260038\n      },\n      \"last-modified-date\"\
-        \ : {\n        \"value\" : 1588084263343\n      },\n      \"source\" : {\n\
+        work-summary\" : [ {\n      \"put-code\" : 73087697,\n      \"created-date\"\
+        \ : {\n        \"value\" : 1588174346279\n      },\n      \"last-modified-date\"\
+        \ : {\n        \"value\" : 1588174349731\n      },\n      \"source\" : {\n\
         \        \"source-orcid\" : null,\n        \"source-client-id\" : {\n    \
         \      \"uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \
         \    \"path\" : \"0000-0001-8607-8906\",\n          \"host\" : \"orcid.org\"\
@@ -383,7 +383,7 @@ interactions:
         external-id-url\" : {\n            \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\
         \n          },\n          \"external-id-relationship\" : \"SELF\"\n      \
         \  } ]\n      },\n      \"type\" : \"JOURNAL_ARTICLE\",\n      \"publication-date\"\
-        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/72994840\"\
+        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/73087697\"\
         ,\n      \"display-index\" : \"0\"\n    } ]\n  } ],\n  \"path\" : \"/0000-0003-1134-6827/works\"\
         \n}"
     headers:
@@ -396,7 +396,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Tue, 28 Apr 2020 14:31:08 GMT
+      - Wed, 29 Apr 2020 15:32:34 GMT
       Expires:
       - '0'
       Pragma:
@@ -417,8 +417,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\"><work:title><common:title>title1</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{666,\n\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\"><work:title><common:title>title1</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{666,\n\
       \    author = \"Rossoni, A.\",\n    doi = \"10.1111/test.orcid.push\",\n   \
       \ month = \"5\",\n    title = \"{title1}\",\n    year = \"2017\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>666</common:external-id-value><common:external-id-url>http://inspirehep.net/record/666</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.1111/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.1111/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/666</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
       \ A.</work:credit-name><work:contributor-attributes><work:contributor-sequence>first</work:contributor-sequence><work:contributor-role>author</work:contributor-role></work:contributor-attributes></work:contributor></work:contributors></work:work>"
@@ -439,7 +439,7 @@ interactions:
     body:
       string: '{"response-code":409,"developer-message":"409 Conflict: You have already
         added this activity (matched by external identifiers), please see element
-        with put-code 72994840. If you are trying to edit the item, please use PUT
+        with put-code 73087697. If you are trying to edit the item, please use PUT
         instead of POST.","user-message":"There was an error when updating the record.
         Please try again. If the error persists, please contact INSPIRE-HEP for assistance.","error-code":9021,"more-info":"https://members.orcid.org/api/resources/troubleshooting"}'
     headers:
@@ -454,7 +454,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Tue, 28 Apr 2020 14:31:09 GMT
+      - Wed, 29 Apr 2020 15:32:35 GMT
       Expires:
       - '0'
       Pragma:

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherPostNewWork.test_push_new_work_already_existing.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherPostNewWork.test_push_new_work_already_existing.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\"><work:title><common:title>Some Results Arising\
       \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{45,\n\
       \    author = \"Rossoni, A.\",\n    doi = \"10.1111/test.orcid.push\",\n   \
       \ month = \"5\",\n    title = \"{Some Results Arising from the Study of ORCID\
@@ -24,7 +24,7 @@ interactions:
     body:
       string: '{"response-code":409,"developer-message":"409 Conflict: You have already
         added this activity (matched by external identifiers), please see element
-        with put-code 71114492. If you are trying to edit the item, please use PUT
+        with put-code 73086013. If you are trying to edit the item, please use PUT
         instead of POST.","user-message":"There was an error when updating the record.
         Please try again. If the error persists, please contact INSPIRE-HEP for assistance.","error-code":9021,"more-info":"https://members.orcid.org/api/resources/troubleshooting"}'
     headers:
@@ -39,7 +39,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Thu, 26 Mar 2020 15:06:23 GMT
+      - Wed, 29 Apr 2020 15:08:27 GMT
       Expires:
       - '0'
       Pragma:
@@ -68,8 +68,8 @@ interactions:
     uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/works
   response:
     body:
-      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1585235178756\n  },\n\
-        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1585235178756\n\
+      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1588172903233\n  },\n\
+        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1588172903233\n\
         \    },\n    \"external-ids\" : {\n      \"external-id\" : [ {\n        \"\
         external-id-type\" : \"other-id\",\n        \"external-id-value\" : \"45\"\
         ,\n        \"external-id-url\" : {\n          \"value\" : \"http://inspirehep.net/record/45\"\
@@ -78,9 +78,9 @@ interactions:
         \ \"10.1111/test.orcid.push\",\n        \"external-id-url\" : {\n        \
         \  \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\n        },\n\
         \        \"external-id-relationship\" : \"SELF\"\n      } ]\n    },\n    \"\
-        work-summary\" : [ {\n      \"put-code\" : 71114492,\n      \"created-date\"\
-        \ : {\n        \"value\" : 1585235178756\n      },\n      \"last-modified-date\"\
-        \ : {\n        \"value\" : 1585235178756\n      },\n      \"source\" : {\n\
+        work-summary\" : [ {\n      \"put-code\" : 73086013,\n      \"created-date\"\
+        \ : {\n        \"value\" : 1588172903233\n      },\n      \"last-modified-date\"\
+        \ : {\n        \"value\" : 1588172903233\n      },\n      \"source\" : {\n\
         \        \"source-orcid\" : null,\n        \"source-client-id\" : {\n    \
         \      \"uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \
         \    \"path\" : \"0000-0001-8607-8906\",\n          \"host\" : \"orcid.org\"\
@@ -97,7 +97,7 @@ interactions:
         external-id-url\" : {\n            \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\
         \n          },\n          \"external-id-relationship\" : \"SELF\"\n      \
         \  } ]\n      },\n      \"type\" : \"JOURNAL_ARTICLE\",\n      \"publication-date\"\
-        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/71114492\"\
+        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/73086013\"\
         ,\n      \"display-index\" : \"0\"\n    } ]\n  } ],\n  \"path\" : \"/0000-0003-1134-6827/works\"\
         \n}"
     headers:
@@ -110,7 +110,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Thu, 26 Mar 2020 15:06:23 GMT
+      - Wed, 29 Apr 2020 15:08:28 GMT
       Expires:
       - '0'
       Pragma:
@@ -131,8 +131,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\" put-code=\"71114492\"><work:title><common:title>Some\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\" put-code=\"73086013\"><work:title><common:title>Some\
       \ Results Arising from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{45,\n\
       \    author = \"Rossoni, A.\",\n    doi = \"10.1111/test.orcid.push\",\n   \
       \ month = \"5\",\n    title = \"{Some Results Arising from the Study of ORCID\
@@ -150,16 +150,16 @@ interactions:
       Content-Type:
       - application/orcid+xml
     method: PUT
-    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/71114492
+    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/73086013
   response:
     body:
-      string: "{\n  \"created-date\" : {\n    \"value\" : 1585235178756\n  },\n  \"\
-        last-modified-date\" : {\n    \"value\" : 1585235178756\n  },\n  \"source\"\
+      string: "{\n  \"created-date\" : {\n    \"value\" : 1588172903233\n  },\n  \"\
+        last-modified-date\" : {\n    \"value\" : 1588172903233\n  },\n  \"source\"\
         \ : {\n    \"source-orcid\" : null,\n    \"source-client-id\" : {\n      \"\
         uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \"path\" :\
         \ \"0000-0001-8607-8906\",\n      \"host\" : \"orcid.org\"\n    },\n    \"\
         source-name\" : {\n      \"value\" : \"INSPIRE-HEP\"\n    }\n  },\n  \"put-code\"\
-        \ : 71114492,\n  \"path\" : null,\n  \"title\" : {\n    \"title\" : {\n  \
+        \ : 73086013,\n  \"path\" : null,\n  \"title\" : {\n    \"title\" : {\n  \
         \    \"value\" : \"Some Results Arising from the Study of ORCID push\"\n \
         \   },\n    \"subtitle\" : null,\n    \"translated-title\" : null\n  },\n\
         \  \"journal-title\" : null,\n  \"short-description\" : null,\n  \"citation\"\
@@ -192,7 +192,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Thu, 26 Mar 2020 15:06:24 GMT
+      - Wed, 29 Apr 2020 15:08:28 GMT
       Expires:
       - '0'
       Pragma:

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherPostNewWork.test_push_new_work_already_existing_and_delete_duplicated_records_different_putcodes.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherPostNewWork.test_push_new_work_already_existing_and_delete_duplicated_records_different_putcodes.yaml
@@ -42,11 +42,11 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Fri, 17 Apr 2020 14:12:57 GMT
+      - Wed, 29 Apr 2020 15:08:35 GMT
       Expires:
       - '0'
       Location:
-      - http://api.orcid.org/v2.0/0000-0003-1134-6827/work/72275735
+      - http://api.orcid.org/v2.0/0000-0003-1134-6827/work/73086084
       Pragma:
       - no-cache
       Server:
@@ -61,8 +61,8 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\"><work:title><common:title>Some Results Arising\
       \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{45,\n\
       \    author = \"Rossoni, A.\",\n    doi = \"10.1111/test.orcid.push\",\n   \
       \ month = \"5\",\n    title = \"{Some Results Arising from the Study of ORCID\
@@ -85,7 +85,7 @@ interactions:
     body:
       string: '{"response-code":409,"developer-message":"409 Conflict: You have already
         added this activity (matched by external identifiers), please see element
-        with put-code 72275728. If you are trying to edit the item, please use PUT
+        with put-code 73086013. If you are trying to edit the item, please use PUT
         instead of POST.","user-message":"There was an error when updating the record.
         Please try again. If the error persists, please contact INSPIRE-HEP for assistance.","error-code":9021,"more-info":"https://members.orcid.org/api/resources/troubleshooting"}'
     headers:
@@ -100,7 +100,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Fri, 17 Apr 2020 14:12:58 GMT
+      - Wed, 29 Apr 2020 15:08:36 GMT
       Expires:
       - '0'
       Pragma:
@@ -129,8 +129,8 @@ interactions:
     uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/works
   response:
     body:
-      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1587132777541\n  },\n\
-        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1587132768100\n\
+      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1588172915338\n  },\n\
+        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1588172903233\n\
         \    },\n    \"external-ids\" : {\n      \"external-id\" : [ {\n        \"\
         external-id-type\" : \"other-id\",\n        \"external-id-value\" : \"45\"\
         ,\n        \"external-id-url\" : {\n          \"value\" : \"http://inspirehep.net/record/45\"\
@@ -139,9 +139,9 @@ interactions:
         \ \"10.1111/test.orcid.push\",\n        \"external-id-url\" : {\n        \
         \  \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\n        },\n\
         \        \"external-id-relationship\" : \"SELF\"\n      } ]\n    },\n    \"\
-        work-summary\" : [ {\n      \"put-code\" : 72275728,\n      \"created-date\"\
-        \ : {\n        \"value\" : 1587132768100\n      },\n      \"last-modified-date\"\
-        \ : {\n        \"value\" : 1587132768100\n      },\n      \"source\" : {\n\
+        work-summary\" : [ {\n      \"put-code\" : 73086013,\n      \"created-date\"\
+        \ : {\n        \"value\" : 1588172903233\n      },\n      \"last-modified-date\"\
+        \ : {\n        \"value\" : 1588172903233\n      },\n      \"source\" : {\n\
         \        \"source-orcid\" : null,\n        \"source-client-id\" : {\n    \
         \      \"uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \
         \    \"path\" : \"0000-0001-8607-8906\",\n          \"host\" : \"orcid.org\"\
@@ -158,16 +158,16 @@ interactions:
         external-id-url\" : {\n            \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\
         \n          },\n          \"external-id-relationship\" : \"SELF\"\n      \
         \  } ]\n      },\n      \"type\" : \"JOURNAL_ARTICLE\",\n      \"publication-date\"\
-        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/72275728\"\
+        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/73086013\"\
         ,\n      \"display-index\" : \"0\"\n    } ]\n  }, {\n    \"last-modified-date\"\
-        \ : {\n      \"value\" : 1587132777541\n    },\n    \"external-ids\" : {\n\
+        \ : {\n      \"value\" : 1588172915338\n    },\n    \"external-ids\" : {\n\
         \      \"external-id\" : [ {\n        \"external-id-type\" : \"doi\",\n  \
         \      \"external-id-value\" : \"10.99/test.orcid.push\",\n        \"external-id-url\"\
         \ : {\n          \"value\" : \"http://dx.doi.org/10.99/test.orcid.push\"\n\
         \        },\n        \"external-id-relationship\" : \"SELF\"\n      } ]\n\
-        \    },\n    \"work-summary\" : [ {\n      \"put-code\" : 72275735,\n    \
-        \  \"created-date\" : {\n        \"value\" : 1587132777541\n      },\n   \
-        \   \"last-modified-date\" : {\n        \"value\" : 1587132777541\n      },\n\
+        \    },\n    \"work-summary\" : [ {\n      \"put-code\" : 73086084,\n    \
+        \  \"created-date\" : {\n        \"value\" : 1588172915338\n      },\n   \
+        \   \"last-modified-date\" : {\n        \"value\" : 1588172915338\n      },\n\
         \      \"source\" : {\n        \"source-orcid\" : null,\n        \"source-client-id\"\
         \ : {\n          \"uri\" : \"http://orcid.org/client/0000-0001-8607-8906\"\
         ,\n          \"path\" : \"0000-0001-8607-8906\",\n          \"host\" : \"\
@@ -181,7 +181,7 @@ interactions:
         \      \"value\" : \"http://dx.doi.org/10.99/test.orcid.push\"\n         \
         \ },\n          \"external-id-relationship\" : \"SELF\"\n        } ]\n   \
         \   },\n      \"type\" : \"JOURNAL_ARTICLE\",\n      \"publication-date\"\
-        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/72275735\"\
+        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/73086084\"\
         ,\n      \"display-index\" : \"0\"\n    } ]\n  } ],\n  \"path\" : \"/0000-0003-1134-6827/works\"\
         \n}"
     headers:
@@ -194,7 +194,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Fri, 17 Apr 2020 14:12:59 GMT
+      - Wed, 29 Apr 2020 15:08:37 GMT
       Expires:
       - '0'
       Pragma:
@@ -224,17 +224,17 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/works/72275735
+    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/works/73086084
   response:
     body:
       string: "{\n  \"bulk\" : [ {\n    \"work\" : {\n      \"created-date\" : {\n\
-        \        \"value\" : 1587132777541\n      },\n      \"last-modified-date\"\
-        \ : {\n        \"value\" : 1587132777541\n      },\n      \"source\" : {\n\
+        \        \"value\" : 1588172915338\n      },\n      \"last-modified-date\"\
+        \ : {\n        \"value\" : 1588172915338\n      },\n      \"source\" : {\n\
         \        \"source-orcid\" : null,\n        \"source-client-id\" : {\n    \
         \      \"uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \
         \    \"path\" : \"0000-0001-8607-8906\",\n          \"host\" : \"orcid.org\"\
         \n        },\n        \"source-name\" : {\n          \"value\" : \"INSPIRE-HEP\"\
-        \n        }\n      },\n      \"put-code\" : 72275735,\n      \"path\" : null,\n\
+        \n        }\n      },\n      \"put-code\" : 73086084,\n      \"path\" : null,\n\
         \      \"title\" : {\n        \"title\" : {\n          \"value\" : \"Some\
         \ Results Arising from the Study of ORCID push\"\n        },\n        \"subtitle\"\
         \ : null,\n        \"translated-title\" : null\n      },\n      \"journal-title\"\
@@ -262,7 +262,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Fri, 17 Apr 2020 14:13:00 GMT
+      - Wed, 29 Apr 2020 15:08:38 GMT
       Expires:
       - '0'
       Pragma:
@@ -296,7 +296,7 @@ interactions:
       Content-Type:
       - application/orcid+json
     method: DELETE
-    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/72275735
+    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/73086084
   response:
     body:
       string: ''
@@ -310,7 +310,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Fri, 17 Apr 2020 14:13:00 GMT
+      - Wed, 29 Apr 2020 15:08:38 GMT
       Expires:
       - '0'
       Pragma:
@@ -327,8 +327,8 @@ interactions:
       code: 204
       message: No Content
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\" put-code=\"72275728\"><work:title><common:title>Some\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\" put-code=\"73086013\"><work:title><common:title>Some\
       \ Results Arising from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{45,\n\
       \    author = \"Rossoni, A.\",\n    doi = \"10.1111/test.orcid.push\",\n   \
       \ month = \"5\",\n    title = \"{Some Results Arising from the Study of ORCID\
@@ -346,16 +346,16 @@ interactions:
       Content-Type:
       - application/orcid+xml
     method: PUT
-    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/72275728
+    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/73086013
   response:
     body:
-      string: "{\n  \"created-date\" : {\n    \"value\" : 1587132768100\n  },\n  \"\
-        last-modified-date\" : {\n    \"value\" : 1587132768100\n  },\n  \"source\"\
+      string: "{\n  \"created-date\" : {\n    \"value\" : 1588172903233\n  },\n  \"\
+        last-modified-date\" : {\n    \"value\" : 1588172903233\n  },\n  \"source\"\
         \ : {\n    \"source-orcid\" : null,\n    \"source-client-id\" : {\n      \"\
         uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \"path\" :\
         \ \"0000-0001-8607-8906\",\n      \"host\" : \"orcid.org\"\n    },\n    \"\
         source-name\" : {\n      \"value\" : \"INSPIRE-HEP\"\n    }\n  },\n  \"put-code\"\
-        \ : 72275728,\n  \"path\" : null,\n  \"title\" : {\n    \"title\" : {\n  \
+        \ : 73086013,\n  \"path\" : null,\n  \"title\" : {\n    \"title\" : {\n  \
         \    \"value\" : \"Some Results Arising from the Study of ORCID push\"\n \
         \   },\n    \"subtitle\" : null,\n    \"translated-title\" : null\n  },\n\
         \  \"journal-title\" : null,\n  \"short-description\" : null,\n  \"citation\"\
@@ -388,7 +388,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Fri, 17 Apr 2020 14:13:01 GMT
+      - Wed, 29 Apr 2020 15:08:39 GMT
       Expires:
       - '0'
       Pragma:

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherPostNewWork.test_push_new_work_already_existing_duplicated_external_identifier_exception.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherPostNewWork.test_push_new_work_already_existing_duplicated_external_identifier_exception.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\"><work:title><common:title>Some Results Arising\
       \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{46,\n\
       \    author = \"Rossoni, A.\",\n    doi = \"10.1111/test.orcid.push\",\n   \
       \ month = \"5\",\n    title = \"{Some Results Arising from the Study of ORCID\
@@ -24,7 +24,7 @@ interactions:
     body:
       string: '{"response-code":409,"developer-message":"409 Conflict: You have already
         added this activity (matched by external identifiers), please see element
-        with put-code 71114492. If you are trying to edit the item, please use PUT
+        with put-code 73086013. If you are trying to edit the item, please use PUT
         instead of POST.","user-message":"There was an error when updating the record.
         Please try again. If the error persists, please contact INSPIRE-HEP for assistance.","error-code":9021,"more-info":"https://members.orcid.org/api/resources/troubleshooting"}'
     headers:
@@ -39,7 +39,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Thu, 26 Mar 2020 15:06:27 GMT
+      - Wed, 29 Apr 2020 15:08:31 GMT
       Expires:
       - '0'
       Pragma:
@@ -68,8 +68,8 @@ interactions:
     uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/works
   response:
     body:
-      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1585235178756\n  },\n\
-        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1585235178756\n\
+      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1588172903233\n  },\n\
+        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1588172903233\n\
         \    },\n    \"external-ids\" : {\n      \"external-id\" : [ {\n        \"\
         external-id-type\" : \"other-id\",\n        \"external-id-value\" : \"45\"\
         ,\n        \"external-id-url\" : {\n          \"value\" : \"http://inspirehep.net/record/45\"\
@@ -78,9 +78,9 @@ interactions:
         \ \"10.1111/test.orcid.push\",\n        \"external-id-url\" : {\n        \
         \  \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\n        },\n\
         \        \"external-id-relationship\" : \"SELF\"\n      } ]\n    },\n    \"\
-        work-summary\" : [ {\n      \"put-code\" : 71114492,\n      \"created-date\"\
-        \ : {\n        \"value\" : 1585235178756\n      },\n      \"last-modified-date\"\
-        \ : {\n        \"value\" : 1585235178756\n      },\n      \"source\" : {\n\
+        work-summary\" : [ {\n      \"put-code\" : 73086013,\n      \"created-date\"\
+        \ : {\n        \"value\" : 1588172903233\n      },\n      \"last-modified-date\"\
+        \ : {\n        \"value\" : 1588172903233\n      },\n      \"source\" : {\n\
         \        \"source-orcid\" : null,\n        \"source-client-id\" : {\n    \
         \      \"uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \
         \    \"path\" : \"0000-0001-8607-8906\",\n          \"host\" : \"orcid.org\"\
@@ -97,7 +97,7 @@ interactions:
         external-id-url\" : {\n            \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\
         \n          },\n          \"external-id-relationship\" : \"SELF\"\n      \
         \  } ]\n      },\n      \"type\" : \"JOURNAL_ARTICLE\",\n      \"publication-date\"\
-        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/71114492\"\
+        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/73086013\"\
         ,\n      \"display-index\" : \"0\"\n    } ]\n  } ],\n  \"path\" : \"/0000-0003-1134-6827/works\"\
         \n}"
     headers:
@@ -110,7 +110,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Thu, 26 Mar 2020 15:06:28 GMT
+      - Wed, 29 Apr 2020 15:08:32 GMT
       Expires:
       - '0'
       Pragma:
@@ -143,8 +143,8 @@ interactions:
     uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/works
   response:
     body:
-      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1585235178756\n  },\n\
-        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1585235178756\n\
+      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1588172903233\n  },\n\
+        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1588172903233\n\
         \    },\n    \"external-ids\" : {\n      \"external-id\" : [ {\n        \"\
         external-id-type\" : \"other-id\",\n        \"external-id-value\" : \"45\"\
         ,\n        \"external-id-url\" : {\n          \"value\" : \"http://inspirehep.net/record/45\"\
@@ -153,9 +153,9 @@ interactions:
         \ \"10.1111/test.orcid.push\",\n        \"external-id-url\" : {\n        \
         \  \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\n        },\n\
         \        \"external-id-relationship\" : \"SELF\"\n      } ]\n    },\n    \"\
-        work-summary\" : [ {\n      \"put-code\" : 71114492,\n      \"created-date\"\
-        \ : {\n        \"value\" : 1585235178756\n      },\n      \"last-modified-date\"\
-        \ : {\n        \"value\" : 1585235178756\n      },\n      \"source\" : {\n\
+        work-summary\" : [ {\n      \"put-code\" : 73086013,\n      \"created-date\"\
+        \ : {\n        \"value\" : 1588172903233\n      },\n      \"last-modified-date\"\
+        \ : {\n        \"value\" : 1588172903233\n      },\n      \"source\" : {\n\
         \        \"source-orcid\" : null,\n        \"source-client-id\" : {\n    \
         \      \"uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \
         \    \"path\" : \"0000-0001-8607-8906\",\n          \"host\" : \"orcid.org\"\
@@ -172,7 +172,7 @@ interactions:
         external-id-url\" : {\n            \"value\" : \"http://dx.doi.org/10.1111/test.orcid.push\"\
         \n          },\n          \"external-id-relationship\" : \"SELF\"\n      \
         \  } ]\n      },\n      \"type\" : \"JOURNAL_ARTICLE\",\n      \"publication-date\"\
-        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/71114492\"\
+        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/73086013\"\
         ,\n      \"display-index\" : \"0\"\n    } ]\n  } ],\n  \"path\" : \"/0000-0003-1134-6827/works\"\
         \n}"
     headers:
@@ -185,7 +185,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Thu, 26 Mar 2020 15:06:29 GMT
+      - Wed, 29 Apr 2020 15:08:32 GMT
       Expires:
       - '0'
       Pragma:
@@ -206,8 +206,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\"><work:title><common:title>Some Results Arising\
       \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{46,\n\
       \    author = \"Rossoni, A.\",\n    doi = \"10.1111/test.orcid.push\",\n   \
       \ month = \"5\",\n    title = \"{Some Results Arising from the Study of ORCID\
@@ -230,7 +230,7 @@ interactions:
     body:
       string: '{"response-code":409,"developer-message":"409 Conflict: You have already
         added this activity (matched by external identifiers), please see element
-        with put-code 71114492. If you are trying to edit the item, please use PUT
+        with put-code 73086013. If you are trying to edit the item, please use PUT
         instead of POST.","user-message":"There was an error when updating the record.
         Please try again. If the error persists, please contact INSPIRE-HEP for assistance.","error-code":9021,"more-info":"https://members.orcid.org/api/resources/troubleshooting"}'
     headers:
@@ -245,7 +245,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Thu, 26 Mar 2020 15:06:30 GMT
+      - Wed, 29 Apr 2020 15:08:33 GMT
       Expires:
       - '0'
       Pragma:

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherPostNewWork.test_push_new_work_already_existing_with_recids.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherPostNewWork.test_push_new_work_already_existing_with_recids.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\"><work:title><common:title>Some Results Arising\
       \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{45,\n\
       \    author = \"Rossoni, A.\",\n    doi = \"10.1111/test.orcid.push\",\n   \
       \ month = \"5\",\n    title = \"{Some Results Arising from the Study of ORCID\
@@ -35,11 +35,11 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Thu, 26 Mar 2020 15:06:26 GMT
+      - Wed, 29 Apr 2020 15:08:30 GMT
       Expires:
       - '0'
       Location:
-      - http://api.orcid.org/v2.0/0000-0001-8627-769X/work/71114503
+      - http://api.orcid.org/v2.0/0000-0001-8627-769X/work/73086058
       Pragma:
       - no-cache
       Server:

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherPostNewWork.test_push_new_work_happy_flow.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherPostNewWork.test_push_new_work_happy_flow.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Thu, 26 Mar 2020 15:06:17 GMT
+      - Wed, 29 Apr 2020 15:08:21 GMT
       Expires:
       - '0'
       Pragma:
@@ -69,7 +69,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Thu, 26 Mar 2020 15:06:17 GMT
+      - Wed, 29 Apr 2020 15:08:22 GMT
       Expires:
       - '0'
       Pragma:
@@ -90,8 +90,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\"><work:title><common:title>Some Results Arising\
       \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{45,\n\
       \    author = \"Rossoni, A.\",\n    doi = \"10.1111/test.orcid.push\",\n   \
       \ month = \"5\",\n    title = \"{Some Results Arising from the Study of ORCID\
@@ -125,11 +125,11 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Thu, 26 Mar 2020 15:06:18 GMT
+      - Wed, 29 Apr 2020 15:08:23 GMT
       Expires:
       - '0'
       Location:
-      - http://api.orcid.org/v2.0/0000-0003-1134-6827/work/71114492
+      - http://api.orcid.org/v2.0/0000-0003-1134-6827/work/73086013
       Pragma:
       - no-cache
       Server:

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherPostNewWork.test_push_new_work_invalid_data_orcid.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherPostNewWork.test_push_new_work_invalid_data_orcid.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\"><work:title><common:title>Some Results Arising\
       \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{45,\n\
       \    author = \"Rossoni, A.\",\n    doi = \"10.1111/test.orcid.push\",\n   \
       \ month = \"5\",\n    title = \"{Some Results Arising from the Study of ORCID\
@@ -35,7 +35,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Thu, 26 Mar 2020 15:06:19 GMT
+      - Wed, 29 Apr 2020 15:08:24 GMT
       Expires:
       - '0'
       Pragma:

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherPostNewWork.test_push_new_work_invalid_data_token.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherPostNewWork.test_push_new_work_invalid_data_token.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\"><work:title><common:title>Some Results Arising\
       \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{45,\n\
       \    author = \"Rossoni, A.\",\n    doi = \"10.1111/test.orcid.push\",\n   \
       \ month = \"5\",\n    title = \"{Some Results Arising from the Study of ORCID\
@@ -34,7 +34,7 @@ interactions:
       Content-Type:
       - application/orcid+json;charset=UTF-8
       Date:
-      - Thu, 26 Mar 2020 15:06:20 GMT
+      - Wed, 29 Apr 2020 15:08:25 GMT
       Pragma:
       - no-cache
       Server:

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherPostNewWork.test_push_new_work_invalid_data_xml.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherPostNewWork.test_push_new_work_invalid_data_xml.yaml
@@ -36,7 +36,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Thu, 26 Mar 2020 15:06:21 GMT
+      - Wed, 29 Apr 2020 15:08:26 GMT
       Expires:
       - '0'
       Pragma:

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherPutUpdatedWork.test_push_updated_work_happy_flow.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherPutUpdatedWork.test_push_updated_work_happy_flow.yaml
@@ -47,11 +47,11 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Fri, 27 Mar 2020 11:22:05 GMT
+      - Wed, 29 Apr 2020 15:08:43 GMT
       Expires:
       - '0'
       Location:
-      - http://api.orcid.org/v2.0/0000-0003-1134-6827/work/71156708
+      - http://api.orcid.org/v2.0/0000-0003-1134-6827/work/73086116
       Pragma:
       - no-cache
       Server:
@@ -66,8 +66,8 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\" put-code=\"71156708\"><work:title><common:title>Some\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\" put-code=\"73086116\"><work:title><common:title>Some\
       \ Results Arising from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{999,\n\
       \    author = \"Rossoni, A.\",\n    doi = \"10.9999/test.orcid.push\",\n   \
       \ month = \"5\",\n    title = \"{Some Results Arising from the Study of ORCID\
@@ -85,16 +85,16 @@ interactions:
       Content-Type:
       - application/orcid+xml
     method: PUT
-    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/71156708
+    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/73086116
   response:
     body:
-      string: "{\n  \"created-date\" : {\n    \"value\" : 1585308125350\n  },\n  \"\
-        last-modified-date\" : {\n    \"value\" : 1585308127085\n  },\n  \"source\"\
+      string: "{\n  \"created-date\" : {\n    \"value\" : 1588172923398\n  },\n  \"\
+        last-modified-date\" : {\n    \"value\" : 1588172924098\n  },\n  \"source\"\
         \ : {\n    \"source-orcid\" : null,\n    \"source-client-id\" : {\n      \"\
         uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \"path\" :\
         \ \"0000-0001-8607-8906\",\n      \"host\" : \"orcid.org\"\n    },\n    \"\
         source-name\" : {\n      \"value\" : \"INSPIRE-HEP\"\n    }\n  },\n  \"put-code\"\
-        \ : 71156708,\n  \"path\" : null,\n  \"title\" : {\n    \"title\" : {\n  \
+        \ : 73086116,\n  \"path\" : null,\n  \"title\" : {\n    \"title\" : {\n  \
         \    \"value\" : \"Some Results Arising from the Study of ORCID push\"\n \
         \   },\n    \"subtitle\" : null,\n    \"translated-title\" : null\n  },\n\
         \  \"journal-title\" : null,\n  \"short-description\" : null,\n  \"citation\"\
@@ -127,7 +127,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Fri, 27 Mar 2020 11:22:07 GMT
+      - Wed, 29 Apr 2020 15:08:44 GMT
       Expires:
       - '0'
       Pragma:

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherPutUpdatedWork.test_push_updated_work_invalid_data_orcid.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherPutUpdatedWork.test_push_updated_work_invalid_data_orcid.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\"><work:title><common:title>Some Results Arising\
       \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{999,\n\
       \    author = \"Rossoni, A.\",\n    doi = \"10.9999/test.orcid.push\",\n   \
       \ month = \"5\",\n    title = \"{Some Results Arising from the Study of ORCID\
@@ -34,7 +34,7 @@ interactions:
       Content-Type:
       - application/orcid+json;charset=UTF-8
       Date:
-      - Fri, 27 Mar 2020 11:22:16 GMT
+      - Wed, 29 Apr 2020 15:08:50 GMT
       Pragma:
       - no-cache
       Server:

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherPutUpdatedWork.test_push_updated_work_invalid_data_putcode.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherPutUpdatedWork.test_push_updated_work_invalid_data_putcode.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\" put-code=\"00000\"><work:title><common:title>Some\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\" put-code=\"00000\"><work:title><common:title>Some\
       \ Results Arising from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{999,\n\
       \    author = \"Rossoni, A.\",\n    doi = \"10.9999/test.orcid.push\",\n   \
       \ month = \"5\",\n    title = \"{Some Results Arising from the Study of ORCID\
@@ -35,13 +35,15 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Fri, 27 Mar 2020 11:22:08 GMT
+      - Wed, 29 Apr 2020 15:08:45 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
       Server:
       - nginx/1.16.1
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -53,118 +55,6 @@ interactions:
     status:
       code: 404
       message: Not Found
-- request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
-      \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{999,\n\
-      \    author = \"Rossoni, A.\",\n    doi = \"10.9999/test.orcid.push\",\n   \
-      \ month = \"5\",\n    title = \"{Some Results Arising from the Study of ORCID\
-      \ push}\",\n    year = \"2017\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>999</common:external-id-value><common:external-id-url>http://inspirehep.net/record/999</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.9999/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.9999/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/999</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
-      \ A.</work:credit-name><work:contributor-attributes><work:contributor-sequence>first</work:contributor-sequence><work:contributor-role>author</work:contributor-role></work:contributor-attributes></work:contributor></work:contributors></work:work>"
-    headers:
-      Accept:
-      - application/orcid+json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '1588'
-      Content-Type:
-      - application/orcid+xml
-    method: POST
-    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work
-  response:
-    body:
-      string: '{"response-code":409,"developer-message":"409 Conflict: You have already
-        added this activity (matched by external identifiers), please see element
-        with put-code 71156708. If you are trying to edit the item, please use PUT
-        instead of POST.","user-message":"There was an error when updating the record.
-        Please try again. If the error persists, please contact INSPIRE-HEP for assistance.","error-code":9021,"more-info":"https://members.orcid.org/api/resources/troubleshooting"}'
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '474'
-      Content-Type:
-      - application/orcid+json; qs=2;charset=UTF-8
-      Date:
-      - Fri, 27 Mar 2020 11:22:08 GMT
-      Expires:
-      - '0'
-      Pragma:
-      - no-cache
-      Server:
-      - nginx/1.16.1
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 409
-      message: Conflict
-- request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
-      \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{999,\n\
-      \    author = \"Rossoni, A.\",\n    doi = \"10.9999/test.orcid.push\",\n   \
-      \ month = \"5\",\n    title = \"{Some Results Arising from the Study of ORCID\
-      \ push}\",\n    year = \"2017\"\n}\n</work:citation-value></work:citation><work:type>journal-article</work:type><common:external-ids><common:external-id><common:external-id-type>other-id</common:external-id-type><common:external-id-value>999</common:external-id-value><common:external-id-url>http://inspirehep.net/record/999</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id><common:external-id><common:external-id-type>doi</common:external-id-type><common:external-id-value>10.9999/test.orcid.push</common:external-id-value><common:external-id-url>http://dx.doi.org/10.9999/test.orcid.push</common:external-id-url><common:external-id-relationship>self</common:external-id-relationship></common:external-id></common:external-ids><work:url>http://inspirehep.net/record/999</work:url><work:contributors><work:contributor><work:credit-name>Rossoni,\
-      \ A.</work:credit-name><work:contributor-attributes><work:contributor-sequence>first</work:contributor-sequence><work:contributor-role>author</work:contributor-role></work:contributor-attributes></work:contributor></work:contributors></work:work>"
-    headers:
-      Accept:
-      - application/orcid+json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '1588'
-      Content-Type:
-      - application/orcid+xml
-    method: POST
-    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work
-  response:
-    body:
-      string: '{"response-code":409,"developer-message":"409 Conflict: You have already
-        added this activity (matched by external identifiers), please see element
-        with put-code 71156708. If you are trying to edit the item, please use PUT
-        instead of POST.","user-message":"There was an error when updating the record.
-        Please try again. If the error persists, please contact INSPIRE-HEP for assistance.","error-code":9021,"more-info":"https://members.orcid.org/api/resources/troubleshooting"}'
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '474'
-      Content-Type:
-      - application/orcid+json; qs=2;charset=UTF-8
-      Date:
-      - Fri, 27 Mar 2020 11:22:09 GMT
-      Expires:
-      - '0'
-      Pragma:
-      - no-cache
-      Server:
-      - nginx/1.16.1
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 409
-      message: Conflict
 - request:
     body: null
     headers:
@@ -178,8 +68,8 @@ interactions:
     uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/works
   response:
     body:
-      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1585308127085\n  },\n\
-        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1585308127085\n\
+      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1588172924098\n  },\n\
+        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1588172924098\n\
         \    },\n    \"external-ids\" : {\n      \"external-id\" : [ {\n        \"\
         external-id-type\" : \"other-id\",\n        \"external-id-value\" : \"999\"\
         ,\n        \"external-id-url\" : {\n          \"value\" : \"http://inspirehep.net/record/999\"\
@@ -188,9 +78,9 @@ interactions:
         \ \"10.9999/test.orcid.push\",\n        \"external-id-url\" : {\n        \
         \  \"value\" : \"http://dx.doi.org/10.9999/test.orcid.push\"\n        },\n\
         \        \"external-id-relationship\" : \"SELF\"\n      } ]\n    },\n    \"\
-        work-summary\" : [ {\n      \"put-code\" : 71156708,\n      \"created-date\"\
-        \ : {\n        \"value\" : 1585308125350\n      },\n      \"last-modified-date\"\
-        \ : {\n        \"value\" : 1585308127085\n      },\n      \"source\" : {\n\
+        work-summary\" : [ {\n      \"put-code\" : 73086116,\n      \"created-date\"\
+        \ : {\n        \"value\" : 1588172923398\n      },\n      \"last-modified-date\"\
+        \ : {\n        \"value\" : 1588172924098\n      },\n      \"source\" : {\n\
         \        \"source-orcid\" : null,\n        \"source-client-id\" : {\n    \
         \      \"uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \
         \    \"path\" : \"0000-0001-8607-8906\",\n          \"host\" : \"orcid.org\"\
@@ -207,7 +97,7 @@ interactions:
         external-id-url\" : {\n            \"value\" : \"http://dx.doi.org/10.9999/test.orcid.push\"\
         \n          },\n          \"external-id-relationship\" : \"SELF\"\n      \
         \  } ]\n      },\n      \"type\" : \"JOURNAL_ARTICLE\",\n      \"publication-date\"\
-        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/71156708\"\
+        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/73086116\"\
         ,\n      \"display-index\" : \"0\"\n    } ]\n  } ],\n  \"path\" : \"/0000-0003-1134-6827/works\"\
         \n}"
     headers:
@@ -220,13 +110,15 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Fri, 27 Mar 2020 11:22:11 GMT
+      - Wed, 29 Apr 2020 15:08:46 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
       Server:
       - nginx/1.16.1
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -239,8 +131,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\" put-code=\"71156708\"><work:title><common:title>Some\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\" put-code=\"73086116\"><work:title><common:title>Some\
       \ Results Arising from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{999,\n\
       \    author = \"Rossoni, A.\",\n    doi = \"10.9999/test.orcid.push\",\n   \
       \ month = \"5\",\n    title = \"{Some Results Arising from the Study of ORCID\
@@ -258,16 +150,16 @@ interactions:
       Content-Type:
       - application/orcid+xml
     method: PUT
-    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/71156708
+    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/73086116
   response:
     body:
-      string: "{\n  \"created-date\" : {\n    \"value\" : 1585308125350\n  },\n  \"\
-        last-modified-date\" : {\n    \"value\" : 1585308127085\n  },\n  \"source\"\
+      string: "{\n  \"created-date\" : {\n    \"value\" : 1588172923398\n  },\n  \"\
+        last-modified-date\" : {\n    \"value\" : 1588172924098\n  },\n  \"source\"\
         \ : {\n    \"source-orcid\" : null,\n    \"source-client-id\" : {\n      \"\
         uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \"path\" :\
         \ \"0000-0001-8607-8906\",\n      \"host\" : \"orcid.org\"\n    },\n    \"\
         source-name\" : {\n      \"value\" : \"INSPIRE-HEP\"\n    }\n  },\n  \"put-code\"\
-        \ : 71156708,\n  \"path\" : null,\n  \"title\" : {\n    \"title\" : {\n  \
+        \ : 73086116,\n  \"path\" : null,\n  \"title\" : {\n    \"title\" : {\n  \
         \    \"value\" : \"Some Results Arising from the Study of ORCID push\"\n \
         \   },\n    \"subtitle\" : null,\n    \"translated-title\" : null\n  },\n\
         \  \"journal-title\" : null,\n  \"short-description\" : null,\n  \"citation\"\
@@ -300,7 +192,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Fri, 27 Mar 2020 11:22:12 GMT
+      - Wed, 29 Apr 2020 15:08:47 GMT
       Expires:
       - '0'
       Pragma:
@@ -320,3 +212,4 @@ interactions:
     status:
       code: 200
       message: OK
+version: 1

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherPutUpdatedWork.test_push_updated_work_invalid_data_token.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherPutUpdatedWork.test_push_updated_work_invalid_data_token.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\"><work:title><common:title>Some Results Arising\
       \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{999,\n\
       \    author = \"Rossoni, A.\",\n    doi = \"10.9999/test.orcid.push\",\n   \
       \ month = \"5\",\n    title = \"{Some Results Arising from the Study of ORCID\
@@ -34,7 +34,7 @@ interactions:
       Content-Type:
       - application/orcid+json;charset=UTF-8
       Date:
-      - Fri, 27 Mar 2020 11:22:17 GMT
+      - Wed, 29 Apr 2020 15:08:52 GMT
       Pragma:
       - no-cache
       Server:

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherPutUpdatedWork.test_push_updated_work_no_cache.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherPutUpdatedWork.test_push_updated_work_no_cache.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\"><work:title><common:title>Some Results Arising\
       \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{999,\n\
       \    author = \"Rossoni, A.\",\n    doi = \"10.9999/test.orcid.push\",\n   \
       \ month = \"5\",\n    title = \"{Some Results Arising from the Study of ORCID\
@@ -24,7 +24,7 @@ interactions:
     body:
       string: '{"response-code":409,"developer-message":"409 Conflict: You have already
         added this activity (matched by external identifiers), please see element
-        with put-code 71156708. If you are trying to edit the item, please use PUT
+        with put-code 73086116. If you are trying to edit the item, please use PUT
         instead of POST.","user-message":"There was an error when updating the record.
         Please try again. If the error persists, please contact INSPIRE-HEP for assistance.","error-code":9021,"more-info":"https://members.orcid.org/api/resources/troubleshooting"}'
     headers:
@@ -39,7 +39,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Fri, 27 Mar 2020 11:22:13 GMT
+      - Wed, 29 Apr 2020 15:08:48 GMT
       Expires:
       - '0'
       Pragma:
@@ -68,8 +68,8 @@ interactions:
     uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/works
   response:
     body:
-      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1585308127085\n  },\n\
-        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1585308127085\n\
+      string: "{\n  \"last-modified-date\" : {\n    \"value\" : 1588172924098\n  },\n\
+        \  \"group\" : [ {\n    \"last-modified-date\" : {\n      \"value\" : 1588172924098\n\
         \    },\n    \"external-ids\" : {\n      \"external-id\" : [ {\n        \"\
         external-id-type\" : \"other-id\",\n        \"external-id-value\" : \"999\"\
         ,\n        \"external-id-url\" : {\n          \"value\" : \"http://inspirehep.net/record/999\"\
@@ -78,9 +78,9 @@ interactions:
         \ \"10.9999/test.orcid.push\",\n        \"external-id-url\" : {\n        \
         \  \"value\" : \"http://dx.doi.org/10.9999/test.orcid.push\"\n        },\n\
         \        \"external-id-relationship\" : \"SELF\"\n      } ]\n    },\n    \"\
-        work-summary\" : [ {\n      \"put-code\" : 71156708,\n      \"created-date\"\
-        \ : {\n        \"value\" : 1585308125350\n      },\n      \"last-modified-date\"\
-        \ : {\n        \"value\" : 1585308127085\n      },\n      \"source\" : {\n\
+        work-summary\" : [ {\n      \"put-code\" : 73086116,\n      \"created-date\"\
+        \ : {\n        \"value\" : 1588172923398\n      },\n      \"last-modified-date\"\
+        \ : {\n        \"value\" : 1588172924098\n      },\n      \"source\" : {\n\
         \        \"source-orcid\" : null,\n        \"source-client-id\" : {\n    \
         \      \"uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \
         \    \"path\" : \"0000-0001-8607-8906\",\n          \"host\" : \"orcid.org\"\
@@ -97,7 +97,7 @@ interactions:
         external-id-url\" : {\n            \"value\" : \"http://dx.doi.org/10.9999/test.orcid.push\"\
         \n          },\n          \"external-id-relationship\" : \"SELF\"\n      \
         \  } ]\n      },\n      \"type\" : \"JOURNAL_ARTICLE\",\n      \"publication-date\"\
-        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/71156708\"\
+        \ : null,\n      \"visibility\" : \"PUBLIC\",\n      \"path\" : \"/0000-0003-1134-6827/work/73086116\"\
         ,\n      \"display-index\" : \"0\"\n    } ]\n  } ],\n  \"path\" : \"/0000-0003-1134-6827/works\"\
         \n}"
     headers:
@@ -110,13 +110,15 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Fri, 27 Mar 2020 11:22:14 GMT
+      - Wed, 29 Apr 2020 15:08:48 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
       Server:
       - nginx/1.16.1
+      Transfer-Encoding:
+      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -129,8 +131,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\" put-code=\"71156708\"><work:title><common:title>Some\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\" put-code=\"73086116\"><work:title><common:title>Some\
       \ Results Arising from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{999,\n\
       \    author = \"Rossoni, A.\",\n    doi = \"10.9999/test.orcid.push\",\n   \
       \ month = \"5\",\n    title = \"{Some Results Arising from the Study of ORCID\
@@ -148,16 +150,16 @@ interactions:
       Content-Type:
       - application/orcid+xml
     method: PUT
-    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/71156708
+    uri: https://api.orcid.org/v2.0/0000-0003-1134-6827/work/73086116
   response:
     body:
-      string: "{\n  \"created-date\" : {\n    \"value\" : 1585308125350\n  },\n  \"\
-        last-modified-date\" : {\n    \"value\" : 1585308127085\n  },\n  \"source\"\
+      string: "{\n  \"created-date\" : {\n    \"value\" : 1588172923398\n  },\n  \"\
+        last-modified-date\" : {\n    \"value\" : 1588172924098\n  },\n  \"source\"\
         \ : {\n    \"source-orcid\" : null,\n    \"source-client-id\" : {\n      \"\
         uri\" : \"http://orcid.org/client/0000-0001-8607-8906\",\n      \"path\" :\
         \ \"0000-0001-8607-8906\",\n      \"host\" : \"orcid.org\"\n    },\n    \"\
         source-name\" : {\n      \"value\" : \"INSPIRE-HEP\"\n    }\n  },\n  \"put-code\"\
-        \ : 71156708,\n  \"path\" : null,\n  \"title\" : {\n    \"title\" : {\n  \
+        \ : 73086116,\n  \"path\" : null,\n  \"title\" : {\n    \"title\" : {\n  \
         \    \"value\" : \"Some Results Arising from the Study of ORCID push\"\n \
         \   },\n    \"subtitle\" : null,\n    \"translated-title\" : null\n  },\n\
         \  \"journal-title\" : null,\n  \"short-description\" : null,\n  \"citation\"\
@@ -190,7 +192,7 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Fri, 27 Mar 2020 11:22:15 GMT
+      - Wed, 29 Apr 2020 15:08:49 GMT
       Expires:
       - '0'
       Pragma:
@@ -210,4 +212,4 @@ interactions:
     status:
       code: 200
       message: OK
-
+version: 1

--- a/backend/tests/integration/orcid/cassettes/TestOrcidPusherRecordDBVersion.test_happy_flow.yaml
+++ b/backend/tests/integration/orcid/cassettes/TestOrcidPusherRecordDBVersion.test_happy_flow.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: "<work:work xmlns:common=\"http://www.orcid.org/ns/common\" xmlns:work=\"\
-      http://www.orcid.org/ns/work\"><work:title><common:title>Some Results Arising\
+    body: "<work:work xmlns:work=\"http://www.orcid.org/ns/work\" xmlns:common=\"\
+      http://www.orcid.org/ns/common\"><work:title><common:title>Some Results Arising\
       \ from the Study of ORCID push</common:title></work:title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{45,\n\
       \    author = \"Rossoni, A.\",\n    doi = \"10.1100/test.orcid.push\",\n   \
       \ month = \"5\",\n    title = \"{Some Results Arising from the Study of ORCID\
@@ -35,11 +35,11 @@ interactions:
       Content-Type:
       - application/orcid+json; qs=2;charset=UTF-8
       Date:
-      - Thu, 26 Mar 2020 15:19:31 GMT
+      - Wed, 29 Apr 2020 15:09:31 GMT
       Expires:
       - '0'
       Location:
-      - http://api.orcid.org/v2.0/0000-0003-1134-6827/work/71115041
+      - http://api.orcid.org/v2.0/0000-0003-1134-6827/work/73086169
       Pragma:
       - no-cache
       Server:

--- a/backend/tests/integration/orcid/test_orcid_converter.py
+++ b/backend/tests/integration/orcid/test_orcid_converter.py
@@ -19,7 +19,7 @@
 # In applying this licenseCERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
-
+import io
 import json
 import os
 
@@ -29,6 +29,15 @@ from lxml import etree
 
 from inspirehep.orcid.cache import _OrcidHasher
 from inspirehep.orcid.converter import ExternalIdentifier, OrcidConverter
+
+
+def canonicalize_xml_element(element):
+    """Return a string with a canonical representation of the element.
+    """
+    element_tree = element.getroottree()
+    output_stream = io.BytesIO()
+    element_tree.write_c14n(output_stream, with_comments=False, exclusive=True)
+    return output_stream.getvalue()
 
 
 def valid_against_schema(xml):
@@ -49,9 +58,9 @@ def xml_parse(xml_string):
 
 def xml_compare(expected, result):
     """Assert two XML nodes equal."""
-    assert etree.tostring(result, pretty_print=True) == etree.tostring(
-        expected, pretty_print=True
-    )
+    result_xml_canonicalized = canonicalize_xml_element(result)
+    expected_xml_canonicalized = canonicalize_xml_element(expected)
+    assert result_xml_canonicalized == expected_xml_canonicalized
     return True
 
 

--- a/backend/tests/integration/orcid/test_orcid_domain_models.py
+++ b/backend/tests/integration/orcid/test_orcid_domain_models.py
@@ -469,7 +469,7 @@ class TestOrcidPusherDuplicatedIdentifier(TestOrcidPusherBase):
             self.factory_clashing.record_metadata.json["deleted"] = True
 
             with pytest.raises(exceptions.DuplicatedExternalIdentifierPusherException):
-                tasks.orcid_push.apply_async(
+                tasks.orcid_push.apply(
                     queue="orcid_push_legacy_tokens",
                     kwargs={
                         "orcid": self.orcid,


### PR DESCRIPTION
* upgrade orcid tests which were failing because of switch to newer version (different canonicalisation method was used since 4.4.)
* makes inspire compatibile with inspire-utils
* INSPIR-3477