### PR TITLE
pidstore: make queries faster by using an index

### DIFF
--- a/backend/inspirehep/pidstore/minters/base.py
+++ b/backend/inspirehep/pidstore/minters/base.py
@@ -113,7 +113,7 @@ class Minter:
                 PersistentIdentifier.pid_value
             )
             .filter_by(pid_type=self.pid_type or self.provider.pid_type)
-            .filter_by(object_uuid=self.object_uuid)
+            .filter_by(object_uuid=self.object_uuid, object_type=self.object_type)
             .filter_by(pid_provider=self.provider.pid_provider)
             .filter(PersistentIdentifier.status != PIDStatus.DELETED)
         }

--- a/backend/inspirehep/pidstore/minters/cnum.py
+++ b/backend/inspirehep/pidstore/minters/cnum.py
@@ -70,7 +70,7 @@ class CNUMMinter(Minter):
         """
         cnum_pid = (
             PersistentIdentifier.query.filter_by(pid_type="cnum")
-            .filter_by(object_uuid=object_uuid)
+            .filter_by(object_uuid=object_uuid, object_type=cls.object_type)
             .one_or_none()
         )
 

--- a/backend/inspirehep/pidstore/minters/texkey.py
+++ b/backend/inspirehep/pidstore/minters/texkey.py
@@ -119,6 +119,7 @@ class TexKeyMinter(Minter):
                 PersistentIdentifier.pid_value
             )
             .filter(PersistentIdentifier.object_uuid == object_uuid)
+            .filter(PersistentIdentifier.object_type == cls.object_type)
             .filter(PersistentIdentifier.pid_type == cls.pid_type)
             .filter(PersistentIdentifier.status != PIDStatus.DELETED)
         ]

--- a/backend/inspirehep/pidstore/providers/external.py
+++ b/backend/inspirehep/pidstore/providers/external.py
@@ -21,7 +21,7 @@ class InspireExternalIdProvider(InspireBaseProvider):
     def delete(self):
         try:
             PersistentIdentifier.query.filter_by(
-                id=self.pid.id, object_uuid=self.pid.object_uuid
+                id=self.pid.id, object_uuid=self.pid.object_uuid, object_type="rec"
             ).delete()
         except PIDDoesNotExistError:
             LOGGER.warning("Pids ``external`` not found", uuid=str(self.object_uuid))

--- a/backend/inspirehep/pidstore/providers/texkey.py
+++ b/backend/inspirehep/pidstore/providers/texkey.py
@@ -164,7 +164,7 @@ class InspireTexKeyProvider(InspireBaseProvider):
         raise NoAvailableTexKeyFound
 
     @classmethod
-    def query_pid(cls, pid_value, object_uuid=None):
+    def query_pid(cls, pid_value, object_uuid=None, object_type="rec"):
         query = (
             PersistentIdentifier.query.filter(
                 PersistentIdentifier.pid_type == cls.pid_type
@@ -173,7 +173,10 @@ class InspireTexKeyProvider(InspireBaseProvider):
             .filter(PersistentIdentifier.pid_provider == cls.pid_provider)
         )
         if object_uuid:
-            query = query.filter(PersistentIdentifier.object_uuid == object_uuid)
+            query = query.filter(
+                PersistentIdentifier.object_uuid == object_uuid,
+                PersistentIdentifier.object_type == object_type,
+            )
         return query
 
     @classmethod

--- a/backend/inspirehep/records/api/base.py
+++ b/backend/inspirehep/records/api/base.py
@@ -276,7 +276,7 @@ class InspireRecord(Record):
     def copy(self):
         """Copy the record metadata.
 
-            This is needed because the default ``dict.copy`` always returns a ``dict``.
+        This is needed because the default ``dict.copy`` always returns a ``dict``.
         """
         return type(self)(self)
 
@@ -417,6 +417,7 @@ class InspireRecord(Record):
         with db.session.begin_nested():
             pids = PersistentIdentifier.query.filter(
                 PersistentIdentifier.object_uuid == self.id,
+                PersistentIdentifier.object_type == "rec",
                 PersistentIdentifier.status != PIDStatus.REDIRECTED,
             ).all()
             for pid in pids:


### PR DESCRIPTION
* When querying for `object_uuid` on the pidstore, it's important to
  also query on `object_type="rec"`, otherwise the index won't be used,
  and queries will be much slower than necessary. This is the case in
  the migration, where 20% of the time is spent in the
  `Minter.get_all_pidstore_pids` method due to this issue. So I searched
  for all occurrences of `object_uuid` and fixed the wrong ones.