### PR TITLE
cypress: fix container logs on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,8 @@ jobs:
           path: smoke-tests/cypress/__screenshots__
       - store_artifacts:
           path: smoke-tests/cypress/__snapshots__
-      - run: docker-compose -f docker-compose.yml -f ./smoke-tests/docker-compose.cypress.yml logs --no-color > logs.txt
       - store_artifacts:
-          path: logs.txt
+          path: cypress-container-logs.txt
 workflows:
   version: 2
   e2e:

--- a/cypress-tests-run.sh
+++ b/cypress-tests-run.sh
@@ -5,4 +5,6 @@ docker wait inspirehep_ui-build_1
 docker wait inspirehep_record-editor-build_1
 
 docker-compose $files run -w "/tests" --rm cypress bash -c "yarn && yarn test --browser chrome --headless --env inspirehep_url=http://ui:8080" || rc=$?
+
+docker-compose $files logs --no-color > cypress-container-logs.txt
 exit $rc


### PR DESCRIPTION
Container logs wasn't uploaded when tests failed