### PR TITLE
pidstore: do not delete all external pids when it's unecessary

### DIFF
--- a/backend/inspirehep/migrator/tasks.py
+++ b/backend/inspirehep/migrator/tasks.py
@@ -467,9 +467,9 @@ def migrate_record_from_mirror(
             for deleted_record in cls.get_linked_records_from_dict_field(
                 json_record, "deleted_records"
             ):
-                deleted_record.pidstore_handler(
+                deleted_record.pidstore_handler.delete(
                     deleted_record.id, deleted_record
-                ).delete_external_pids()
+                )
             original_urls = replace_afs_file_locations_with_local(json_record)
             record = cls.create_or_update(
                 json_record,

--- a/backend/inspirehep/pidstore/api/base.py
+++ b/backend/inspirehep/pidstore/api/base.py
@@ -30,16 +30,12 @@ class PidStoreBase(object):
     @classmethod
     def update(cls, object_uuid, data):
         LOGGER.info("Updating PIDs", uuid=str(object_uuid))
-        pid_base = cls(object_uuid, data)
-        pid_base.delete_external_pids()
         for minter in cls.minters:
             minter.update(object_uuid, data)
 
     @classmethod
     def delete(cls, object_uuid, data):
         LOGGER.info("Deleting PIDs", uuid=str(object_uuid))
-        pid_base = cls(object_uuid, data)
-        pid_base.delete_external_pids()
         for minter in cls.minters:
             try:
                 minter.delete(object_uuid, data)
@@ -47,15 +43,6 @@ class PidStoreBase(object):
                 LOGGER.warning(
                     "Pid is missing or already deleted", object_uuid=object_uuid
                 )
-
-    def delete_external_pids(self):
-        try:
-            LOGGER.info("Deleting external PIDs", uuid=str(self.object_uuid))
-            return PersistentIdentifier.query.filter_by(
-                object_type="rec", object_uuid=self.object_uuid, pid_provider="external"
-            ).delete()
-        except PIDDoesNotExistError:
-            LOGGER.warning("Pids ``external`` not found", uuid=str(self.object_uuid))
 
     @staticmethod
     def get_endpoint_from_pid_type(pid_type):

--- a/backend/inspirehep/pidstore/minters/bai.py
+++ b/backend/inspirehep/pidstore/minters/bai.py
@@ -14,4 +14,4 @@ class BAIMinter(Minter):
     pid_type = "bai"
 
     def get_pid_values(self):
-        return get_values_for_schema(self.data.get("ids", []), "INSPIRE BAI")
+        return set(get_values_for_schema(self.data.get("ids", []), "INSPIRE BAI"))

--- a/backend/inspirehep/pidstore/minters/cnum.py
+++ b/backend/inspirehep/pidstore/minters/cnum.py
@@ -4,7 +4,6 @@
 #
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
-
 from invenio_pidstore.models import PersistentIdentifier, PIDStatus
 
 from inspirehep.pidstore.errors import CNUMChanged
@@ -40,18 +39,17 @@ class CNUMMinter(Minter):
         minter = cls(object_uuid, data)
         minter.validate()
         if "cnum" not in data:
-            cnum_provider = minter.create(data)
+            cnum_provider = minter.create(pid_value=None, data=data)
             if cnum_provider:
                 cnum = cnum_provider.pid.pid_value
                 data["cnum"] = cnum
         else:
             # migrated record already have a CNUM identifier in metadata
-            PersistentIdentifier.create(
-                pid_type="cnum",
-                pid_value=data["cnum"],
+            cls.provider.create(
+                object_type=cls.object_type,
                 object_uuid=object_uuid,
-                object_type="rec",
-                status=PIDStatus.REGISTERED,
+                pid_type=cls.pid_type,
+                pid_value=data["cnum"],
             )
         return minter
 

--- a/backend/inspirehep/pidstore/minters/orcid.py
+++ b/backend/inspirehep/pidstore/minters/orcid.py
@@ -14,4 +14,4 @@ class OrcidMinter(Minter):
     pid_type = "orcid"
 
     def get_pid_values(self):
-        return get_values_for_schema(self.data.get("ids", []), "ORCID")
+        return set(get_values_for_schema(self.data.get("ids", []), "ORCID"))

--- a/backend/inspirehep/pidstore/providers/cnum.py
+++ b/backend/inspirehep/pidstore/providers/cnum.py
@@ -22,9 +22,14 @@ class InspireCNUMProvider(BaseProvider):
     default_status = PIDStatus.RESERVED
 
     @classmethod
-    def create(cls, object_type=None, object_uuid=None, **kwargs):
+    def create(
+        cls, object_type=None, object_uuid=None, data=None, pid_value=None, **kwargs
+    ):
         """Create a new record identifier."""
-        cnum = cls.next(kwargs["pid_value"])
+        if pid_value or "cnum" in data:
+            cnum = pid_value or data.get("cnum")
+        else:
+            cnum = cls.next(data)
         if not cnum:
             return
         kwargs["pid_value"] = cnum


### PR DESCRIPTION
 * Additionally fix cnum provider when creating cnum from data provided.
 * Fix ORCID generator in tests

 * INSPIR-3641