### PR TITLE
Improve latex escaping

### DIFF
--- a/backend/inspirehep/records/marshmallow/literature/utils.py
+++ b/backend/inspirehep/records/marshmallow/literature/utils.py
@@ -5,7 +5,15 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
+import re
+
+from pylatexenc.latexencode import UnicodeToLatexEncoder
+
 from inspirehep.records.api import InspireRecord
+
+# The regex selects math delimited by ``$...$`` or ``\(...\)``
+# where the delimiters are not escaped
+MATH_EXPRESSION_REGEX = re.compile(r"((?<!\\)\$.*?(?<!\\)\$|(?<!\\)\\\(.*?(?<!\\)\\\))")
 
 
 def get_parent_record(data):
@@ -20,3 +28,29 @@ def get_parent_record(data):
         data, "publication_info.parent_record"
     )
     return next(book_records, {})
+
+
+def latex_encode(text, contains_math=False):
+    """Encode a string for use in a LaTeX format.
+
+    Args:
+        contains_math (bool): when True, math environments delimited by $...$
+        or \\(...\\) are preserved to avoid double escaping. Note that $$...$$
+        is not handled.
+    """
+    if text is None:
+        return None
+
+    encode = UnicodeToLatexEncoder(
+        replacement_latex_protection="braces-after-macro"
+    ).unicode_to_latex
+
+    if not (contains_math and ("$" in text or r"\(" in text)):
+        return encode(text)
+
+    parts = MATH_EXPRESSION_REGEX.split(text)
+    encoded_text = "".join(
+        encode(part) if i % 2 == 0 else part for i, part in enumerate(parts)
+    )
+
+    return encoded_text

--- a/backend/inspirehep/records/serializers/bibtex.py
+++ b/backend/inspirehep/records/serializers/bibtex.py
@@ -8,7 +8,6 @@ import structlog
 from invenio_records_rest.serializers.response import search_responsify
 from pybtex.database import BibliographyData, Entry, Person
 from pybtex.database.output.bibtex import Writer
-from pylatexenc.latexencode import UnicodeToLatexEncoder
 
 from ..marshmallow.literature.bibtex import BibTexCommonSchema
 from .response import record_responsify
@@ -17,12 +16,9 @@ LOGGER = structlog.getLogger()
 
 
 class BibtexWriter(Writer):
-    latex_encode = UnicodeToLatexEncoder(
-        replacement_latex_protection="braces-after-macro", non_ascii_only=True
-    ).unicode_to_latex
-
     def _encode(self, text):
-        return self.latex_encode(text)
+        """Dummy encoding as it is already done in the marshmallow schemas."""
+        return text
 
     def _write_persons(self, stream, persons, role):
         if len(persons) > 10:

--- a/backend/inspirehep/records/serializers/latex.py
+++ b/backend/inspirehep/records/serializers/latex.py
@@ -40,7 +40,7 @@ class LatexSerializer(MarshmallowMixin, PreprocessorMixin):
 
     def latex_template(self):
         latex_jinja_env = jinja2.Environment(
-            variable_start_string="\VAR{",
+            variable_start_string="\\VAR{",
             variable_end_string="}",
             loader=jinja2.FileSystemLoader(os.path.abspath("/")),
         )  # noqa

--- a/backend/inspirehep/records/serializers/templates/latex_template.tex
+++ b/backend/inspirehep/records/serializers/templates/latex_template.tex
@@ -42,7 +42,7 @@
     \VAR{- format_list(data.authors[:10]) ~ ',' }
     \VAR{- ' \\textit{et al.}' if data.authors|length > 10 }
 {%- endif -%}
-\VAR{- '\n%``' ~ data.titles.0.title ~ ",''" }
+\VAR{- '\n%``' ~ data.title ~ ",''" }
 {%- if 'journal_title' in data.publication_info -%}
     \VAR{- '\n' }
     \VAR{- publication_info(format, data.publication_info)}

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -2909,6 +2909,11 @@ optional = false
 python-versions = "*"
 version = "2.7"
 
