### PR TITLE
ui: refactor core suggester and the form field

### DIFF
--- a/ui/src/common/components/__tests__/__snapshots__/Suggester.test.jsx.snap
+++ b/ui/src/common/components/__tests__/__snapshots__/Suggester.test.jsx.snap
@@ -3,22 +3,25 @@
 exports[`Suggester does not render results onSearch without waiting for debounce 1`] = `
 <ForwardRef(AutoComplete)
   onSearch={[Function]}
+  onSelect={[Function]}
 />
 `;
 
 exports[`Suggester renders empty if request fails 1`] = `
 <ForwardRef(AutoComplete)
   onSearch={[Function]}
+  onSelect={[Function]}
 />
 `;
 
 exports[`Suggester renders results onSearch 1`] = `
 <ForwardRef(AutoComplete)
   onSearch={[Function]}
+  onSelect={[Function]}
 >
   <Option
     key="Result 1"
-    result={
+    suggestion={
       Object {
         "text": "Result 1",
       }
@@ -29,7 +32,7 @@ exports[`Suggester renders results onSearch 1`] = `
   </Option>
   <Option
     key="Result 2"
-    result={
+    suggestion={
       Object {
         "text": "Result 2",
       }
@@ -41,13 +44,14 @@ exports[`Suggester renders results onSearch 1`] = `
 </ForwardRef(AutoComplete)>
 `;
 
-exports[`Suggester renders results with custom completion value 1`] = `
+exports[`Suggester renders results with custom extractUniqueItemValue 1`] = `
 <ForwardRef(AutoComplete)
   onSearch={[Function]}
+  onSelect={[Function]}
 >
   <Option
     key="Result 1 - Extra 1"
-    result={
+    suggestion={
       Object {
         "extra": "Extra 1",
         "text": "Result 1",
@@ -59,7 +63,7 @@ exports[`Suggester renders results with custom completion value 1`] = `
   </Option>
   <Option
     key="Result 2 - Extra 2"
-    result={
+    suggestion={
       Object {
         "extra": "Extra 2",
         "text": "Result 2",
@@ -75,10 +79,11 @@ exports[`Suggester renders results with custom completion value 1`] = `
 exports[`Suggester renders results with custom result template 1`] = `
 <ForwardRef(AutoComplete)
   onSearch={[Function]}
+  onSelect={[Function]}
 >
   <Option
     key="Result 1"
-    result={
+    suggestion={
       Object {
         "extra": "Extra 1",
         "text": "Result 1",
@@ -96,7 +101,7 @@ exports[`Suggester renders results with custom result template 1`] = `
   </Option>
   <Option
     key="Result 2"
-    result={
+    suggestion={
       Object {
         "extra": "Extra 2",
         "text": "Result 2",

--- a/ui/src/submissions/common/components/SuggesterField.jsx
+++ b/ui/src/submissions/common/components/SuggesterField.jsx
@@ -3,6 +3,10 @@ import Suggester from '../../../common/components/Suggester';
 
 import withFormItem from '../withFormItem';
 
+function getSuggestionControlNumber(suggestion) {
+  return String(suggestion._source.control_number);
+}
+
 class SuggesterField extends Component {
   constructor(props) {
     super(props);
@@ -27,13 +31,10 @@ class SuggesterField extends Component {
     }
   }
 
-  onSelect(_, selectedOption) {
-    const selectedRecordData = selectedOption.result._source;
+  onSelect(controlNumber) {
     const { form, recordFieldPath, pidType } = this.props;
     // TODO: only send control_number to backend, and create the $ref url there.
-    const $ref = `${window.location.origin}/api/${pidType}/${
-      selectedRecordData.control_number
-    }`;
+    const $ref = `${window.location.origin}/api/${pidType}/${controlNumber}`;
     form.setFieldValue(recordFieldPath, { $ref });
     this.recordFieldPopulated = true;
   }
@@ -44,6 +45,7 @@ class SuggesterField extends Component {
       <Suggester
         {...restProps}
         data-test-type="suggester"
+        extractUniqueItemValue={getSuggestionControlNumber}
         onBlur={this.onBlur}
         onChange={this.onChange}
         onSelect={this.onSelect}


### PR DESCRIPTION
* Moves core logic from SuggesterField to Suggester
which now provides a simpler API.
* Fixes bug #1219, also for all suggester fields
* Adds id for suggester requests so that unncessary requests are
cancelled