### PR TITLE
ui: cancel unncessary http requests

### DIFF
--- a/ui/src/actions/__tests__/authors.test.js
+++ b/ui/src/actions/__tests__/authors.test.js
@@ -5,7 +5,7 @@ import http from '../../common/http';
 import { AUTHOR_ERROR, AUTHOR_REQUEST, AUTHOR_SUCCESS } from '../actionTypes';
 import { fetchAuthor } from '../authors';
 
-const mockHttp = new MockAdapter(http);
+const mockHttp = new MockAdapter(http.httpClient);
 
 describe('AUTHOR - async action creators', () => {
   describe('fetch author', () => {
@@ -36,8 +36,9 @@ describe('AUTHOR - async action creators', () => {
           type: AUTHOR_ERROR,
           payload: {
             error: {
-              message: 'Error', status: 500
-            }
+              message: 'Error',
+              status: 500,
+            },
           },
           meta: { redirectableError: true },
         },

--- a/ui/src/actions/__tests__/citations.test.js
+++ b/ui/src/actions/__tests__/citations.test.js
@@ -8,7 +8,7 @@ import { fetchCitationSummary, fetchCitationsByYear } from '../citations';
 import { AUTHOR_PUBLICATIONS_NS } from '../../search/constants';
 import { LITERATURE } from '../../common/routes';
 
-const mockHttp = new MockAdapter(http);
+const mockHttp = new MockAdapter(http.httpClient);
 
 describe('citations - async action creator', () => {
   afterEach(() => {

--- a/ui/src/actions/__tests__/conferences.test.js
+++ b/ui/src/actions/__tests__/conferences.test.js
@@ -9,7 +9,7 @@ import {
 } from '../actionTypes';
 import fetchConference from '../conferences';
 
-const mockHttp = new MockAdapter(http);
+const mockHttp = new MockAdapter(http.httpClient);
 
 describe('conferences - async action creators', () => {
   describe('fetch conference', () => {
@@ -39,7 +39,7 @@ describe('conferences - async action creators', () => {
         {
           type: CONFERENCE_ERROR,
           payload: {
-            error: { message: 'Error', status: 500 }
+            error: { message: 'Error', status: 500 },
           },
           meta: { redirectableError: true },
         },

--- a/ui/src/actions/__tests__/exceptions.test.js
+++ b/ui/src/actions/__tests__/exceptions.test.js
@@ -5,7 +5,7 @@ import http from '../../common/http';
 import * as types from '../actionTypes';
 import fetch from '../exceptions';
 
-const mockHttp = new MockAdapter(http);
+const mockHttp = new MockAdapter(http.httpClient);
 
 describe('exceptions dashboard - async action creator', () => {
   afterEach(() => {
@@ -34,9 +34,9 @@ describe('exceptions dashboard - async action creator', () => {
       {
         type: types.EXCEPTIONS_ERROR,
         payload: {
-          error: { status: 500 }
+          error: { status: 500 },
         },
-        meta: { redirectableError: true }
+        meta: { redirectableError: true },
       },
     ];
 

--- a/ui/src/actions/__tests__/experiments.test.js
+++ b/ui/src/actions/__tests__/experiments.test.js
@@ -9,7 +9,7 @@ import {
 } from '../actionTypes';
 import fetchExperiment from '../experiments';
 
-const mockHttp = new MockAdapter(http);
+const mockHttp = new MockAdapter(http.httpClient);
 
 describe('experiments - async action creators', () => {
   describe('fetch experiment', () => {

--- a/ui/src/actions/__tests__/inspect.test.js
+++ b/ui/src/actions/__tests__/inspect.test.js
@@ -5,7 +5,7 @@ import http from '../../common/http';
 import * as types from '../actionTypes';
 import fetch from '../inspect';
 
-const mockHttp = new MockAdapter(http);
+const mockHttp = new MockAdapter(http.httpClient);
 
 describe('inspect dashboard - async action creator', () => {
   afterEach(() => {
@@ -34,9 +34,9 @@ describe('inspect dashboard - async action creator', () => {
       {
         type: types.INSPECT_ERROR,
         payload: {
-          error: { status: 404 }
+          error: { status: 404 },
         },
-        meta: { redirectableError: true }
+        meta: { redirectableError: true },
       },
     ];
 

--- a/ui/src/actions/__tests__/institutions.test.js
+++ b/ui/src/actions/__tests__/institutions.test.js
@@ -9,7 +9,7 @@ import {
 } from '../actionTypes';
 import fetchInstitution from '../institutions';
 
-const mockHttp = new MockAdapter(http);
+const mockHttp = new MockAdapter(http.httpClient);
 
 describe('institutions - async action creators', () => {
   describe('fetch institution', () => {

--- a/ui/src/actions/__tests__/jobs.test.js
+++ b/ui/src/actions/__tests__/jobs.test.js
@@ -5,7 +5,7 @@ import http from '../../common/http';
 import { JOB_REQUEST, JOB_SUCCESS, JOB_ERROR } from '../actionTypes';
 import fetchJob from '../jobs';
 
-const mockHttp = new MockAdapter(http);
+const mockHttp = new MockAdapter(http.httpClient);
 
 describe('jobs - async action creators', () => {
   describe('fetch job', () => {
@@ -35,7 +35,7 @@ describe('jobs - async action creators', () => {
         {
           type: JOB_ERROR,
           payload: {
-            error: { message: 'Error', status: 500 }
+            error: { message: 'Error', status: 500 },
           },
           meta: { redirectableError: true },
         },

--- a/ui/src/actions/__tests__/literature.test.js
+++ b/ui/src/actions/__tests__/literature.test.js
@@ -20,7 +20,7 @@ import {
   fetchLiteratureReferences,
 } from '../literature';
 
-const mockHttp = new MockAdapter(http);
+const mockHttp = new MockAdapter(http.httpClient);
 
 describe('literature - async action creators', () => {
   afterEach(() => {
@@ -148,8 +148,8 @@ describe('literature - async action creators', () => {
         {
           type: LITERATURE_AUTHORS_ERROR,
           payload: {
-            error: { status: 500 }
-          }
+            error: { status: 500 },
+          },
         },
       ];
 

--- a/ui/src/actions/__tests__/search.test.js
+++ b/ui/src/actions/__tests__/search.test.js
@@ -17,7 +17,7 @@ import searchConfig from '../../search/config';
 
 jest.mock('../../search/config');
 
-const mockHttp = new MockAdapter(http);
+const mockHttp = new MockAdapter(http.httpClient);
 
 describe('search - action creators', () => {
   describe('fetchSearchResults', () => {

--- a/ui/src/actions/__tests__/seminars.test.js
+++ b/ui/src/actions/__tests__/seminars.test.js
@@ -9,7 +9,7 @@ import {
 } from '../actionTypes';
 import fetchSeminar from '../seminars';
 
-const mockHttp = new MockAdapter(http);
+const mockHttp = new MockAdapter(http.httpClient);
 
 describe('seminars - async action creators', () => {
   describe('fetch seminar', () => {

--- a/ui/src/actions/__tests__/submissions.test.js
+++ b/ui/src/actions/__tests__/submissions.test.js
@@ -18,7 +18,7 @@ import {
   importExternalLiterature,
 } from '../submissions';
 
-const mockHttp = new MockAdapter(http);
+const mockHttp = new MockAdapter(http.httpClient);
 
 describe('submissions - async action creator', () => {
   afterEach(() => {
@@ -61,7 +61,7 @@ describe('submissions - async action creator', () => {
         {
           type: SUBMIT_ERROR,
           payload: {
-            error: { message: 'Error', status: 400 }
+            error: { message: 'Error', status: 400 },
           },
         },
       ];
@@ -106,7 +106,7 @@ describe('submissions - async action creator', () => {
         {
           type: SUBMIT_ERROR,
           payload: {
-            error: { message: 'Error', status: 400 }
+            error: { message: 'Error', status: 400 },
           },
         },
       ];
@@ -160,7 +160,7 @@ describe('submissions - async action creator', () => {
         {
           type: INITIAL_FORM_DATA_ERROR,
           payload: {
-            error: { message: 'Error', status: 404 }
+            error: { message: 'Error', status: 404 },
           },
         },
       ];
@@ -211,7 +211,7 @@ describe('submissions - async action creator', () => {
         {
           type: INITIAL_FORM_DATA_ERROR,
           payload: {
-            error: { message: 'Error', status: 404 }
+            error: { message: 'Error', status: 404 },
           },
         },
       ];

--- a/ui/src/actions/__tests__/user.test.js
+++ b/ui/src/actions/__tests__/user.test.js
@@ -21,7 +21,7 @@ import http from '../../common/http';
 import { HOME } from '../../common/routes';
 import { CITATION_SUMMARY_ENABLING_PREFERENCE } from '../../reducers/user';
 
-const mockHttp = new MockAdapter(http);
+const mockHttp = new MockAdapter(http.httpClient);
 
 describe('user - async action creator', () => {
   it('successful logged in user fetch creates USER_LOGIN_SUCCESS', async () => {

--- a/ui/src/actions/authors.js
+++ b/ui/src/actions/authors.js
@@ -1,5 +1,5 @@
 import { AUTHOR_REQUEST, AUTHOR_SUCCESS, AUTHOR_ERROR } from './actionTypes';
-import { UI_SERIALIZER_REQUEST_OPTIONS } from '../common/http';
+import { UI_SERIALIZER_REQUEST_OPTIONS, isCancelError } from '../common/http';
 import { httpErrorToActionPayload } from '../common/utils';
 
 function fetchingAuthor(recordId) {
@@ -30,12 +30,15 @@ export function fetchAuthor(recordId) {
     try {
       const response = await http.get(
         `/authors/${recordId}`,
-        UI_SERIALIZER_REQUEST_OPTIONS
+        UI_SERIALIZER_REQUEST_OPTIONS,
+        'authors-detail'
       );
       dispatch(fetchAuthorSuccess(response.data));
     } catch (error) {
-      const payload = httpErrorToActionPayload(error);
-      dispatch(fetchAuthorError(payload));
+      if (!isCancelError(error)) {
+        const payload = httpErrorToActionPayload(error);
+        dispatch(fetchAuthorError(payload));
+      }
     }
   };
 }

--- a/ui/src/actions/citations.js
+++ b/ui/src/actions/citations.js
@@ -8,6 +8,7 @@ import {
   CITATIONS_BY_YEAR_ERROR,
 } from './actionTypes';
 import { httpErrorToActionPayload } from '../common/utils';
+import { isCancelError } from '../common/http';
 
 function fetchingCitationSummary(namespace) {
   return {
@@ -47,11 +48,13 @@ export function fetchCitationSummary(namespace) {
 
       const queryString = stringify(query, { indices: false });
       const url = `/literature/facets?${queryString}`;
-      const response = await http.get(url);
+      const response = await http.get(url, {}, 'citations-summary');
       dispatch(fetchCitationSummarySuccess(response.data));
     } catch (error) {
-      const payload = httpErrorToActionPayload(error);
-      dispatch(fetchCitationSummaryError(payload));
+      if (!isCancelError(error)) {
+        const payload = httpErrorToActionPayload(error);
+        dispatch(fetchCitationSummaryError(payload));
+      }
     }
   };
 }
@@ -86,11 +89,13 @@ export function fetchCitationsByYear(literatureSearchQuery) {
       };
       const queryString = stringify(query, { indices: false });
       const url = `/literature/facets?${queryString}`;
-      const response = await http.get(url);
+      const response = await http.get(url, {}, 'citations-by-year');
       dispatch(fetchCitationsByYearSuccess(response.data));
     } catch (error) {
-      const payload = httpErrorToActionPayload(error);
-      dispatch(fetchCitationsByYearError(payload));
+      if (!isCancelError(error)) {
+        const payload = httpErrorToActionPayload(error);
+        dispatch(fetchCitationsByYearError(payload));
+      }
     }
   };
 }

--- a/ui/src/actions/conferences.js
+++ b/ui/src/actions/conferences.js
@@ -3,7 +3,7 @@ import {
   CONFERENCE_SUCCESS,
   CONFERENCE_ERROR,
 } from './actionTypes';
-import { UI_SERIALIZER_REQUEST_OPTIONS } from '../common/http';
+import { UI_SERIALIZER_REQUEST_OPTIONS, isCancelError } from '../common/http';
 import { httpErrorToActionPayload } from '../common/utils';
 
 function fetchingConference(recordId) {
@@ -34,12 +34,15 @@ function fetchConference(recordId) {
     try {
       const response = await http.get(
         `/conferences/${recordId}`,
-        UI_SERIALIZER_REQUEST_OPTIONS
+        UI_SERIALIZER_REQUEST_OPTIONS,
+        'conference-detail'
       );
       dispatch(fetchConferenceSuccess(response.data));
     } catch (error) {
-      const payload = httpErrorToActionPayload(error);
-      dispatch(fetchConferenceError(payload));
+      if (!isCancelError(error)) {
+        const payload = httpErrorToActionPayload(error);
+        dispatch(fetchConferenceError(payload));
+      }
     }
   };
 }

--- a/ui/src/actions/experiments.js
+++ b/ui/src/actions/experiments.js
@@ -3,7 +3,7 @@ import {
   EXPERIMENT_SUCCESS,
   EXPERIMENT_ERROR,
 } from './actionTypes';
-import { UI_SERIALIZER_REQUEST_OPTIONS } from '../common/http';
+import { UI_SERIALIZER_REQUEST_OPTIONS, isCancelError } from '../common/http';
 import { httpErrorToActionPayload } from '../common/utils';
 import { EXPERIMENTS_PID_TYPE } from '../common/constants';
 
@@ -35,12 +35,15 @@ function fetchExperiment(recordId) {
     try {
       const response = await http.get(
         `/${EXPERIMENTS_PID_TYPE}/${recordId}`,
-        UI_SERIALIZER_REQUEST_OPTIONS
+        UI_SERIALIZER_REQUEST_OPTIONS,
+        'experiments-detail'
       );
       dispatch(fetchExperimentSuccess(response.data));
     } catch (error) {
-      const payload = httpErrorToActionPayload(error);
-      dispatch(fetchExperimentError(payload));
+      if (!isCancelError(error)) {
+        const payload = httpErrorToActionPayload(error);
+        dispatch(fetchExperimentError(payload));
+      }
     }
   };
 }

--- a/ui/src/actions/institutions.js
+++ b/ui/src/actions/institutions.js
@@ -3,7 +3,7 @@ import {
   INSTITUTION_SUCCESS,
   INSTITUTION_ERROR,
 } from './actionTypes';
-import { UI_SERIALIZER_REQUEST_OPTIONS } from '../common/http';
+import { UI_SERIALIZER_REQUEST_OPTIONS, isCancelError } from '../common/http';
 import { httpErrorToActionPayload } from '../common/utils';
 
 function fetchingInstitution(recordId) {
@@ -34,12 +34,15 @@ function fetchInstitution(recordId) {
     try {
       const response = await http.get(
         `/institutions/${recordId}`,
-        UI_SERIALIZER_REQUEST_OPTIONS
+        UI_SERIALIZER_REQUEST_OPTIONS,
+        'institutions-detail'
       );
       dispatch(fetchInstitutionSuccess(response.data));
     } catch (error) {
-      const payload = httpErrorToActionPayload(error);
-      dispatch(fetchInstitutionError(payload));
+      if (!isCancelError(error)) {
+        const payload = httpErrorToActionPayload(error);
+        dispatch(fetchInstitutionError(payload));
+      }
     }
   };
 }

--- a/ui/src/actions/jobs.js
+++ b/ui/src/actions/jobs.js
@@ -1,5 +1,6 @@
 import { JOB_REQUEST, JOB_SUCCESS, JOB_ERROR } from './actionTypes';
 import { httpErrorToActionPayload } from '../common/utils';
+import { isCancelError } from '../common/http';
 
 function fetchingJob(recordId) {
   return {
@@ -27,11 +28,13 @@ function fetchJob(recordId) {
   return async (dispatch, getState, http) => {
     dispatch(fetchingJob(recordId));
     try {
-      const response = await http.get(`/jobs/${recordId}`);
+      const response = await http.get(`/jobs/${recordId}`, {}, 'jobs-detail');
       dispatch(fetchJobSuccess(response.data));
     } catch (error) {
-      const payload = httpErrorToActionPayload(error);
-      dispatch(fetchJobError(payload));
+      if (!isCancelError(error)) {
+        const payload = httpErrorToActionPayload(error);
+        dispatch(fetchJobError(payload));
+      }
     }
   };
 }

--- a/ui/src/actions/literature.js
+++ b/ui/src/actions/literature.js
@@ -10,7 +10,7 @@ import {
   LITERATURE_AUTHORS_REQUEST,
   LITERATURE_AUTHORS_SUCCESS,
 } from './actionTypes';
-import { UI_SERIALIZER_REQUEST_OPTIONS } from '../common/http';
+import { UI_SERIALIZER_REQUEST_OPTIONS, isCancelError } from '../common/http';
 import { httpErrorToActionPayload } from '../common/utils';
 
 function fetchingLiterature(recordId) {
@@ -72,7 +72,7 @@ function fetchLiteratureAuthorsSuccess(result) {
 function fetchLiteratureAuthorsError(errorPayload) {
   return {
     type: LITERATURE_AUTHORS_ERROR,
-    payload: errorPayload
+    payload: errorPayload,
   };
 }
 
@@ -82,12 +82,15 @@ export function fetchLiterature(recordId) {
     try {
       const response = await http.get(
         `/literature/${recordId}`,
-        UI_SERIALIZER_REQUEST_OPTIONS
+        UI_SERIALIZER_REQUEST_OPTIONS,
+        'literature-detail'
       );
       dispatch(fetchLiteratureSuccess(response.data));
     } catch (error) {
-      const payload = httpErrorToActionPayload(error);
-      dispatch(fetchLiteratureError(payload));
+      if (!isCancelError(error)) {
+        const payload = httpErrorToActionPayload(error);
+        dispatch(fetchLiteratureError(payload));
+      }
     }
   };
 }
@@ -103,12 +106,16 @@ export function fetchLiteratureReferences(recordId, newQuery = {}) {
     const queryString = stringify(query, { indices: false });
     try {
       const response = await http.get(
-        `/literature/${recordId}/references?${queryString}`
+        `/literature/${recordId}/references?${queryString}`,
+        {},
+        'literature-references-detail'
       );
       dispatch(fetchLiteratureReferencesSuccess(response.data));
     } catch (error) {
-      const payload = httpErrorToActionPayload(error);
-      dispatch(fetchLiteratureReferencesError(payload));
+      if (!isCancelError(error)) {
+        const payload = httpErrorToActionPayload(error);
+        dispatch(fetchLiteratureReferencesError(payload));
+      }
     }
   };
 }
@@ -117,11 +124,17 @@ export function fetchLiteratureAuthors(recordId) {
   return async (dispatch, getState, http) => {
     dispatch(fetchingLiteratureAuthors());
     try {
-      const response = await http.get(`/literature/${recordId}/authors`);
+      const response = await http.get(
+        `/literature/${recordId}/authors`,
+        {},
+        'literature-authors-detail'
+      );
       dispatch(fetchLiteratureAuthorsSuccess(response.data));
     } catch (error) {
-      const errorPayload = httpErrorToActionPayload(error)
-      dispatch(fetchLiteratureAuthorsError(errorPayload));
+      if (!isCancelError(error)) {
+        const errorPayload = httpErrorToActionPayload(error);
+        dispatch(fetchLiteratureAuthorsError(errorPayload));
+      }
     }
   };
 }

--- a/ui/src/actions/search.js
+++ b/ui/src/actions/search.js
@@ -11,7 +11,7 @@ import {
   SEARCH_BASE_QUERIES_UPDATE,
   SEARCH_QUERY_RESET,
 } from './actionTypes';
-import { UI_SERIALIZER_REQUEST_OPTIONS } from '../common/http';
+import { UI_SERIALIZER_REQUEST_OPTIONS, isCancelError } from '../common/http';
 import { httpErrorToActionPayload } from '../common/utils';
 import SearchHelper from '../search/helper';
 import searchConfig from '../search/config';
@@ -49,11 +49,17 @@ export function fetchSearchResults(namespace, url) {
   return async (dispatch, getState, http) => {
     dispatch(searching(namespace));
     try {
-      const response = await http.get(url, UI_SERIALIZER_REQUEST_OPTIONS);
+      const response = await http.get(
+        url,
+        UI_SERIALIZER_REQUEST_OPTIONS,
+        `search-results-${namespace}`
+      );
       dispatch(searchSuccess(namespace, response.data));
     } catch (error) {
-      const errorPayload = httpErrorToActionPayload(error);
-      dispatch(searchError(namespace, errorPayload));
+      if (!isCancelError(error)) {
+        const errorPayload = httpErrorToActionPayload(error);
+        dispatch(searchError(namespace, errorPayload));
+      }
     }
   };
 }
@@ -83,11 +89,17 @@ export function fetchSearchAggregations(namespace, url) {
   return async (dispatch, getState, http) => {
     dispatch(fetchingSearchAggregations(namespace));
     try {
-      const response = await http.get(url);
+      const response = await http.get(
+        url,
+        {},
+        `search-aggregations-${namespace}`
+      );
       dispatch(searchAggregationsSuccess(namespace, response.data));
     } catch (error) {
-      const errorPayload = httpErrorToActionPayload(error);
-      dispatch(searchAggregationsError(namespace, errorPayload));
+      if (!isCancelError(error)) {
+        const errorPayload = httpErrorToActionPayload(error);
+        dispatch(searchAggregationsError(namespace, errorPayload));
+      }
     }
   };
 }

--- a/ui/src/actions/seminars.js
+++ b/ui/src/actions/seminars.js
@@ -1,5 +1,5 @@
 import { SEMINAR_REQUEST, SEMINAR_SUCCESS, SEMINAR_ERROR } from './actionTypes';
-import { UI_SERIALIZER_REQUEST_OPTIONS } from '../common/http';
+import { UI_SERIALIZER_REQUEST_OPTIONS, isCancelError } from '../common/http';
 import { httpErrorToActionPayload } from '../common/utils';
 import { SEMINARS_PID_TYPE } from '../common/constants';
 
@@ -31,12 +31,15 @@ function fetchSeminar(recordId) {
     try {
       const response = await http.get(
         `/${SEMINARS_PID_TYPE}/${recordId}`,
-        UI_SERIALIZER_REQUEST_OPTIONS
+        UI_SERIALIZER_REQUEST_OPTIONS,
+        'seminars-detail'
       );
       dispatch(fetchSeminarSuccess(response.data));
     } catch (error) {
-      const payload = httpErrorToActionPayload(error);
-      dispatch(fetchSeminarError(payload));
+      if (!isCancelError(error)) {
+        const payload = httpErrorToActionPayload(error);
+        dispatch(fetchSeminarError(payload));
+      }
     }
   };
 }

--- a/ui/src/common/components/__tests__/Suggester.test.jsx
+++ b/ui/src/common/components/__tests__/Suggester.test.jsx
@@ -5,7 +5,7 @@ import MockAdapter from 'axios-mock-adapter';
 import http from '../../http';
 import Suggester, { REQUEST_DEBOUNCE_MS } from '../Suggester';
 
-const mockHttp = new MockAdapter(http);
+const mockHttp = new MockAdapter(http.httpClient);
 
 // TODO: use fake timers after https://github.com/facebook/jest/pull/7776
 function wait(milisec = REQUEST_DEBOUNCE_MS + 25) {

--- a/ui/src/common/http.js
+++ b/ui/src/common/http.js
@@ -1,10 +1,63 @@
 import axios from 'axios';
 
-const http = axios.create({
-  baseURL: '/api',
-});
+// `Proxy` could be used instead of wrapper class, depending on the browser support
+class HttpClientWrapper {
+  constructor() {
+    this.httpClient = axios.create({
+      baseURL: '/api',
+    });
 
+    this.activeCancelManagersById = new Map();
+  }
+
+  /**
+   * Allows requests to be tracked by id
+   * and there can't be multiple active requests with the same id
+   * current one is cancelled when a newer one comes
+   */
+  async get(url, config, id) {
+    if (!id) {
+      return this.httpClient.get(url, config);
+    }
+
+    if (this.activeCancelManagersById.has(id)) {
+      const cancelManager = this.activeCancelManagersById.get(id);
+      cancelManager.cancel();
+    }
+
+    const cancelManager = axios.CancelToken.source();
+    this.activeCancelManagersById.set(id, cancelManager);
+    try {
+      const response = await this.httpClient.get(url, {
+        ...config,
+        cancelToken: cancelManager.token,
+      });
+
+      this.activeCancelManagersById.delete(id);
+      return response;
+    } catch (error) {
+      if (!axios.isCancel(error)) {
+        this.activeCancelManagersById.delete(id);
+      }
+      throw error;
+    }
+  }
+
+  post(...args) {
+    return this.httpClient.post(...args);
+  }
+
+  put(...args) {
+    return this.httpClient.put(...args);
+  }
+}
+
+const http = new HttpClientWrapper();
 export default http;
+
+export function isCancelError(error) {
+  return axios.isCancel(error);
+}
 
 export const UI_SERIALIZER_REQUEST_OPTIONS = {
   headers: {

--- a/ui/src/literature/__tests__/citeArticle.test.js
+++ b/ui/src/literature/__tests__/citeArticle.test.js
@@ -3,7 +3,7 @@ import MockAdapter from 'axios-mock-adapter';
 import http from '../../common/http';
 import citeArticle from '../citeArticle';
 
-const mockHttp = new MockAdapter(http);
+const mockHttp = new MockAdapter(http.httpClient);
 
 describe('citeArticle', () => {
   afterEach(() => {
@@ -27,7 +27,9 @@ describe('citeArticle', () => {
     mockHttp
       .onGet(citeUrl, null, { Accept: 'application/x-test' })
       .replyOnce(500);
-    await expect(citeArticle(format, 12345)).rejects.toThrow(new Error('Request failed with status code 500'));
+    await expect(citeArticle(format, 12345)).rejects.toThrow(
+      new Error('Request failed with status code 500')
+    );
     done();
   });
 
@@ -35,8 +37,11 @@ describe('citeArticle', () => {
     const citeUrl = '/literature/12345';
     const format = 'x-test';
     mockHttp
-      .onGet(citeUrl, null, { Accept: 'application/x-test' }).networkError();
-    await expect(citeArticle(format, 12345)).rejects.toThrow(new Error('Network Error'));
+      .onGet(citeUrl, null, { Accept: 'application/x-test' })
+      .networkError();
+    await expect(citeArticle(format, 12345)).rejects.toThrow(
+      new Error('Network Error')
+    );
     done();
   });
 });

--- a/ui/src/literature/components/__tests__/CiteAllAction.test.jsx
+++ b/ui/src/literature/components/__tests__/CiteAllAction.test.jsx
@@ -10,7 +10,7 @@ import { downloadTextAsFile } from '../../../common/utils';
 
 jest.mock('../../../common/utils');
 
-const mockHttp = new MockAdapter(http);
+const mockHttp = new MockAdapter(http.httpClient);
 describe('CiteAllAction', () => {
   beforeEach(() => {
     downloadTextAsFile.mockClear();

--- a/ui/src/submissions/authors/schemas/__tests__/unqiueOrcid.test.jsx
+++ b/ui/src/submissions/authors/schemas/__tests__/unqiueOrcid.test.jsx
@@ -3,7 +3,7 @@ import MockAdapter from 'axios-mock-adapter';
 import uniqueOrcid from '../uniqueOrcid';
 import http from '../../../../common/http';
 
-const mockHttp = new MockAdapter(http);
+const mockHttp = new MockAdapter(http.httpClient);
 
 describe('uniqueOrcid', () => {
   const schema = uniqueOrcid();


### PR DESCRIPTION
Adds a wrapper around http client that initially handles `get` requests.
This fixes problems with inconsistent ui especially when user on a
slow network, also avoid unnecessary downlaods.

Example problem:
1. Click on an author on literature page
2. Go back to literature page before citation summary of the author is loaded

This will trigger another citation summary request and
now there will be 2 active citation summary requests.
It will display wrong results if for some reason earlier request
finishes the last.