### PR TITLE
indexer: replace _previous_version with _last_indexed

### DIFF
--- a/backend/inspirehep/indexer/tasks.py
+++ b/backend/inspirehep/indexer/tasks.py
@@ -77,15 +77,6 @@ def index_record(self, uuid, record_version=None, force_delete=None):
     if not force_delete:
         deleted = record.get("deleted", False)
 
-    if force_delete or deleted:
-        try:
-            InspireRecordIndexer().delete(record)
-            LOGGER.debug("Record removed from ES", uuid=str(uuid))
-        except NotFoundError:
-            LOGGER.debug("Record to delete not found", uuid=str(uuid))
-    else:
-        InspireRecordIndexer().index(record)
-
     uuids_to_reindex = set()
     if isinstance(record, LiteratureRecord):
         uuids_to_reindex |= record.get_linked_papers_if_reference_changed()
@@ -102,3 +93,12 @@ def index_record(self, uuid, record_version=None, force_delete=None):
         )
     if uuids_to_reindex:
         batch_index(list(uuids_to_reindex))
+
+    if force_delete or deleted:
+        try:
+            InspireRecordIndexer().delete(record)
+            LOGGER.debug("Record removed from ES", uuid=str(uuid))
+        except NotFoundError:
+            LOGGER.debug("Record to delete not found", uuid=str(uuid))
+    else:
+        InspireRecordIndexer().index(record)

--- a/backend/inspirehep/records/api/literature.py
+++ b/backend/inspirehep/records/api/literature.py
@@ -187,7 +187,7 @@ class LiteratureRecord(
         Returns:
             List: uuids of references changed from the previous version.
         """
-        prev_version = self._previous_version
+        prev_version = self._last_indexed
 
         changed_deleted_status = self.get("deleted", False) ^ prev_version.get(
             "deleted", False
@@ -210,9 +210,7 @@ class LiteratureRecord(
         if changed_deleted_status or changed_earliest_date or changed_superseded_status:
             return list(self.get_records_ids_by_pids(pids_latest))
 
-        pids_oldest = set(
-            self._previous_version.get_linked_pids_from_field("references.record")
-        )
+        pids_oldest = set(prev_version.get_linked_pids_from_field("references.record"))
 
         pids_changed = set.symmetric_difference(set(pids_latest), pids_oldest)
 

--- a/backend/inspirehep/records/api/mixins.py
+++ b/backend/inspirehep/records/api/mixins.py
@@ -344,7 +344,7 @@ class CitationMixin(PapersAuthorsExtensionMixin):
             self.update_refs_in_citation_table()
 
     def get_all_connected_records_uuids_of_modified_authors(self):
-        prev_version = self._previous_version
+        prev_version = self._last_indexed
         current_authors = set(self.get_authors_bais())
         old_authors = set(prev_version.get_authors_bais())
         diff = current_authors.symmetric_difference(old_authors)
@@ -376,7 +376,7 @@ class CitationMixin(PapersAuthorsExtensionMixin):
         return connected_papers
 
     def get_all_connected_records_uuids_of_modified_collaborations(self):
-        prev_version = self._previous_version
+        prev_version = self._last_indexed
         current_collaborations = set(self.get_collaborations_values())
         old_collaborations = set(prev_version.get_collaborations_values())
         diff = current_collaborations.symmetric_difference(old_collaborations)
@@ -470,7 +470,7 @@ class ConferencePaperAndProceedingsMixin:
     def get_newest_linked_conferences_uuid(self):
         """Returns referenced conferences for which perspective this record has changed
         """
-        prev_version = self._previous_version
+        prev_version = self._last_indexed
 
         changed_deleted_status = self.get("deleted", False) ^ prev_version.get(
             "deleted", False
@@ -491,7 +491,7 @@ class ConferencePaperAndProceedingsMixin:
         type_changed = True if doc_type_diff.intersection(allowed_types) else False
 
         pids_previous = set(
-            self._previous_version.get_linked_pids_from_field(
+            prev_version.get_linked_pids_from_field(
                 "publication_info.conference_record"
             )
         )
@@ -554,7 +554,7 @@ class InstitutionPapersMixin:
             )
 
     def get_modified_institutions_uuids(self):
-        prev_version = self._previous_version
+        prev_version = self._last_indexed
 
         changed_deleted_status = self.get("deleted", False) ^ prev_version.get(
             "deleted", False
@@ -564,7 +564,7 @@ class InstitutionPapersMixin:
         if changed_deleted_status:
             return list(self.get_records_ids_by_pids(pids_latest))
 
-        pids_previous = self._previous_version.linked_institutions_pids
+        pids_previous = prev_version.linked_institutions_pids
 
         pids_changed = set.symmetric_difference(set(pids_latest), set(pids_previous))
 

--- a/backend/tests/helpers/utils.py
+++ b/backend/tests/helpers/utils.py
@@ -192,6 +192,7 @@ def retry_until_matched(steps={}, timeout=30):
                 },
             ]
     """
+    _wait_time = 0.3
     start = datetime.now()
     finished = False
     _current_result = None
@@ -215,10 +216,11 @@ def retry_until_matched(steps={}, timeout=30):
                     _current_result = _fun(*_args, **_kwargs)
             except Exception as e:
                 _last_error = e
+                time.sleep(_wait_time)
                 break
-            if _expected_result:
+            if _expected_result is not None:
                 if (
-                    not _expected_key
+                    _expected_key is None
                     and isinstance(_expected_result, dict)
                     and "expected_key" in _expected_result
                     and "expected_result" in _expected_result
@@ -236,8 +238,10 @@ def retry_until_matched(steps={}, timeout=30):
                 except AssertionError as e:
                     _last_error = e
                     finished = False
-                    time.sleep(0.3)
+                    time.sleep(_wait_time)
                     break
+            else:
+                time.sleep(_wait_time)
     return _current_result
 
 

--- a/backend/tests/integration-async/records/indexer/test_authors.py
+++ b/backend/tests/integration-async/records/indexer/test_authors.py
@@ -143,7 +143,7 @@ def test_record_created_through_api_is_indexed(
 def test_indexer_updates_authors_papers_when_name_changes(
     inspire_app, celery_app_with_context, celery_session_worker
 ):
-    author_data = faker.record("aut")
+    author_data = faker.record("aut", other_pids=["bai"])
     author = AuthorsRecord.create(author_data)
     db.session.commit()
     current_search.flush_and_refresh("records-authors")
@@ -156,6 +156,7 @@ def test_indexer_updates_authors_papers_when_name_changes(
                     "$ref": f"https://labs.inspirehep.net/api/authors/{author_cn}"
                 },
                 "full_name": author["name"]["value"],
+                "ids": [{"schema": "INSPIRE BAI", "value": author["ids"][0]["value"]}],
             }
         ]
     }

