### PR TITLE
cypress: use smaller failure treshold for visual tests

### DIFF
--- a/smoke-tests/cypress/support/commands/visual.js
+++ b/smoke-tests/cypress/support/commands/visual.js
@@ -1,7 +1,7 @@
 import { addMatchImageSnapshotCommand } from 'cypress-image-snapshot/command';
 
 addMatchImageSnapshotCommand({
-  failureThreshold: 0.05,
+  failureThreshold: 0.005,
   failureThresholdType: 'percent',
   capture: 'fullPage',
   customSnapshotsDir: 'cypress/__snapshots__',


### PR DESCRIPTION
Ref: #1402