+[package.source]
+reference = "067404829591314b1d6743e9a8e73548e7931c5d"
+type = "git"
+url = "https://github.com/phfaist/pylatexenc.git"
+
 [[package]]
 category = "dev"
 description = "python code static checker"
@@ -4109,7 +4114,8 @@ test = ["zope.event"]
 testing = ["coverage", "nose", "zope.event"]
 
 [metadata]
-content-hash = "2806a01f7fad7654a11ad7d123e341d570c763bfb01f51eaa8aa1f036b7566c3"
+content-hash = "83516c7aa574ee4da95083295b9ad6416b83ee6b7abc76326fc4500a544128cc"
+lock-version = "1.0"
 python-versions = ">=3.6,<3.8"
 
 [metadata.files]
@@ -5148,9 +5154,7 @@ pyjwt = [
     {file = "PyJWT-1.7.1-py2.py3-none-any.whl", hash = "sha256:5c6eca3c2940464d106b99ba83b00c6add741c9becaec087fb7ccdefea71350e"},
     {file = "PyJWT-1.7.1.tar.gz", hash = "sha256:8d59a976fb773f3e6a39c85636357c4f0e242707394cadadd9814f5cbaa20e96"},
 ]
-pylatexenc = [
-    {file = "pylatexenc-2.7.tar.gz", hash = "sha256:8a3de4c035b9413a7721cab11e4cc7469d9370b441fbd498fc8d2ff37cbff678"},
-]
+pylatexenc = []
 pylint = [
     {file = "pylint-2.4.4-py3-none-any.whl", hash = "sha256:886e6afc935ea2590b462664b161ca9a5e40168ea99e5300935f6591ad467df4"},
     {file = "pylint-2.4.4.tar.gz", hash = "sha256:3db5468ad013380e987410a8d6956226963aed94ecb5f9d3a28acca6d9ac36cd"},

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -76,7 +76,8 @@ inspire-query-parser = "^6.0.6"
 deepdiff = "^4.3.2"
 xmltodict = "^0.12.0"
 inspire-matcher = "9.0.4"
-pylatexenc = "^2.7"
+# Unpin when pylatexenc > 2.7 is released, including the fix for https://github.com/phfaist/pylatexenc/issues/44
+pylatexenc = {git = "https://github.com/phfaist/pylatexenc.git", rev="067404829591314b1d6743e9a8e73548e7931c5d"}
 pypdf2 = "^1.26.0"
 refextract = "^1.0.3"
 fs = "0.5.4"

--- a/backend/tests/integration/records/serializers/test_bibtex.py
+++ b/backend/tests/integration/records/serializers/test_bibtex.py
@@ -147,69 +147,28 @@ def test_bibtex_search(inspire_app):
     assert expected_result_2 in response_data
 
 
-def test_bibtex_doesnt_encode_math_environments(inspire_app):
+def test_bibtex_encodes_non_latex_chars_in_non_verbatim_fields(inspire_app):
     headers = {"Accept": "application/x-bibtex"}
     data = {
-        "control_number": 637_275_237,
-        "titles": [
+        "texkeys": ["Gerard2020:abc"],
+        "titles": [{"title": "About γ-ray bursts"}],
+        "authors": [{"full_name": "Gérard, Paweł"}],
+        "collaborations": [{"value": "DAΦNE"}],
+        "publication_info": [
             {
-                "title": "Low-energy theorem for $\\gamma\\to 3\\pi$: Σ surface terms against $\\pi a_1$-mixing"
+                "journal_title": "Annales H.Poincaré",
+                "journal_volume": "42",
+                "page_start": "314",
+                "page_end": "486",
             }
         ],
+        "dois": [{"value": "10.1234/567_89"}],
     }
     record = create_record("lit", data=data)
     record_control_number = record["control_number"]
 
     expected_status_code = 200
-    expected_result = '@article{637275237,\n    title = "{Low-energy theorem for $\\gamma\\to 3\\pi$: \\ensuremath{\Sigma} surface terms against $\\pi a_1$-mixing}"\n}\n'
-    with inspire_app.test_client() as client:
-        response = client.get(
-            "/literature/{}".format(record_control_number), headers=headers
-        )
-
-    response_status_code = response.status_code
-    response_data = response.get_data(as_text=True)
-    assert expected_status_code == response_status_code
-    assert expected_result == response_data
-
-
-def test_bibtex_encodes_unicode_outside_of_math_environments(inspire_app):
-    headers = {"Accept": "application/x-bibtex"}
-    data = {
-        "control_number": 637_275_237,
-        "titles": [
-            {"title": "Core polarization effects up to 12ℏω in 7Li and 10B nuclei"}
-        ],
-    }
-    record = create_record("lit", data=data)
-    record_control_number = record["control_number"]
-
-    expected_status_code = 200
-    expected_result = '@article{637275237,\n    title = "{Core polarization effects up to 12\\ensuremath{\hbar}\\ensuremath{\omega} in 7Li and 10B nuclei}"\n}\n'
-    with inspire_app.test_client() as client:
-        response = client.get(
-            "/literature/{}".format(record_control_number), headers=headers
-        )
-
-    response_status_code = response.status_code
-    response_data = response.get_data(as_text=True)
-    assert expected_status_code == response_status_code
-    assert expected_result == response_data
-
-
-def test_bibtex_encodes_unicode_without_adding_spurious_spacing(inspire_app):
-    headers = {"Accept": "application/x-bibtex"}
-    data = {
-        "control_number": 637_275_237,
-        "titles": [{"title": "Some notes by Rapčák"}],
-    }
-    record = create_record("lit", data=data)
-    record_control_number = record["control_number"]
-
-    expected_status_code = 200
-    expected_result = (
-        '@article{637275237,\n    title = "{Some notes by Rap\\v{c}\\\'ak}"\n}\n'
-    )
+    expected_result = '@article{Gerard2020:abc,\n    author = "G\\\'erard, Pawe\\l{}",\n    collaboration = "DA\\ensuremath{\\Phi}NE",\n    title = "{About \\ensuremath{\\gamma}-ray bursts}",\n    doi = "10.1234/567_89",\n    journal = "Annales H. Poincar\\\'e",\n    volume = "42",\n    pages = "314--486"\n}\n'
     with inspire_app.test_client() as client:
         response = client.get(
             "/literature/{}".format(record_control_number), headers=headers

--- a/backend/tests/unit/records/marshmallow/literature/test_bibtex_schema.py
+++ b/backend/tests/unit/records/marshmallow/literature/test_bibtex_schema.py
@@ -209,7 +209,7 @@ def test_note_on_erratum():
         "document_type": ["article"],
         "publication_info": [
             {
-                "journal_title": "Zażółć gęślą jaźń",
+                "journal_title": "J.Testing",
                 "journal_volume": "A",
                 "page_start": "12",
                 "page_end": "15",
@@ -224,9 +224,7 @@ def test_note_on_erratum():
             },
         ],
     }
-    expected_note = (
-        "[Erratum: Zażółć gęślą jaźń A, 12--15 (2016), Addendum: A Title B, 987]"
-    )
+    expected_note = "[Erratum: J.Testing A, 12--15 (2016), Addendum: A Title B, 987]"
     schema = BibTexCommonSchema()
 
     result = schema.dump(record).data

--- a/backend/tests/unit/records/marshmallow/literature/test_latex_schema.py
+++ b/backend/tests/unit/records/marshmallow/literature/test_latex_schema.py
@@ -43,7 +43,7 @@ def test_full_schema():
     }
     expected = {
         "texkeys": "a123bx",
-        "titles": [{"title": "Jessica Jones"}],
+        "title": "Jessica Jones",
         "authors": ["F.~Castle", "J.~Smith", "J.~Black, Jr.", "Jimmy"],
         "collaborations": ["LHCb"],
         "dois": [{"value": "10.1088/1361-6633/aa5514"}],
@@ -253,8 +253,8 @@ def test_schema_handles_missing_info_in_erratum():
                 "pubinfo_freetext": "Phys. Rev. D 96, 032004 (2017)",
                 "year": 2017,
             },
-            {"artid": "032005", "material": "erratum",},
-            {"journal_title": "Phys.Rev.D", "material": "erratum",},
+            {"artid": "032005", "material": "erratum"},
+            {"journal_title": "Phys.Rev.D", "material": "erratum"},
         ]
     }
 

