### PR TITLE
login: fix orcid login session issues

### DIFF
--- a/backend/inspirehep/accounts/config.py
+++ b/backend/inspirehep/accounts/config.py
@@ -18,7 +18,7 @@ ORCID_SANDBOX = True
 # ORCID sandbox ================================================================
 REMOTE_SANDBOX_REST_APP = copy.deepcopy(ORCID_REMOTE_SANDBOX_REST_APP)
 REMOTE_SANDBOX_REST_APP["authorized_redirect_url"] = "/api/accounts/login-success"
-REMOTE_SANDBOX_REST_APP["signup_redirect_url"] = "/api/accounts/signup"
+REMOTE_SANDBOX_REST_APP["signup_redirect_url"] = "/user/signup"  # UI signup form
 
 REMOTE_SANDBOX_REST_APP["params"]["request_token_params"] = {
     "scope": " ".join(["/read-limited", "/activities/update", "/person/update"]),
@@ -32,7 +32,7 @@ REMOTE_SANDBOX_REST_APP["signup_handler"][
 # ORCID production =============================================================
 REMOTE_REST_APP = copy.deepcopy(ORCID_REMOTE_REST_APP)
 REMOTE_REST_APP["authorized_redirect_url"] = "/api/accounts/login-success"
-REMOTE_REST_APP["signup_redirect_url"] = "/api/accounts/signup"
+REMOTE_REST_APP["signup_redirect_url"] = "/user/signup"  # UI signup form
 REMOTE_REST_APP["params"]["request_token_params"] = {
     "scope": " ".join(["/read-limited", "/activities/update", "/person/update"]),
     "show_login": "true",

--- a/backend/inspirehep/accounts/views.py
+++ b/backend/inspirehep/accounts/views.py
@@ -32,12 +32,7 @@ def me():
 
 @blueprint.route("/login-success")
 def login_success():
-    return redirect(session["next_url"])
-
-
-@blueprint.route("/signup", methods=["GET"])
-def sign_up_required():
-    return redirect(session["signup_url"])
+    return redirect(session.get("next_url", "/"))
 
 
 @blueprint.route("/signup", methods=["POST"])
@@ -58,7 +53,6 @@ def sign_up_user():
 @blueprint.route("/login", methods=["GET"])
 def login():
     session["next_url"] = request.args.get("next")
-    session["signup_url"] = request.args.get("signup_url")
     return redirect("/api/oauth/login/orcid")
 
 

--- a/backend/tests/integration/accounts/test_views.py
+++ b/backend/tests/integration/accounts/test_views.py
@@ -35,15 +35,14 @@ def test_me_returns_user_data_if_logged_in(api_client, create_user):
     assert response.json == expected_data
 
 
-def test_login_sets_next_url_and_signup_url(api_client):
-    api_client.get("/accounts/login?next=/jobs&signup_url=/user/signup")
+def test_login_sets_next_url(api_client):
+    api_client.get("/accounts/login?next=/jobs")
 
     assert session["next_url"] == "/jobs"
-    assert session["signup_url"] == "/user/signup"
 
 
 def test_login_redirects_to_oauthclient_login(api_client):
-    response = api_client.get("/accounts/login?next=/jobs&signup_url=/user/signup")
+    response = api_client.get("/accounts/login?next=/jobs")
 
     response_status_code = response.status_code
     response_location_header = response.headers.get("Location")
@@ -71,18 +70,14 @@ def test_login_success_redirects_to_next_url(api_client):
     assert response_location_header == expected_redirect_url
 
 
-def test_sign_up_required_redirects_to_signup_form(api_client):
-    signup_form_url = "http://localhost:3000/user/signup"
-
-    with api_client.session_transaction() as sess:
-        sess["signup_url"] = signup_form_url
-
-    response = api_client.get("/accounts/signup")
+# Session is lost in rare occasions due to issues with redis
+def test_login_success_redirects_to_home_if_next_url_not_in_session(api_client):
+    response = api_client.get("/accounts/login-success")
 
     response_status_code = response.status_code
     response_location_header = response.headers.get("Location")
 
-    expected_redirect_url = signup_form_url
+    expected_redirect_url = "http://localhost:5000/"
     expected_status_code = 302
     assert expected_status_code == response_status_code
     assert response_location_header == expected_redirect_url

--- a/ui/src/user/components/LoginPage/LoginPage.jsx
+++ b/ui/src/user/components/LoginPage/LoginPage.jsx
@@ -8,7 +8,6 @@ import './LoginPage.scss';
 import ExternalLink from '../../../common/components/ExternalLink';
 import DocumentHead from '../../../common/components/DocumentHead';
 import { WHAT_IS_ORCID_URL } from '../../../common/constants';
-import { USER_SIGNUP } from '../../../common/routes';
 
 const META_DESCRIPTION = 'Log in to your INSPIRE account. Log in with ORCID';
 const TITLE = 'Login';
@@ -16,7 +15,7 @@ const TITLE = 'Login';
 class LoginPage extends Component {
   render() {
     const { previousUrl } = this.props;
-    const loginHref = `/api/accounts/login?next=${previousUrl}&signup_url=${USER_SIGNUP}`;
+    const loginHref = `/api/accounts/login?next=${previousUrl}`;
     return (
       <>
         <DocumentHead title={TITLE} description={META_DESCRIPTION} />

--- a/ui/src/user/components/LoginPage/__tests__/__snapshots__/LoginPage.test.jsx.snap
+++ b/ui/src/user/components/LoginPage/__tests__/__snapshots__/LoginPage.test.jsx.snap
@@ -37,7 +37,7 @@ exports[`LoginPage renders page 1`] = `
         block={false}
         className="login-button h3"
         ghost={false}
-        href="/api/accounts/login?next=/&signup_url=/user/signup"
+        href="/api/accounts/login?next=/"
         htmlType="button"
         loading={false}
       >


### PR DESCRIPTION
* Fix for INSPIR-3349

The problem is that the session is reset on rare occasions probably due to some issues with Redis, so in that situation a KeyError was being thrown when reading `next_url` and `signup_url` from session.