### PR TITLE
serializers: do not display search_options on non ui requests

### DIFF
--- a/backend/inspirehep/serializers.py
+++ b/backend/inspirehep/serializers.py
@@ -51,25 +51,25 @@ class JSONSerializer(InvenioJSONSerializer):
         :param links: Dictionary of links to add to response.
         """
         links = inspire_search_links(links)
-        return json.dumps(
-            dict(
-                hits=dict(
-                    hits=[
-                        self.transform_search_hit(
-                            pid_fetcher(hit["_id"], hit["_source"]),
-                            hit,
-                            links_factory=item_links_factory,
-                            **kwargs
-                        )
-                        for hit in search_result["hits"]["hits"]
-                    ],
-                    total=search_result["hits"]["total"]["value"],
-                ),
-                links=links,
-                sort_options=self._get_sort_options(),
+        data = dict(
+            hits=dict(
+                hits=[
+                    self.transform_search_hit(
+                        pid_fetcher(hit["_id"], hit["_source"]),
+                        hit,
+                        links_factory=item_links_factory,
+                        **kwargs
+                    )
+                    for hit in search_result["hits"]["hits"]
+                ],
+                total=search_result["hits"]["total"]["value"],
             ),
-            **self._format_args()
+            links=links,
         )
+        sort_options = self._get_sort_options()
+        if sort_options:
+            data["sort_options"] = sort_options
+        return json.dumps(data, **self._format_args())
 
     def _get_sort_options(self):
         alias_name = None

--- a/backend/tests/integration/records/serializers/json/test_authors.py
+++ b/backend/tests/integration/records/serializers/json/test_authors.py
@@ -266,11 +266,10 @@ def test_authors_search_json_does_not_have_sort_options(inspire_app):
         response = client.get("/authors", headers=headers)
 
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
-    sort_options = response_data["sort_options"]
+    response_data = response.json
 
     assert expected_status_code == response_status_code
-    assert expected_sort_options == sort_options
+    assert "sort_options" not in response_data
 
 
 def test_authors_search_json_with_logged_in_cataloger(inspire_app):


### PR DESCRIPTION
*INSPIR-3605