--- a/backend/tests/unit/records/marshmallow/literature/test_literature_marshmallow_utils.py
+++ b/backend/tests/unit/records/marshmallow/literature/test_literature_marshmallow_utils.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CERN.
+#
+# inspirehep is free software; you can redistribute it and/or modify it under
+# the terms of the MIT License; see LICENSE file for more details.
+
+from inspirehep.records.marshmallow.literature.utils import latex_encode
+
+
+def test_latex_encode_returns_none_when_input_is_none():
+    assert None == latex_encode(None)
+
+
+def test_latex_encode_escapes_special_chars():
+    text = r" # $ % & \ { } _ ~ ^"
+    expected = (
+        r" \# \$ \% \& \textbackslash{} \{ \} \_ \textasciitilde{} \textasciicircum{}"
+    )
+
+    assert expected == latex_encode(text)
+
+
+def test_latex_encode_escapes_non_ascii():
+    text = "Rapčák"
+    expected = r"Rap\v{c}\'ak"
+
+    assert expected == latex_encode(text)
+
+
+def test_latex_encode_escapes_math_by_default():
+    text = r"Paper on $\gamma$-ray bursts and \(\mu\)-neutrinos \o/"
+    expected = r"Paper on \$\textbackslash{}gamma\$-ray bursts and \textbackslash{}(\textbackslash{}mu\textbackslash{})-neutrinos \textbackslash{}o/"
+
+    assert expected == latex_encode(text)
+
+
+def test_latex_encode_preserves_math_when_contains_math_is_true():
+    text = r"Paper on $\gamma$-ray bursts and \(\mu\)-neutrinos \o/"
+    expected = r"Paper on $\gamma$-ray bursts and \(\mu\)-neutrinos \textbackslash{}o/"
+
+    assert expected == latex_encode(text, contains_math=True)
+
+
+def test_latex_encode_encodes_the_right_parts_when_contains_math_is_true_and_starts_with_math():
+    text = r"$\alpha$ to ω"
+    expected = r"$\alpha$ to \ensuremath{\omega}"
+
+    assert expected == latex_encode(text, contains_math=True)
+
+
+def test_latex_encode_is_correct_when_contains_math_is_true_and_no_math():
+    text = r"Paper on γ-ray bursts and μ-neutrinos \o/"
+    expected = r"Paper on \ensuremath{\gamma}-ray bursts and \ensuremath{\mu}-neutrinos \textbackslash{}o/"
+
+    assert expected == latex_encode(text, contains_math=True)
+
+
+def test_latex_encodes_understands_escaped_math_delimiters():
+    text = r"How to make $\$ 10^100$ from $\alpha$ to Ω"
+    expected = r"How to make $\$ 10^100$ from $\alpha$ to \ensuremath{\Omega}"
+
+    assert expected == latex_encode(text, contains_math=True)


### PR DESCRIPTION
* Moves the encoding from the serializers to the marshmallow schemas,
  which allows to selectively encode only some fields and avoid encoding
  others (e.g. DOI).
* Also adds encoding to LaTeX US/EU formats, previously only BibTeX was
  handled.
* Pins `pylatexenc` to get the bugfix for https://github.com/phfaist/pylatexenc/issues/44 reported by @tsgit (not released yet)