### PR TITLE
submission: save proceeding and conference info in private_notes

### DIFF
--- a/backend/inspirehep/submissions/marshmallow/literature.py
+++ b/backend/inspirehep/submissions/marshmallow/literature.py
@@ -65,9 +65,8 @@ class Literature(Schema):
     supervisors = fields.Raw()
 
     conference_record = fields.Raw()
-    comments = fields.Raw()
 
-    # FIXME: below fields aren't used
+    comments = fields.Raw()
     conference_info = fields.Raw()
     proceedings_info = fields.Raw()
 
@@ -241,6 +240,10 @@ class Literature(Schema):
             )
             literature.add_author(record_supervisor)
 
-        literature.add_private_note(data.get("comments"))
+        literature.add_private_note(data.get("comments"), source="submitter")
+        literature.add_private_note(data.get("proceedings_info"), source="submitter")
+
+        if data.get("conference_record") is None:
+            literature.add_private_note(data.get("conference_info"), source="submitter")
 
         return literature.record

--- a/smoke-tests/cypress/integration/literature.test.js
+++ b/smoke-tests/cypress/integration/literature.test.js
@@ -111,6 +111,8 @@ describe('Literature Submission', () => {
       issue: '20',
       year: '2014',
       comments: 'very private thing',
+      proceedings_info: 'very private proceeding',
+      conference_info: 'very private conference',
     };
     const expectedMetadata = {
       acquisition_source: {
@@ -148,7 +150,14 @@ describe('Literature Submission', () => {
         },
       ],
       accelerator_experiments: [{ legacy_name: 'CERN-LEP-L3' }],
-      _private_notes: [{ value: 'very private thing' }],
+      _private_notes: [
+        { value: 'very private thing', source: 'submitter' },
+        { value: 'very private proceeding', source: 'submitter' },
+        {
+          value: 'very private conference',
+          source: 'submitter',
+        },
+      ],
     };
     const expectedWorkflow = {
       _workflow: { data_type: 'hep' },
@@ -160,6 +169,8 @@ describe('Literature Submission', () => {
     };
     cy.visit('/submissions/literature');
     cy.selectLiteratureDocType('article');
+    cy.contains('Conference Info').click();
+    cy.contains('Proceedings Info').click();
     cy.contains('Comments').click();
     cy
       .testSubmission({


### PR DESCRIPTION
Save proceeding and conference info in `_private_notes` field for literature submission.

Ref: #1430