### PR TITLE
suggesters: fix series suggesters

### DIFF
--- a/backend/inspirehep/records/config.py
+++ b/backend/inspirehep/records/config.py
@@ -468,7 +468,8 @@ SEMINARS.update(
         },
         "suggesters": {
             "series_name": {
-                "completion": {"field": "series_autocomplete", "skip_duplicates": True}
+                "_source": ["control_number"],
+                "completion": {"field": "series_autocomplete", "skip_duplicates": True},
             }
         },
     }

--- a/ui/src/common/components/Suggester.jsx
+++ b/ui/src/common/components/Suggester.jsx
@@ -47,7 +47,10 @@ class Suggester extends Component {
     if (uniqueItemValue !== completionValue) {
       onChange(completionValue);
     }
-    onSelect(uniqueItemValue, suggestion);
+
+    if (onSelect) {
+      onSelect(uniqueItemValue, suggestion);
+    }
   }
 
   responseDataToResults(responseData) {
@@ -103,15 +106,15 @@ class Suggester extends Component {
 }
 
 Suggester.propTypes = {
+  // also accepts other antd.AutoComplete props
   pidType: PropTypes.string.isRequired,
   suggesterName: PropTypes.string.isRequired,
-  renderResultItem: PropTypes.func, // defaults to extractItemCompletionValue
-  extractItemCompletionValue: PropTypes.func, // defaults to extractUniqueItemValue
   extractUniqueItemValue: PropTypes.func,
+  extractItemCompletionValue: PropTypes.func, // defaults to extractUniqueItemValue
+  renderResultItem: PropTypes.func, // defaults to extractItemCompletionValue
 };
 
 Suggester.defaultProps = {
   extractUniqueItemValue: resultItem => resultItem.text,
 };
-
 export default Suggester;

--- a/ui/src/common/components/__tests__/Suggester.test.jsx
+++ b/ui/src/common/components/__tests__/Suggester.test.jsx
@@ -248,6 +248,41 @@ describe('Suggester', () => {
     expect(onChange).toHaveBeenCalledWith('Result');
   });
 
+  it('calls only onChange if extractItemCompletionValue prop is present and onSelect is not when an option is selected', async () => {
+    const suggesterQueryUrl = '/literature/_suggest?abstract_source=test';
+    const responseData = {
+      abstract_source: [
+        {
+          options: [
+            {
+              id: '1',
+              name: 'Result',
+            },
+          ],
+        },
+      ],
+    };
+    mockHttp.onGet(suggesterQueryUrl).replyOnce(200, responseData);
+    const onChange = jest.fn();
+    const wrapper = shallow(
+      <Suggester
+        onChange={onChange}
+        pidType="literature"
+        extractItemCompletionValue={suggestion => suggestion.name}
+        extractUniqueItemValue={suggestion => suggestion.id}
+        suggesterName="abstract_source"
+      />
+    );
+    await wrapper.instance().onSearch('test');
+    await wait();
+    wrapper.update();
+    const suggestionWrapper = wrapper.find(AutoComplete.Option);
+    wrapper
+      .find(AutoComplete)
+      .simulate('select', null, suggestionWrapper.props());
+    expect(onChange).toHaveBeenCalledWith('Result');
+  });
+
   it('renders empty if request fails', async () => {
     const suggesterQueryUrl = '/literature/_suggest?abstract_source=test';
     mockHttp.onGet(suggesterQueryUrl).replyOnce(404);

--- a/ui/src/submissions/common/components/SuggesterField.jsx
+++ b/ui/src/submissions/common/components/SuggesterField.jsx
@@ -48,10 +48,14 @@ class SuggesterField extends Component {
         extractUniqueItemValue={getSuggestionControlNumber}
         onBlur={this.onBlur}
         onChange={this.onChange}
-        onSelect={this.onSelect}
+        onSelect={recordFieldPath ? this.onSelect : null}
       />
     );
   }
 }
+
+SuggesterField.defaultProps = {
+  extractItemCompletionValue: resultItem => resultItem.text,
+};
 
 export default withFormItem(SuggesterField);

--- a/ui/src/submissions/seminars/components/SeminarForm.jsx
+++ b/ui/src/submissions/seminars/components/SeminarForm.jsx
@@ -156,7 +156,7 @@ function SeminarForm({ values }) {
         )}
       />
       <Field name="captioned" label="Has captions" component={BooleanField} />
-      <AntForm.Item
+      <AntForm.Item // TODO: create `ObjectOf` component
         label="Address"
         labelCol={LABEL_COL}
         wrapperCol={WRAPPER_COL}


### PR DESCRIPTION
* Fixes suggerter form field bug when there is no custom item completion value
* Calls suggester onSelect only when there is affilated record link to be autocompleted
* Reduces seminar suggester payload to only `control_number` instead of whole record