--- a/backend/tests/integration-async/test_test_utils.py
+++ b/backend/tests/integration-async/test_test_utils.py
@@ -86,3 +86,15 @@ def test_retry_until_matched_raises_timeout_on_timeout_when_no_other_exceptions(
     steps = [{"step": sleep, "args": [2]}, {"step": sleep, "args": [2]}]
     with pytest.raises(TimeoutError):
         retry_until_matched(steps, 1)
+
+
+def test_regression_retry_until_matched_works_correctly_when_logical_false_is_expected_value():
+    def _test_return_value(value):
+        return value
+
+    steps = [
+        {"step": _test_return_value, "args": [0], "expected_result": 0},
+        {"step": _test_return_value, "args": [False], "expected_result": False},
+        {"step": _test_return_value, "args": [""], "expected_result": ""},
+    ]
+    retry_until_matched(steps)

--- a/backend/tests/integration/records/api/test_api_authors.py
+++ b/backend/tests/integration/records/api/test_api_authors.py
@@ -171,7 +171,7 @@ def test_create_or_update_record_from_db_depending_on_its_pid_type(inspire_app):
 
 
 def test_get_author_papers(inspire_app):
-    author = create_record("aut")
+    author = create_record("aut", other_pids=["bai"])
 
     author_cn = author["control_number"]
     lit_data = {
@@ -181,6 +181,7 @@ def test_get_author_papers(inspire_app):
                     "$ref": f"https://labs.inspirehep.net/api/authors/{author_cn}"
                 },
                 "full_name": author["name"]["value"],
+                "ids": author["ids"],
             }
         ]
     }
@@ -188,8 +189,8 @@ def test_get_author_papers(inspire_app):
     lit_2 = create_record("lit")
 
     author_papers = author.get_papers_uuids()
-    assert str(lit_1.id) in author_papers
-    assert str(lit_2.id) not in author_papers
+    assert lit_1.id in author_papers
+    assert lit_2.id not in author_papers
 
 
 def test_orcid_url_also_supports_format_alias(inspire_app):


### PR DESCRIPTION
 * replace `_previous_version` with `_last_indexed` which is a db version of last indexed version of record (based on `_update` field)
 * indexer_task: move search of records to re-index before current record re-indexing.
 * integration_async: Update all tests which were checking `_previous_version` as now after re-indexing `_last_indexed` will show current_version (as current will be last indexed).
 * fixed `retry_until_matched` for expected_results which are logical False

* INSPIR-3618