### PR TITLE
orcid: fix StaleRecordDBVersion exception

### DIFF
--- a/backend/inspirehep/orcid/domain_models.py
+++ b/backend/inspirehep/orcid/domain_models.py
@@ -296,6 +296,5 @@ class OrcidPusher(object):
                 self.oauth_token,
                 dict(
                     pushing_duplicated_identifier=True,
-                    record_db_version=self.record_db_version,
                 ),
             )


### PR DESCRIPTION
* This was caused by passing the current record version when trying to
  push a different record, which in general won't match. The fix is not
  to pass any version (which is ok, as the versioning checks is there
  only to avoid reading stale data from the DB in case the task is fired
  before the update gets commited).
* Ref #1570.