### PR TITLE
disambiguation: pass authors data directly to create_new_author

### DIFF
--- a/backend/inspirehep/assign/views.py
+++ b/backend/inspirehep/assign/views.py
@@ -11,7 +11,7 @@ from invenio_db import db
 
 from inspirehep.accounts.decorators import login_required_with_roles
 from inspirehep.accounts.roles import Roles
-from inspirehep.disambiguation.utils import create_new_empty_author, update_author_names
+from inspirehep.disambiguation.utils import create_new_stub_author, update_author_names
 from inspirehep.records.api import AuthorsRecord, LiteratureRecord
 
 blueprint = Blueprint("inspirehep_assign", __name__, url_prefix="/assign")
@@ -50,7 +50,7 @@ def assign_papers(from_author_recid, to_author_recid, literature_recids):
 
 def assign_to_new_stub_author(from_author_recid, literature_recids):
     # TODO: differentiate from BEARD created stub author
-    to_author = create_new_empty_author()
+    to_author = create_new_stub_author()
     author_signatures = assign_papers(
         from_author_recid, to_author["control_number"], literature_recids
     )

--- a/backend/inspirehep/disambiguation/tasks.py
+++ b/backend/inspirehep/disambiguation/tasks.py
@@ -8,7 +8,7 @@ from invenio_db import db
 from prometheus_client import Counter
 
 from inspirehep.disambiguation.utils import (
-    create_new_empty_author,
+    create_new_stub_author,
     link_signatures_to_author,
     update_author_names,
 )
@@ -59,7 +59,7 @@ def disambiguate_signatures(self, clusters):
                 LOGGER.debug(
                     "Received cluster with 0 authors.", signatures=cluster["signatures"]
                 )
-                author = create_new_empty_author()
+                author = create_new_stub_author()
                 linked_signatures = link_signatures_to_author(
                     cluster["signatures"], author["control_number"]
                 )
@@ -167,8 +167,7 @@ def create_new_author(full_name, from_recid):
         ],
     }
 
-    new_author = create_new_empty_author()
-    new_author.update({**new_author, **new_author_data})
+    new_author = create_new_stub_author(**new_author_data)
     LOGGER.info(
         "Created new author record",
         {

--- a/backend/inspirehep/disambiguation/utils.py
+++ b/backend/inspirehep/disambiguation/utils.py
@@ -72,7 +72,7 @@ def link_signatures_to_author(signatures_data, author_control_number):
     return linked_signatures
 
 
-def create_new_empty_author():
+def create_new_stub_author(**kwargs):
     """Create a stub author record."""
     author_data = {
         "name": {"value": "BEARD STUB"},
@@ -88,6 +88,7 @@ def create_new_empty_author():
             _external=True,
         ),
     }
+    author_data.update(kwargs)
     author = AuthorsRecord.create(author_data)
     return author
 

--- a/backend/tests/integration/disambiguation/test_utils.py
+++ b/backend/tests/integration/disambiguation/test_utils.py
@@ -10,7 +10,7 @@ from freezegun import freeze_time
 from helpers.utils import create_record
 
 from inspirehep.disambiguation.utils import (
-    create_new_empty_author,
+    create_new_stub_author,
     link_signature_to_author,
     link_signatures_to_author,
 )
@@ -194,8 +194,8 @@ def test_link_signatures_to_author_missing_uuid(inspire_app):
 
 
 @freeze_time("2019-02-15")
-def test_create_new_empty_author(inspire_app):
-    author = create_new_empty_author()
+def test_create_new_stub_author(inspire_app):
+    author = create_new_stub_author()
     control_number = author["control_number"]
     expected_data = {
         "name": {"value": "BEARD STUB"},


### PR DESCRIPTION
* solves bug with assigning already existing pid to newly created authors