### PR TITLE
  all: replace json with orjson module 

### DIFF
--- a/backend/inspirehep/accounts/views.py
+++ b/backend/inspirehep/accounts/views.py
@@ -5,7 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-from flask import Blueprint, jsonify, redirect, request, session
+from flask import Blueprint, redirect, request, session
 from flask_security.utils import login_user, logout_user, verify_password
 from invenio_accounts.models import User
 from invenio_db import db
@@ -13,6 +13,7 @@ from invenio_oauthclient import current_oauthclient
 from sqlalchemy.exc import IntegrityError
 
 from inspirehep.orcid.tasks import push_account_literature_to_orcid
+from inspirehep.serializers import jsonify
 
 from .api import get_current_user_remote_orcid_account
 from .decorators import login_required

--- a/backend/inspirehep/assign/views.py
+++ b/backend/inspirehep/assign/views.py
@@ -5,7 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, request
 from inspire_dojson.utils import get_recid_from_ref, get_record_ref
 from invenio_db import db
 
@@ -13,6 +13,7 @@ from inspirehep.accounts.decorators import login_required_with_roles
 from inspirehep.accounts.roles import Roles
 from inspirehep.disambiguation.utils import create_new_stub_author, update_author_names
 from inspirehep.records.api import AuthorsRecord, LiteratureRecord
+from inspirehep.serializers import jsonify
 
 blueprint = Blueprint("inspirehep_assign", __name__, url_prefix="/assign")
 

--- a/backend/inspirehep/config.py
+++ b/backend/inspirehep/config.py
@@ -13,8 +13,11 @@ You overwrite and set instance-specific configuration by either:
 - Environment variables: ``APP_<variable name>``
 """
 
+import orjson
 import pkg_resources
 
+from inspirehep.search.serializers import ORJSONSerializerES
+from inspirehep.serializers import serialize_json_for_sqlalchemy
 from inspirehep.utils import include_table_check
 
 # INSPIRE configuration
@@ -156,6 +159,11 @@ SQLALCHEMY_DATABASE_URI = (
     "postgresql+psycopg2://inspirehep:inspirehep@localhost:5432/inspirehep"
 )
 
+SQLALCHEMY_ENGINE_OPTIONS = {
+    "json_deserializer": orjson.loads,
+    "json_serializer": serialize_json_for_sqlalchemy,
+}
+
 # JSONSchemas
 # ===========
 #: Hostname used in URLs for local JSONSchemas.
@@ -201,6 +209,7 @@ INDEXER_DEFAULT_DOC_TYPE = "_doc"
 INDEXER_BULK_REQUEST_TIMEOUT = 900
 INDEXER_REPLACE_REFS = False
 SEARCH_INDEX_PREFIX = None
+SEARCH_CLIENT_CONFIG = {"serializer": ORJSONSerializerES()}
 
 # Alembic
 # =======

--- a/backend/inspirehep/disambiguation/views.py
+++ b/backend/inspirehep/disambiguation/views.py
@@ -6,12 +6,13 @@
 # the terms of the MIT License; see LICENSE file for more details.
 
 import structlog
-from flask import Blueprint, current_app, jsonify, request
+from flask import Blueprint, current_app, request
 
 from inspirehep.accounts.decorators import login_required_with_roles
 from inspirehep.accounts.roles import Roles
 from inspirehep.disambiguation.loaders import DisambiguateSignaturesSchema
 from inspirehep.disambiguation.tasks import disambiguate_signatures
+from inspirehep.serializers import jsonify
 
 LOGGER = structlog.getLogger()
 

--- a/backend/inspirehep/editor/views.py
+++ b/backend/inspirehep/editor/views.py
@@ -7,7 +7,7 @@
 
 from os.path import splitext
 
-from flask import Blueprint, current_app, jsonify, make_response, request
+from flask import Blueprint, current_app, make_response, request
 from flask_login import current_user
 from inspire_schemas.api import load_schema
 from invenio_db import db
@@ -24,6 +24,7 @@ from inspirehep.matcher.utils import create_journal_dict, map_refextract_to_sche
 from inspirehep.pidstore.api.base import PidStoreBase
 from inspirehep.records.api import InspireRecord
 from inspirehep.rt import tickets
+from inspirehep.serializers import jsonify
 from inspirehep.utils import hash_data
 
 from .errors import EditorGetRevisionError, EditorRevertToRevisionError

--- a/backend/inspirehep/mailing/views.py
+++ b/backend/inspirehep/mailing/views.py
@@ -10,10 +10,11 @@ from datetime import datetime
 import pytz
 import structlog
 from feedgen.feed import FeedGenerator
-from flask import Blueprint, Response, current_app, jsonify, request
+from flask import Blueprint, Response, current_app, request
 from redis import StrictRedis
 
 from inspirehep.mailing.api.jobs import subscribe_to_jobs_weekly_list
+from inspirehep.serializers import jsonify
 
 from .loaders import JobsWeeklySubscribeSchema
 

--- a/backend/inspirehep/matcher/views.py
+++ b/backend/inspirehep/matcher/views.py
@@ -1,6 +1,7 @@
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, request
 
 from inspirehep.matcher.api import match_references
+from inspirehep.serializers import jsonify
 
 blueprint = Blueprint("inspirehep_matcher", __name__, url_prefix="/matcher")
 

--- a/backend/inspirehep/migrator/views.py
+++ b/backend/inspirehep/migrator/views.py
@@ -6,11 +6,12 @@
 # the terms of the MIT License; see LICENSE file for more details.
 
 
-from flask import Blueprint, jsonify
+from flask import Blueprint
 from flask.views import MethodView
 
 from inspirehep.accounts.decorators import login_required_with_roles
 from inspirehep.accounts.roles import Roles
+from inspirehep.serializers import jsonify
 
 from .marshmallow.error import ErrorList
 from .models import LegacyRecordsMirror

--- a/backend/inspirehep/records/api/literature.py
+++ b/backend/inspirehep/records/api/literature.py
@@ -5,13 +5,13 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 import datetime
-import json
 import threading
 import uuid
 from concurrent.futures import ThreadPoolExecutor, TimeoutError, as_completed
 from io import BytesIO
 
 import magic
+import orjson
 import requests
 import structlog
 from flask import current_app
@@ -132,7 +132,7 @@ class LiteratureRecord(
             results = LiteratureSearch.get_records_by_pids(pids, source=["_ui_display"])
             for result in results:
                 try:
-                    rec_data = json.loads(result._ui_display)
+                    rec_data = orjson.loads(result._ui_display)
                 except AttributeError:
                     LOGGER.exception(
                         "Record does not have _ui_display field!", record=result.meta.id

--- a/backend/inspirehep/records/cli.py
+++ b/backend/inspirehep/records/cli.py
@@ -6,10 +6,10 @@
 # the terms of the MIT License; see LICENSE file for more details.
 
 import datetime
-import json
 import os
 
 import click
+import orjson
 import requests
 import structlog
 from flask import current_app
@@ -47,7 +47,7 @@ def _create_record(data, save_to_file=False):
         file_path = os.path.join(f"data/records/{endpoint}/{control_number}.json")
         click.echo(click.style(f"Writing to {file_path}", fg="green"))
         with open(file_path, "w+") as file:
-            file.write(json.dumps(data))
+            file.write(orjson.dumps(data))
 
 
 def _create_records_from_urls(urls, token, save_to_file):
@@ -83,8 +83,8 @@ def _create_records_from_urls(urls, token, save_to_file):
 
 
 def _create_records_from_list_files(files):
-    for path in files:
-        data = json.load(path)
+    for _file in files:
+        data = orjson.loads(_file.read())
         _create_record(data)
 
 
@@ -92,7 +92,7 @@ def _create_records_from_files_in_directory(directory):
     if directory:
         for path in os.listdir(directory):
             with open(os.path.join(directory, path)) as file_:
-                data = json.load(file_)
+                data = orjson.loads(file_.read())
                 _create_record(data)
 
 

--- a/backend/inspirehep/records/marshmallow/base.py
+++ b/backend/inspirehep/records/marshmallow/base.py
@@ -6,6 +6,7 @@
 # the terms of the MIT License; see LICENSE file for more details.
 from copy import deepcopy
 
+import orjson
 from flask import abort
 from inspire_dojson.utils import strip_empty_values
 from invenio_records_rest.schemas.json import RecordSchemaJSONV1
@@ -49,6 +50,9 @@ class ElasticSearchBaseSchema:
 
 class BaseSchema(Schema):
     """Base schema."""
+
+    class Meta:
+        json_module = orjson
 
     def dump(self, obj, *args, **kwargs):
         obj_copy = deepcopy(obj)

--- a/backend/inspirehep/records/marshmallow/literature/es.py
+++ b/backend/inspirehep/records/marshmallow/literature/es.py
@@ -5,9 +5,9 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
 from itertools import chain
 
+import orjson
 import structlog
 from flask import current_app
 from inspire_utils.helpers import force_list
@@ -74,7 +74,7 @@ class LiteratureElasticSearchSchema(ElasticSearchBaseSchema, LiteratureRawSchema
         ]
 
     def get_ui_display(self, record):
-        return json.dumps(LiteratureDetailSchema().dump(record).data)
+        return orjson.dumps(LiteratureDetailSchema().dump(record).data).decode("utf-8")
 
     def get_latex_us_display(self, record):
         from inspirehep.records.serializers.latex import latex_US

--- a/backend/inspirehep/records/marshmallow/literature/ui.py
+++ b/backend/inspirehep/records/marshmallow/literature/ui.py
@@ -5,8 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
-
+import orjson
 from flask import current_app, url_for
 from inspire_utils.date import format_date
 from inspire_utils.record import get_value, get_values_for_schema
@@ -222,7 +221,7 @@ class LiteratureListWrappedSchema(EnvelopeSchema):
 
     def get_ui_display(self, data):
         try:
-            ui_display = json.loads(get_value(data, "metadata._ui_display", ""))
+            ui_display = orjson.loads(get_value(data, "metadata._ui_display", ""))
             if is_superuser_or_cataloger_logged_in():
                 ui_display["can_edit"] = True
             if is_assign_view_enabled():
@@ -236,5 +235,5 @@ class LiteratureListWrappedSchema(EnvelopeSchema):
                 del acquisition_source["email"]
                 ui_display.update({"acquisition_source": acquisition_source})
             return ui_display
-        except json.JSONDecodeError:
+        except orjson.JSONDecodeError:
             return {}

--- a/backend/inspirehep/records/views.py
+++ b/backend/inspirehep/records/views.py
@@ -5,7 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-from flask import Blueprint, abort, current_app, jsonify, request
+from flask import Blueprint, abort, current_app, request
 from flask.views import MethodView
 from invenio_records_rest.views import pass_record
 
@@ -21,6 +21,7 @@ from inspirehep.records.errors import (
 from inspirehep.records.marshmallow.literature.references import (
     LiteratureReferencesSchema,
 )
+from inspirehep.serializers import jsonify
 from inspirehep.submissions.serializers import literature_v1
 
 from ..search.api import LiteratureSearch

--- a/backend/inspirehep/search/serializers.py
+++ b/backend/inspirehep/search/serializers.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CERN.
+#
+# inspirehep is free software; you can redistribute it and/or modify it under
+# the terms of the MIT License; see LICENSE file for more details.
+import orjson
+from elasticsearch import SerializationError
+from elasticsearch.compat import string_types
+from elasticsearch.serializer import JSONSerializer
+from flask import current_app
+
+from inspirehep.search.utils import RecursionLimit
+
+
+class ORJSONSerializerES(JSONSerializer):
+    def dumps(self, data):
+        if isinstance(data, string_types):
+            return data
+        try:
+            with RecursionLimit(
+                current_app.config.get("SEARCH_MAX_RECURSION_LIMIT", 5000)
+            ):
+                dump = orjson.dumps(data, default=self.default).decode("utf-8")
+            return dump
+        except (ValueError, TypeError) as ex:
+            if isinstance(ex, TypeError) and ex.args == ("Recursion limit reached",):
+                # As currently we can only turn off recursion limit but we don't want that as
+                # then we should handle overflow error in rust
+                return super().dumps(data)
+            raise SerializationError(data, ex)
+
+    def loads(self, s):
+        try:
+            return orjson.loads(s)
+        except (ValueError, TypeError) as ex:
+            raise SerializationError(s, ex)

--- a/backend/inspirehep/search/views.py
+++ b/backend/inspirehep/search/views.py
@@ -5,8 +5,10 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-from flask import Blueprint, abort, current_app, jsonify, request
+from flask import Blueprint, abort, current_app, request
 from inspire_query_parser import parse_query
+
+from inspirehep.serializers import jsonify
 
 blueprint = Blueprint("inspirehep_search", __name__, url_prefix="/search")
 

--- a/backend/inspirehep/serializers.py
+++ b/backend/inspirehep/serializers.py
@@ -136,7 +136,7 @@ class JSONSerializerFacets(ORJSONSerializerMixin, InvenioJSONSerializer):
             search_result.get("aggregations", {})
         )
 
-        return orjson.dumps(search_result)
+        return orjson.dumps(search_result, **self._format_args())
 
     @staticmethod
     def flatten_aggregations(aggregations):

--- a/backend/inspirehep/submissions/views.py
+++ b/backend/inspirehep/submissions/views.py
@@ -6,11 +6,11 @@
 # the terms of the MIT License; see LICENSE file for more details.
 
 import datetime
-import json
 
+import orjson
 import requests
 import structlog
-from flask import Blueprint, abort, current_app, jsonify, request, url_for
+from flask import Blueprint, abort, current_app, request, url_for
 from flask.views import MethodView
 from flask_login import current_user
 from inspire_schemas.builders import JobBuilder
@@ -34,6 +34,7 @@ from inspirehep.records.api import (
     JobsRecord,
     SeminarsRecord,
 )
+from inspirehep.serializers import jsonify
 from inspirehep.submissions.errors import RESTDataError
 from inspirehep.utils import get_inspirehep_url
 
@@ -80,7 +81,7 @@ class BaseSubmissionsResource(MethodView):
         }
         response = requests.post(
             f"{current_app.config['INSPIRE_NEXT_URL']}{endpoint}",
-            data=json.dumps(data),
+            data=orjson.dumps(data),
             headers=headers,
         )
         if response.status_code == 200:

--- a/backend/inspirehep/tools/views.py
+++ b/backend/inspirehep/tools/views.py
@@ -8,9 +8,10 @@
 from io import BytesIO, TextIOWrapper
 from os.path import splitext
 
-from flask import Blueprint, current_app, jsonify, request
+from flask import Blueprint, current_app, request
 
 from inspirehep.files.api import current_s3_instance
+from inspirehep.serializers import jsonify
 from inspirehep.tools.utils import (
     find_references,
     get_filename,

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -2608,6 +2608,14 @@ six = ">=1.8.0"
 
 [[package]]
 category = "main"
+description = "Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy"
+name = "orjson"
+optional = false
+python-versions = ">=3.6"
+version = "3.4.6"
+
+[[package]]
+category = "main"
 description = "Core utilities for Python packages"
 name = "packaging"
 optional = false
@@ -4126,7 +4134,7 @@ test = ["zope.event"]
 testing = ["coverage", "nose", "zope.event"]
 
 [metadata]
-content-hash = "5d5c689a2ffdc8ebd61c47642ea5310c6c1ef96c9c1a4ffc27b10dbd78b6fcab"
+content-hash = "e2a125ab64282951a87a737fbc891829363a667241c6253112f6d0556f49b9fa"
 lock-version = "1.0"
 python-versions = ">=3.6,<3.8"
 
@@ -4209,9 +4217,7 @@ base32-lib = [
     {file = "base32_lib-1.0.1-py2.py3-none-any.whl", hash = "sha256:ebbf80687ef9791580135f372db1c0a09a1a5d02089d57a8a49bf5ef3330221f"},
 ]
 beard = [
-    {file = "beard-0.2.1-py2.7.egg", hash = "sha256:481220480742f7d9317c3682fb27c3e442fb0406b92d82425433cd93f236dec8"},
     {file = "beard-0.2.1-py3-none-any.whl", hash = "sha256:56ca82003b15fc4cedd3c913e6ce6afeaa10bd27c2b5bbc4c467627c63722227"},
-    {file = "beard-0.2.1-py3.6.egg", hash = "sha256:fba7c6c3c56d29906e14cdab29085f186ca1c23ff3a27ed0260c6ef4334893b3"},
     {file = "beard-0.2.1.tar.gz", hash = "sha256:589ca864cd4125fa7382d8e484e969b4512ff8d0e7f9a760e8f55110ff8ef8da"},
 ]
 beautifulsoup4 = [
@@ -4893,11 +4899,6 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-win32.whl", hash = "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"},
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
 ]
 marshmallow = [
@@ -4980,7 +4981,6 @@ node-semver = [
 ]
 nodeenv = [
     {file = "nodeenv-1.3.4-py2.py3-none-any.whl", hash = "sha256:561057acd4ae3809e665a9aaaf214afff110bbb6a6d5c8a96121aea6878408b3"},
-    {file = "nodeenv-1.3.4.tar.gz", hash = "sha256:ff860d311cb9cee1a74e7056b6526436eceb2d5177f584b128eca3530849c1ec"},
 ]
 numpy = [
     {file = "numpy-1.18.1-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:20b26aaa5b3da029942cdcce719b363dbe58696ad182aff0e5dcb1687ec946dc"},
@@ -5018,6 +5018,25 @@ ordered-set = [
 orderedmultidict = [
     {file = "orderedmultidict-1.0.1-py2.py3-none-any.whl", hash = "sha256:43c839a17ee3cdd62234c47deca1a8508a3f2ca1d0678a3bf791c87cf84adbf3"},
     {file = "orderedmultidict-1.0.1.tar.gz", hash = "sha256:04070bbb5e87291cc9bfa51df413677faf2141c73c61d2a5f7b26bea3cd882ad"},
+]
+orjson = [
+    {file = "orjson-3.4.6-cp36-cp36m-macosx_10_7_x86_64.whl", hash = "sha256:4e258f4696255de8038fd01ead8277a7c5c6d1e453cc7ca5aad8c1e9f74af62e"},
+    {file = "orjson-3.4.6-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:283e54f0e2175ffe3f3acb20473da9d13f944a5faca6b066e0df2096ca8dda58"},
+    {file = "orjson-3.4.6-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:9864c587a009cc266fce02fbb2d99dd25c773bdd650d4728ef419686c4130380"},
+    {file = "orjson-3.4.6-cp36-none-win_amd64.whl", hash = "sha256:9a861504727f3ded5e13ca321fb4187ace3300113c6bf1554088619bbb557f89"},
+    {file = "orjson-3.4.6-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:3fe17a3f0f68b29a2f096817afd98ef680dec7c7577d12de6465e942cd9e4e71"},
+    {file = "orjson-3.4.6-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:38f01ee249813d80e18eaeb5c434e026ddce631a7f1a93265f7035bc7e6621ff"},
+    {file = "orjson-3.4.6-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:c961711a8e1ec688fcc978638a1b618c1bfff65929f99edecfa8b67ab26ec2de"},
+    {file = "orjson-3.4.6-cp37-none-win_amd64.whl", hash = "sha256:218f164aa917b82e328f177c4121fb45c178b746f917c21739fc3eb5f5b7ca8b"},
+    {file = "orjson-3.4.6-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:67d8e09030342d0153c86676cebdbca5cd12e257a436c8238a25e52f800de98a"},
+    {file = "orjson-3.4.6-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:bac00616ee44c78c8a8bd7e3d6c394ff97d2a45e1b3f453d6a29ffce97b6ffca"},
+    {file = "orjson-3.4.6-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:f5008f92ecf5d0cb0cb172d6d9aa76f48d54cc1b6abc4fc83f430d58de9148ba"},
+    {file = "orjson-3.4.6-cp38-none-win_amd64.whl", hash = "sha256:5fe9097f622c7ad47a511a3d2189576b11d1be4b067f094089c45a01ae80b34f"},
+    {file = "orjson-3.4.6-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:7132aa4779388f0c0ef2d944efd7f170b41f9d5eadd69813b715afe05af23fbc"},
+    {file = "orjson-3.4.6-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:8b246b9234d920fb8f1373167e63254581639482e710ea515354979ec13a47a9"},
+    {file = "orjson-3.4.6-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:b62c64d2336fe9e1a21f0b89f12946d988fd1feb365c2e6f90071c21aca3127d"},
+    {file = "orjson-3.4.6-cp39-none-win_amd64.whl", hash = "sha256:a60db27bcba1645c0199ebe4edc1290a91ee22644dde61ee9257ebbacbf5d81e"},
+    {file = "orjson-3.4.6.tar.gz", hash = "sha256:e1b4128baebf7968572343834b282794e20c5082f55f42b9675b04df0749e087"},
 ]
 packaging = [
     {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},
@@ -5530,28 +5549,19 @@ typed-ast = [
     {file = "typed_ast-1.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75"},
     {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652"},
     {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:fcf135e17cc74dbfbc05894ebca928ffeb23d9790b3167a674921db19082401f"},
     {file = "typed_ast-1.4.1-cp36-cp36m-win32.whl", hash = "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1"},
     {file = "typed_ast-1.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa"},
     {file = "typed_ast-1.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614"},
     {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41"},
     {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:f208eb7aff048f6bea9586e61af041ddf7f9ade7caed625742af423f6bae3298"},
     {file = "typed_ast-1.4.1-cp37-cp37m-win32.whl", hash = "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe"},
     {file = "typed_ast-1.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355"},
     {file = "typed_ast-1.4.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6"},
     {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907"},
     {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d"},
-    {file = "typed_ast-1.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:7e4c9d7658aaa1fc80018593abdf8598bf91325af6af5cce4ce7c73bc45ea53d"},
     {file = "typed_ast-1.4.1-cp38-cp38-win32.whl", hash = "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c"},
     {file = "typed_ast-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4"},
     {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34"},
-    {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:92c325624e304ebf0e025d1224b77dd4e6393f18aab8d829b5b7e04afe9b7a2c"},
-    {file = "typed_ast-1.4.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:d648b8e3bf2fe648745c8ffcee3db3ff903d0817a01a12dd6a6ea7a8f4889072"},
-    {file = "typed_ast-1.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:fac11badff8313e23717f3dada86a15389d0708275bddf766cca67a84ead3e91"},
-    {file = "typed_ast-1.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:0d8110d78a5736e16e26213114a38ca35cb15b6515d535413b090bd50951556d"},
-    {file = "typed_ast-1.4.1-cp39-cp39-win32.whl", hash = "sha256:b52ccf7cfe4ce2a1064b18594381bccf4179c2ecf7f513134ec2f993dd4ab395"},
-    {file = "typed_ast-1.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:3742b32cf1c6ef124d57f95be609c473d7ec4c14d0090e5a5e05a15269fb4d0c"},
     {file = "typed_ast-1.4.1.tar.gz", hash = "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b"},
 ]
 ua-parser = [

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -92,6 +92,7 @@ refextract = "^1.0.3"
 fs = "0.5.4"
 invenio-oaiserver = {git = "https://github.com/inspirehep/invenio-oaiserver.git", rev = "5d796cf354467773a7e00b75bc382ba2bf2efef7"}
 invenio-records-rest = {git = "https://github.com/inspirehep/invenio-records-rest.git", rev = "f398bab4f4f96607045e753d25aa09bb404e9e42"}
+orjson = "^3.4.6"
 
 
 [tool.poetry.dev-dependencies]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -213,7 +213,7 @@ atomic = true
 skip = "ui"
 
 [tool.coverage.run]
-omit = "inspirehep/accounts/handlers.py"
+omit = ["inspirehep/accounts/handlers.py",]
 
 [build-system]
 requires = ["poetry_core>=1.0.0"]

--- a/backend/tests/helpers/compare.py
+++ b/backend/tests/helpers/compare.py
@@ -5,18 +5,18 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
+import orjson
 
 
 def compare_data_with_ui_display_field(expected, result):
     """Comparing results with ``ui_display``.
 
     Note:
-        `_ui_display` is being stringify (`json.dumps`), hence the order is
+        `_ui_display` is being stringify (`orjson.dumps`), hence the order is
         never the same.
     """
     expected_ui_display = expected.pop("_ui_display")
-    result_ui_display = json.loads(result.pop("_ui_display"))
+    result_ui_display = orjson.loads(result.pop("_ui_display"))
 
     assert expected_ui_display == result_ui_display
     assert expected == result

--- a/backend/tests/helpers/factories/db/invenio_records.py
+++ b/backend/tests/helpers/factories/db/invenio_records.py
@@ -7,11 +7,11 @@
 
 
 import copy
-import json
 import os
 import random
 import uuid
 
+import orjson
 import pkg_resources
 from invenio_records.models import RecordMetadata
 from invenio_search import current_search_client as es
@@ -134,6 +134,6 @@ class TestRecordMetadata(TestBaseModel):
         path = pkg_resources.resource_filename(
             module_name, os.path.join("fixtures", filename)
         )
-
-        data = json.load(open(path))
+        with open(path) as fp:
+            data = orjson.loads(fp.read())
         return cls.create_from_kwargs(json=data, **kwargs)

--- a/backend/tests/helpers/providers/record_provider.py
+++ b/backend/tests/helpers/providers/record_provider.py
@@ -58,7 +58,12 @@ class RecordProvider(BaseProvider):
 
     @staticmethod
     def bai():
-        return f"{re.sub('[ .]+', '.', fake.name())}.{fake.random_number(digits=1)}"
+        bai_value = re.sub(
+            "\.+",
+            ".",
+            f"{re.sub(' +', '.', fake.name())}.{fake.random_number(digits=1)}",
+        )
+        return bai_value
 
     @staticmethod
     def hep_record():

--- a/backend/tests/integration-async/editor/test_editor_api.py
+++ b/backend/tests/integration-async/editor/test_editor_api.py
@@ -6,8 +6,7 @@
 # the terms of the MIT License; see LICENSE file for more details.
 
 
-import json
-
+import orjson
 import pytest
 from helpers.utils import create_record_async, create_user
 from invenio_accounts.testutils import login_user_via_session
@@ -81,7 +80,7 @@ def test_get_revisions(
 
     assert response.status_code == 200
 
-    result = json.loads(response.data)
+    result = orjson.loads(response.data)
 
     assert result[0]["revision_id"] == 4
     assert result[1]["revision_id"] == 2
@@ -100,7 +99,7 @@ def test_revert_to_revision_requires_authentication(
         response = client.put(
             "/api/editor/literature/111/revisions/revert",
             content_type="application/json",
-            data=json.dumps({"revision_id": 2}),
+            data=orjson.dumps({"revision_id": 2}),
         )
 
     assert response.status_code == 401
@@ -115,7 +114,7 @@ def test_revert_to_revision_with_error(
         response = client.put(
             "/api/editor/literature/555/revisions/revert",
             content_type="application/json",
-            data=json.dumps({"revision_id": 0}),
+            data=orjson.dumps({"revision_id": 0}),
         )
 
     assert response.status_code == 400
@@ -136,7 +135,7 @@ def test_revert_to_revision(
         response = client.put(
             "/api/editor/literature/111/revisions/revert",
             content_type="application/json",
-            data=json.dumps({"revision_id": 2}),
+            data=orjson.dumps({"revision_id": 2}),
         )
 
     assert response.status_code == 200
@@ -212,6 +211,6 @@ def test_get_revision(
 
     assert response.status_code == 200
 
-    result = json.loads(response.data)
+    result = orjson.loads(response.data)
 
     assert result["titles"][0]["title"] == "record rev0"

--- a/backend/tests/integration-async/records/indexer/test_conferences.py
+++ b/backend/tests/integration-async/records/indexer/test_conferences.py
@@ -5,9 +5,9 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
 import time
 
+import orjson
 from helpers.providers.faker import faker
 from helpers.utils import es_search, retry_until_matched, retry_until_pass
 from inspire_utils.record import get_value
@@ -130,7 +130,7 @@ def test_indexer_updates_conference_papers_when_name_changes(
         assert total == 1
 
         literature = get_value(result, "hits.hits[0]._source")
-        ui_display = json.loads(literature["_ui_display"])
+        ui_display = orjson.loads(literature["_ui_display"])
         assert conference["titles"] == get_value(
             ui_display, "conference_info[0].titles"
         )

--- a/backend/tests/integration/accounts/test_views.py
+++ b/backend/tests/integration/accounts/test_views.py
@@ -5,9 +5,8 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
-
 import mock
+import orjson
 from flask import session
 from helpers.utils import create_user
 from invenio_accounts.testutils import login_user_via_session
@@ -102,7 +101,7 @@ def test_sign_up_user_success(mock_current_user, inspire_app):
     with inspire_app.test_client() as client:
         response = client.post(
             "/accounts/signup",
-            data=json.dumps({"email": user.email}),
+            data=orjson.dumps({"email": user.email}),
             content_type="application/json",
         )
     current_oauthclient.signup_handlers = previous_current_oauthclient_signup_handlers
@@ -131,7 +130,7 @@ def test_sign_up_user_error_on_duplicate_user(inspire_app):
     with inspire_app.test_client() as client:
         response = client.post(
             "/accounts/signup",
-            data=json.dumps({"email": user.email}),
+            data=orjson.dumps({"email": user.email}),
             content_type="application/json",
         )
 
@@ -155,7 +154,7 @@ def test_sign_up_user_error_on_unexpected_error(inspire_app):
     with inspire_app.test_client() as client:
         response = client.post(
             "/accounts/signup",
-            data=json.dumps({"email": user.email}),
+            data=orjson.dumps({"email": user.email}),
             content_type="application/json",
         )
 
@@ -175,7 +174,7 @@ def test_disable_orcid_push(mock_push_account_literature, inspire_app):
         login_user_via_session(client, email=user.email)
         response = client.put(
             "/accounts/settings/orcid-push",
-            data=json.dumps({"value": False}),
+            data=orjson.dumps({"value": False}),
             content_type="application/json",
         )
 
@@ -198,7 +197,7 @@ def test_enable_orcid_push(mock_push_account_literature, inspire_app):
         login_user_via_session(client, email=user.email)
         response = client.put(
             "/accounts/settings/orcid-push",
-            data=json.dumps({"value": True}),
+            data=orjson.dumps({"value": True}),
             content_type="application/json",
         )
 
@@ -218,7 +217,7 @@ def test_orcid_push_setting_without_user(inspire_app):
     with inspire_app.test_client() as client:
         response = client.put(
             "/accounts/settings/orcid-push",
-            data=json.dumps({"value": True}),
+            data=orjson.dumps({"value": True}),
             content_type="application/json",
         )
 

--- a/backend/tests/integration/assign/test_views.py
+++ b/backend/tests/integration/assign/test_views.py
@@ -5,8 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
-
+import orjson
 from helpers.utils import create_record, create_user
 from inspire_dojson.utils import get_recid_from_ref
 from invenio_accounts.testutils import login_user_via_session
@@ -35,7 +34,7 @@ def test_assign_without_login(inspire_app):
     with inspire_app.test_client() as client:
         response = client.post(
             "/assign",
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "literature_recids": [literature["control_number"]],
                     "from_author_recid": from_author["control_number"],
@@ -85,7 +84,7 @@ def test_assign_requires_cataloger_login(inspire_app):
         login_user_via_session(client, email=user.email)
         response = client.post(
             "/assign",
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "literature_recids": [literature["control_number"]],
                     "from_author_recid": from_author["control_number"],
@@ -153,7 +152,7 @@ def test_assign_from_an_author_to_another(inspire_app):
         login_user_via_session(client, email=cataloger.email)
         response = client.post(
             "/assign",
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "literature_recids": [
                         literature_1["control_number"],
@@ -209,7 +208,7 @@ def test_assign_from_an_author_to_another_that_is_not_stub(inspire_app):
         login_user_via_session(client, email=cataloger.email)
         response = client.post(
             "/assign",
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "literature_recids": [literature["control_number"]],
                     "from_author_recid": from_author["control_number"],
@@ -272,7 +271,7 @@ def test_assign_without_to_author(inspire_app):
         login_user_via_session(client, email=cataloger.email)
         response = client.post(
             "/assign",
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "literature_recids": [
                         literature1["control_number"],

--- a/backend/tests/integration/disambiguation/test_tasks.py
+++ b/backend/tests/integration/disambiguation/test_tasks.py
@@ -5,9 +5,9 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
 import re
 
+import orjson
 import pytest
 from freezegun import freeze_time
 from helpers.utils import create_record
@@ -114,7 +114,7 @@ def test_disambiguate_signatures_cluster_creates_author_with_facet_author_name(
     headers = {"Accept": "application/vnd+inspire.record.ui+json"}
     with inspire_app.test_client() as client:
         response = client.get(f"/authors/{author_control_number}", headers=headers)
-    author_details_json = json.loads(response.data)
+    author_details_json = orjson.loads(response.data)
     assert (
         expected_facet_author_name
         == author_details_json["metadata"]["facet_author_name"]

--- a/backend/tests/integration/disambiguation/test_views.py
+++ b/backend/tests/integration/disambiguation/test_views.py
@@ -1,5 +1,4 @@
-import json
-
+import orjson
 from flask import current_app
 from helpers.utils import create_user_and_token
 from mock import patch
@@ -25,7 +24,7 @@ def test_view_disambiguate(disambiguate_signatures_mock, inspire_app, override_c
         response = client.post(
             "/disambiguation",
             content_type="application/json",
-            data=json.dumps({"clusters": clusters}),
+            data=orjson.dumps({"clusters": clusters}),
             headers=headers,
         )
     expected_message = "Disambiguation started."
@@ -62,7 +61,7 @@ def test_view_disambiguate_with_disambiguation_disabled(
         response = client.post(
             "/disambiguation",
             content_type="application/json",
-            data=json.dumps({"clusters": clusters}),
+            data=orjson.dumps({"clusters": clusters}),
             headers=headers,
         )
     expected_message = "Disambiguation feature is disabled."
@@ -95,7 +94,7 @@ def test_view_disambiguate_requires_authentication(
         response = client.post(
             "/disambiguation",
             content_type="application/json",
-            data=json.dumps({"wrong key": clusters}),
+            data=orjson.dumps({"wrong key": clusters}),
         )
     expected_status_code = 401
     result_status_code = response.status_code
@@ -111,7 +110,7 @@ def test_view_disambiguate_with_missing_data(inspire_app):
         response = client.post(
             "/disambiguation",
             content_type="application/json",
-            data=json.dumps({"clusters": clusters}),
+            data=orjson.dumps({"clusters": clusters}),
             headers=headers,
         )
     expected_message = "Validation Error."

--- a/backend/tests/integration/indexer/test_indexer_authors.py
+++ b/backend/tests/integration/indexer/test_indexer_authors.py
@@ -4,8 +4,7 @@
 #
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
-import json
-
+import orjson
 from freezegun import freeze_time
 from helpers.utils import create_record, es_search
 from invenio_search import current_search
@@ -17,11 +16,11 @@ from inspirehep.search.api import AuthorsSearch
 
 @freeze_time("2010-12-19")
 def test_index_author_record(inspire_app, datadir):
-    data = json.loads((datadir / "999108.json").read_text())
+    data = orjson.loads((datadir / "999108.json").read_text())
     record = create_record("aut", data=data)
 
     expected_count = 1
-    expected_metadata = data = json.loads(
+    expected_metadata = data = orjson.loads(
         (datadir / "999108_expected.json").read_text()
     )
     expected_metadata["_created"] = utils.isoformat(record.created)
@@ -34,7 +33,7 @@ def test_index_author_record(inspire_app, datadir):
 
 
 def test_indexer_deletes_record_from_es(inspire_app, datadir):
-    data = json.loads((datadir / "999108.json").read_text())
+    data = orjson.loads((datadir / "999108.json").read_text())
     record = create_record("aut", data=data)
 
     record["deleted"] = True

--- a/backend/tests/integration/indexer/test_indexer_conferences.py
+++ b/backend/tests/integration/indexer/test_indexer_conferences.py
@@ -4,8 +4,7 @@
 #
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
-import json
-
+import orjson
 from helpers.utils import create_record, es_search
 from invenio_search import current_search
 from marshmallow import utils
@@ -15,7 +14,7 @@ from inspirehep.search.api import ConferencesSearch
 
 
 def test_index_conference_record(inspire_app, datadir):
-    data = json.loads((datadir / "1203206.json").read_text())
+    data = orjson.loads((datadir / "1203206.json").read_text())
     record = create_record("con", data=data)
 
     expected_count = 1
@@ -31,7 +30,7 @@ def test_index_conference_record(inspire_app, datadir):
 
 
 def test_indexer_deletes_record_from_es(inspire_app, datadir):
-    data = json.loads((datadir / "1203206.json").read_text())
+    data = orjson.loads((datadir / "1203206.json").read_text())
     record = create_record("con", data=data)
 
     record["deleted"] = True

--- a/backend/tests/integration/indexer/test_indexer_experiments.py
+++ b/backend/tests/integration/indexer/test_indexer_experiments.py
@@ -5,9 +5,9 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
 from copy import deepcopy
 
+import orjson
 from helpers.utils import create_record, es_search
 from invenio_search import current_search
 from marshmallow import utils
@@ -16,7 +16,7 @@ from inspirehep.search.api import ExperimentsSearch
 
 
 def test_index_experiment_record(inspire_app, datadir):
-    data = json.loads((datadir / "1108541.json").read_text())
+    data = orjson.loads((datadir / "1108541.json").read_text())
     record = create_record("exp", data=data)
 
     expected_count = 1
@@ -41,7 +41,7 @@ def test_index_experiment_record(inspire_app, datadir):
 
 
 def test_indexer_deletes_record_from_es(inspire_app, datadir):
-    data = json.loads((datadir / "1108541.json").read_text())
+    data = orjson.loads((datadir / "1108541.json").read_text())
     record = create_record("exp", data=data)
 
     record["deleted"] = True

--- a/backend/tests/integration/indexer/test_indexer_institutions.py
+++ b/backend/tests/integration/indexer/test_indexer_institutions.py
@@ -5,9 +5,9 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
 from copy import deepcopy
 
+import orjson
 from helpers.utils import create_record, es_search
 from invenio_search import current_search
 from invenio_search import current_search_client as es
@@ -18,7 +18,7 @@ from inspirehep.search.api import InstitutionsSearch
 
 
 def test_index_institutions_record(inspire_app, datadir):
-    data = json.loads((datadir / "902725.json").read_text())
+    data = orjson.loads((datadir / "902725.json").read_text())
     record = create_record("ins", data=data)
 
     expected_count = 1
@@ -45,7 +45,7 @@ def test_index_institutions_record(inspire_app, datadir):
 
 
 def test_indexer_deletes_record_from_es(inspire_app, datadir):
-    data = json.loads((datadir / "902725.json").read_text())
+    data = orjson.loads((datadir / "902725.json").read_text())
     record = create_record("ins", data=data)
 
     record["deleted"] = True

--- a/backend/tests/integration/indexer/test_indexer_journals.py
+++ b/backend/tests/integration/indexer/test_indexer_journals.py
@@ -5,9 +5,9 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
 from copy import deepcopy
 
+import orjson
 from helpers.utils import create_record, es_search
 from invenio_search import current_search
 from invenio_search import current_search_client as es
@@ -17,7 +17,7 @@ from inspirehep.search.api import JournalsSearch
 
 
 def test_index_journal_record(inspire_app, datadir):
-    data = json.loads((datadir / "1213103.json").read_text())
+    data = orjson.loads((datadir / "1213103.json").read_text())
     record = create_record("jou", data=data)
 
     expected_count = 1
@@ -60,7 +60,7 @@ def test_index_journal_record(inspire_app, datadir):
 
 
 def test_indexer_deletes_record_from_es(inspire_app, datadir):
-    data = json.loads((datadir / "1213103.json").read_text())
+    data = orjson.loads((datadir / "1213103.json").read_text())
     record = create_record("jou", data=data)
 
     record["deleted"] = True

--- a/backend/tests/integration/indexer/test_indexer_literature.py
+++ b/backend/tests/integration/indexer/test_indexer_literature.py
@@ -5,8 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
-
+import orjson
 import pytest
 from deepdiff import DeepDiff
 from freezegun import freeze_time
@@ -20,15 +19,15 @@ from inspirehep.search.api import LiteratureSearch
 
 @freeze_time("1994-12-19")
 def test_index_literature_record(inspire_app, datadir):
-    author_data = json.loads((datadir / "1032336.json").read_text())
+    author_data = orjson.loads((datadir / "1032336.json").read_text())
     author = create_record("aut", data=author_data)
 
-    data = json.loads((datadir / "1630825.json").read_text())
+    data = orjson.loads((datadir / "1630825.json").read_text())
     record = create_record("lit", data=data)
 
     expected_count = 1
-    expected_metadata = json.loads((datadir / "es_1630825.json").read_text())
-    expected_metadata_ui_display = json.loads(expected_metadata.pop("_ui_display"))
+    expected_metadata = orjson.loads((datadir / "es_1630825.json").read_text())
+    expected_metadata_ui_display = orjson.loads(expected_metadata.pop("_ui_display"))
     expected_metadata_latex_us_display = expected_metadata.pop("_latex_us_display")
     expected_metadata_latex_eu_display = expected_metadata.pop("_latex_eu_display")
     expected_metadata_bibtex_display = expected_metadata.pop("_bibtex_display")
@@ -38,7 +37,7 @@ def test_index_literature_record(inspire_app, datadir):
     response = es_search("records-hep")
 
     result = response["hits"]["hits"][0]["_source"]
-    result_ui_display = json.loads(result.pop("_ui_display"))
+    result_ui_display = orjson.loads(result.pop("_ui_display"))
     result_latex_us_display = result.pop("_latex_us_display")
     result_latex_eu_display = result.pop("_latex_eu_display")
     result_bibtex_display = result.pop("_bibtex_display")
@@ -57,7 +56,7 @@ def test_index_literature_record(inspire_app, datadir):
 
 
 def test_regression_index_literature_record_with_related_records(inspire_app, datadir):
-    data = json.loads((datadir / "1503270.json").read_text())
+    data = orjson.loads((datadir / "1503270.json").read_text())
     record = create_record("lit", data=data)
 
     response = es_search("records-hep")
@@ -68,7 +67,7 @@ def test_regression_index_literature_record_with_related_records(inspire_app, da
 
 
 def test_indexer_deletes_record_from_es(inspire_app, datadir):
-    data = json.loads((datadir / "1630825.json").read_text())
+    data = orjson.loads((datadir / "1630825.json").read_text())
     record = create_record("lit", data=data)
     record.delete()
     record.index(delay=False)
@@ -104,14 +103,14 @@ def test_indexer_creates_proper_fulltext_links_for_hidden_documents_in_ui_displa
                 "hidden": True,
                 "key": "arXiv:nucl-th_9310030.pdf",
                 "url": "https://arxiv.org/pdf/1910.11662.pdf",
-            },
+            }
         ],
     }
     record = create_record("lit", data=data)
     response = es_search("records-hep")
 
     result = response["hits"]["hits"][0]["_source"]
-    result_ui_display = json.loads(result.pop("_ui_display"))
+    result_ui_display = orjson.loads(result.pop("_ui_display"))
     for link in result_ui_display["fulltext_links"]:
         assert link["value"]
         assert link["description"] in expected_fulltext_links
@@ -138,14 +137,14 @@ def test_indexer_creates_proper_fulltext_links_in_ui_display_files_enabled(
                 "fulltext": True,
                 "key": "arXiv:nucl-th_9310030.pdf",
                 "url": "https://arxiv.org/pdf/1906.00123.pdf",
-            },
+            }
         ],
     }
     record = create_record("lit", data=data)
     response = es_search("records-hep")
 
     result = response["hits"]["hits"][0]["_source"]
-    result_ui_display = json.loads(result.pop("_ui_display"))
+    result_ui_display = orjson.loads(result.pop("_ui_display"))
     for link in result_ui_display["fulltext_links"]:
         assert link["value"]
         assert link["description"] in expected_fulltext_links
@@ -188,7 +187,7 @@ def test_indexer_creates_proper_fulltext_links_in_ui_display_files_disabled(
     response = es_search("records-hep")
 
     result = response["hits"]["hits"][0]["_source"]
-    result_ui_display = json.loads(result.pop("_ui_display"))
+    result_ui_display = orjson.loads(result.pop("_ui_display"))
 
     assert result_ui_display["fulltext_links"] == expected_fulltext_links
 
@@ -213,7 +212,7 @@ def test_indexer_not_fulltext_links_in_ui_display_when_no_fulltext_links(inspire
     response = es_search("records-hep")
 
     result = response["hits"]["hits"][0]["_source"]
-    result_ui_display = json.loads(result.pop("_ui_display"))
+    result_ui_display = orjson.loads(result.pop("_ui_display"))
 
     assert "fulltext_links" not in result_ui_display
 
@@ -229,7 +228,7 @@ def test_indexer_removes_supervisors_from_authors_for_ui_display_field(inspire_a
 
     expected_author_full_name = "Frank Castle"
     result = response["hits"]["hits"][0]["_source"]
-    result_ui_display = json.loads(result.pop("_ui_display"))
+    result_ui_display = orjson.loads(result.pop("_ui_display"))
     result_authors = result["authors"]
     assert len(result_ui_display["authors"]) == 1
     assert result_ui_display["authors"][0]["full_name"] == expected_author_full_name

--- a/backend/tests/integration/indexer/test_indexer_seminars.py
+++ b/backend/tests/integration/indexer/test_indexer_seminars.py
@@ -4,8 +4,7 @@
 #
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
-import json
-
+import orjson
 from helpers.utils import create_record, es_search
 from invenio_search import current_search
 from marshmallow import utils
@@ -15,7 +14,7 @@ from inspirehep.search.api import SeminarsSearch
 
 
 def test_index_seminars_record(inspire_app, datadir):
-    seminar_data = json.loads((datadir / "1.json").read_text())
+    seminar_data = orjson.loads((datadir / "1.json").read_text())
     record = create_record("sem", data=seminar_data)
 
     expected_count = 1

--- a/backend/tests/integration/mailing/conftest.py
+++ b/backend/tests/integration/mailing/conftest.py
@@ -6,9 +6,9 @@
 # the terms of the MIT License; see LICENSE file for more details.
 
 import datetime
-import json
 
 import mock
+import orjson
 import pytest
 from helpers.providers.faker import faker
 from helpers.utils import create_record
@@ -41,40 +41,40 @@ def mock_job_create_and_update_time(date, data=None):
 def create_jobs(inspire_app, shared_datadir):
     now_utc = datetime.datetime.utcnow()
 
-    data = json.loads((shared_datadir / "1444586.json").read_text())
+    data = orjson.loads((shared_datadir / "1444586.json").read_text())
     job_5_days_old = mock_job_create_and_update_time(
         now_utc - datetime.timedelta(days=5), data=data
     )
 
-    data = json.loads((shared_datadir / "1234567.json").read_text())
+    data = orjson.loads((shared_datadir / "1234567.json").read_text())
     job_5_days_old_pending = mock_job_create_and_update_time(
         now_utc - datetime.timedelta(days=5), data=data
     )
 
-    data = json.loads((shared_datadir / "1234568.json").read_text())
+    data = orjson.loads((shared_datadir / "1234568.json").read_text())
     job_5_days_old_closed = mock_job_create_and_update_time(
         now_utc - datetime.timedelta(days=5), data=data
     )
 
-    data = json.loads((shared_datadir / "1468124.json").read_text())
+    data = orjson.loads((shared_datadir / "1468124.json").read_text())
     job_6_days_old = mock_job_create_and_update_time(
         now_utc - datetime.timedelta(days=6), data=data
     )
 
-    data = json.loads((shared_datadir / "1616162.json").read_text())
+    data = orjson.loads((shared_datadir / "1616162.json").read_text())
     job_7_days_old = mock_job_create_and_update_time(
         now_utc - datetime.timedelta(days=7), data=data
     )
 
-    data = json.loads((shared_datadir / "1600035.json").read_text())
+    data = orjson.loads((shared_datadir / "1600035.json").read_text())
     job_8_days_old = mock_job_create_and_update_time(
         now_utc - datetime.timedelta(days=8), data=data
     )
 
-    job_30_days_old = json.loads((shared_datadir / "1735925.json").read_text())
+    job_30_days_old = orjson.loads((shared_datadir / "1735925.json").read_text())
     create_record("job", data=job_30_days_old)
 
-    job_60_days_old = json.loads((shared_datadir / "1745106.json").read_text())
+    job_60_days_old = orjson.loads((shared_datadir / "1745106.json").read_text())
     create_record("job", data=job_60_days_old)
 
     current_search.flush_and_refresh("records-jobs")

--- a/backend/tests/integration/mailing/test_views.py
+++ b/backend/tests/integration/mailing/test_views.py
@@ -5,8 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
-
+import orjson
 import pytest
 
 
@@ -16,7 +15,7 @@ def test_view_subscribe_to_list(inspire_app):
         response = client.post(
             "/mailing/subscribe/jobs/weekly",
             content_type="application/json",
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "email": "frank@castle.com",
                     "first_name": "Frank",
@@ -33,7 +32,7 @@ def test_view_subscribe_to_list_with_invalid_email(inspire_app):
         response = client.post(
             "/mailing/subscribe/jobs/weekly",
             content_type="application/json",
-            data=json.dumps(
+            data=orjson.dumps(
                 {"email": "frank", "first_name": "Frank", "last_name": "Castle"}
             ),
         )
@@ -55,7 +54,7 @@ def test_view_subscribe_to_list_with_missing_data(inspire_app):
         response = client.post(
             "/mailing/subscribe/jobs/weekly",
             content_type="application/json",
-            data=json.dumps({"email": "frank@castle.com"}),
+            data=orjson.dumps({"email": "frank@castle.com"}),
         )
     expected_message = "Validation Error."
     expected_status_code = 400

--- a/backend/tests/integration/matcher/test_views.py
+++ b/backend/tests/integration/matcher/test_views.py
@@ -1,5 +1,4 @@
-import json
-
+import orjson
 from helpers.factories.db.invenio_records import TestRecordMetadata
 from helpers.utils import create_record, create_user
 from invenio_accounts.testutils import login_user_via_session
@@ -47,11 +46,11 @@ def test_get_linked_refs(inspire_app):
         response = client.post(
             "api/matcher/linked_references/",
             content_type="application/json",
-            data=json.dumps(references),
+            data=orjson.dumps(references),
         )
     assert response.status_code == 200
 
-    linked_refs = json.loads(response.data)
+    linked_refs = orjson.loads(response.data)
     assert (
         linked_refs["references"][0]["record"]["$ref"]
         == "http://localhost:5000/api/literature/1"
@@ -66,11 +65,11 @@ def test_get_linked_refs_empty_list(inspire_app):
         response = client.post(
             "api/matcher/linked_references/",
             content_type="application/json",
-            data=json.dumps({"references": []}),
+            data=orjson.dumps({"references": []}),
         )
     assert response.status_code == 200
 
-    linked_refs = json.loads(response.data)
+    linked_refs = orjson.loads(response.data)
     assert linked_refs["references"] == []
 
 
@@ -90,7 +89,5 @@ def test_get_linked_refs_bad_request(inspire_app):
 
     with inspire_app.test_client() as client:
         login_user_via_session(client, email=user.email)
-        response = client.get(
-            "api/matcher/linked_references/",
-        )
+        response = client.get("api/matcher/linked_references/")
     assert response.status_code == 405

--- a/backend/tests/integration/migrator/test_migrator_cli.py
+++ b/backend/tests/integration/migrator/test_migrator_cli.py
@@ -5,9 +5,9 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
 import os
 
+import orjson
 import pkg_resources
 import pytest
 from helpers.utils import create_record
@@ -61,7 +61,7 @@ def test_migrate_file(inspire_app, cli):
 
     assert result.exit_code == 0
     assert response.status_code == 200
-    assert json.loads(response.data)["metadata"]["control_number"] == 1663923
+    assert orjson.loads(response.data)["metadata"]["control_number"] == 1663923
 
 
 def test_migrate_file_mirror_only(inspire_app, cli):
@@ -111,7 +111,7 @@ def test_migrate_mirror_migrates_pending(inspire_app, cli):
 
     assert result.exit_code == 0
     assert response.status_code == 200
-    assert json.loads(response.data)["metadata"]["control_number"] == 1663924
+    assert orjson.loads(response.data)["metadata"]["control_number"] == 1663924
 
 
 def test_migrate_mirror_broken_migrates_invalid(inspire_app, cli):
@@ -141,7 +141,7 @@ def test_migrate_mirror_broken_migrates_invalid(inspire_app, cli):
 
     assert result.exit_code == 0
     assert response.status_code == 200
-    assert json.loads(response.data)["metadata"]["control_number"] == 1663927
+    assert orjson.loads(response.data)["metadata"]["control_number"] == 1663927
 
 
 @pytest.mark.xfail(
@@ -179,7 +179,8 @@ def test_migrate_mirror_all_migrates_all(inspire_app, cli):
     assert result.exit_code == 0
     assert response.status_code == 200
     assert (
-        "A funny joke" in json.loads(response.data)["metadata"]["abstracts"][0]["value"]
+        "A funny joke"
+        in orjson.loads(response.data)["metadata"]["abstracts"][0]["value"]
     )
 
 

--- a/backend/tests/integration/migrator/test_migrator_tasks.py
+++ b/backend/tests/integration/migrator/test_migrator_tasks.py
@@ -4,10 +4,10 @@
 #
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
-import json
 import os
 from time import sleep
 
+import orjson
 import pkg_resources
 import pytest
 import requests_mock
@@ -337,7 +337,7 @@ def test_migrate_from_mirror_doesnt_index_deleted_records(inspire_app):
 
 
 def test_migrate_from_mirror_removes_record_from_es(inspire_app, datadir):
-    data = json.loads((datadir / "dummy_record.json").read_text())
+    data = orjson.loads((datadir / "dummy_record.json").read_text())
     create_record("lit", data=data)
 
     expected_record_lit_es_len = 1

--- a/backend/tests/integration/orcid/test_orcid_api.py
+++ b/backend/tests/integration/orcid/test_orcid_api.py
@@ -20,10 +20,10 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-import json
 import os
 
 import mock
+import orjson
 import pkg_resources
 import pytest
 from invenio_db import db
@@ -319,7 +319,8 @@ class TestPushToOrcid(object):
         record_fixture_path = pkg_resources.resource_filename(
             __name__, os.path.join("fixtures", "736770.json")
         )
-        data = json.load(open(record_fixture_path))
+        with open(record_fixture_path) as fp:
+            data = orjson.loads(fp.read())
         self.record = LiteratureRecord.create(data)
 
     def test_existing_record(self, override_config):

--- a/backend/tests/integration/orcid/test_orcid_converter.py
+++ b/backend/tests/integration/orcid/test_orcid_converter.py
@@ -20,10 +20,10 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 import io
-import json
 import os
 
 import mock
+import orjson
 import pkg_resources
 from helpers.utils import create_record, create_record_factory
 from lxml import etree
@@ -67,12 +67,12 @@ def xml_compare(expected, result):
 
 
 def test_format_article(inspire_app, datadir):
-    data = json.loads((datadir / "4328.json").read_text())
+    data = orjson.loads((datadir / "4328.json").read_text())
     create_record("lit", data=data)
     with inspire_app.test_client() as client:
         response = client.get("/literature/4328")
     assert response.status_code == 200
-    article = json.loads(response.data)
+    article = orjson.loads(response.data)
 
     expected = xml_parse(
         """
@@ -124,16 +124,16 @@ def test_format_article(inspire_app, datadir):
 
 
 def test_format_conference_paper(inspire_app, datadir):
-    data = json.loads((datadir / "524480.json").read_text())
+    data = orjson.loads((datadir / "524480.json").read_text())
     record = create_record("lit", data=data)
-    data_conference = json.loads((datadir / "972464.json").read_text())
+    data_conference = orjson.loads((datadir / "972464.json").read_text())
     record_conference = create_record_factory(
         "con", data=data_conference, with_indexing=True
     )
     with inspire_app.test_client() as client:
         response = client.get("/literature/524480")
     assert response.status_code == 200
-    inproceedings = json.loads(response.data)
+    inproceedings = orjson.loads(response.data)
 
     expected = xml_parse(
         """
@@ -181,12 +181,12 @@ def test_format_conference_paper(inspire_app, datadir):
 
 
 def test_format_proceedings(inspire_app, datadir):
-    data = json.loads((datadir / "701585.json").read_text())
+    data = orjson.loads((datadir / "701585.json").read_text())
     record = create_record("lit", data=data)
     with inspire_app.test_client() as client:
         response = client.get("/literature/701585")
     assert response.status_code == 200
-    proceedings = json.loads(response.data)
+    proceedings = orjson.loads(response.data)
 
     expected = xml_parse(
         """
@@ -244,12 +244,12 @@ def test_format_proceedings(inspire_app, datadir):
 
 
 def test_format_thesis(inspire_app, datadir):
-    data = json.loads((datadir / "1395663.json").read_text())
+    data = orjson.loads((datadir / "1395663.json").read_text())
     record = create_record("lit", data=data)
     with inspire_app.test_client() as client:
         response = client.get("/literature/1395663")
     assert response.status_code == 200
-    phdthesis = json.loads(response.data)
+    phdthesis = orjson.loads(response.data)
 
     expected = xml_parse(
         """
@@ -291,12 +291,12 @@ def test_format_thesis(inspire_app, datadir):
 
 
 def test_format_book(inspire_app, datadir):
-    data = json.loads((datadir / "736770.json").read_text())
+    data = orjson.loads((datadir / "736770.json").read_text())
     record = create_record("lit", data=data)
     with inspire_app.test_client() as client:
         response = client.get("/literature/736770")
     assert response.status_code == 200
-    book = json.loads(response.data)
+    book = orjson.loads(response.data)
 
     expected = xml_parse(
         """
@@ -355,13 +355,13 @@ def test_format_book(inspire_app, datadir):
 
 
 def test_format_book_chapter(inspire_app, datadir):
-    data = json.loads((datadir / "1375491.json").read_text())
+    data = orjson.loads((datadir / "1375491.json").read_text())
     del data["deleted_records"]
     record = create_record("lit", data=data)
     with inspire_app.test_client() as client:
         response = client.get("/literature/1375491")
     assert response.status_code == 200
-    inbook = json.loads(response.data)
+    inbook = orjson.loads(response.data)
 
     expected = xml_parse(
         """
@@ -432,12 +432,12 @@ def test_format_book_chapter(inspire_app, datadir):
 
 
 def test_format_thesis_with_author_orcid(inspire_app, datadir):
-    data = json.loads((datadir / "1395663.json").read_text())
+    data = orjson.loads((datadir / "1395663.json").read_text())
     record = create_record("lit", data=data)
     with inspire_app.test_client() as client:
         response = client.get("/literature/1395663")
     assert response.status_code == 200
-    phdthesis = json.loads(response.data)
+    phdthesis = orjson.loads(response.data)
 
     phdthesis["metadata"]["authors"][0]["ids"] = [
         {"schema": "ORCID", "value": "0000-0002-1825-0097"}
@@ -490,13 +490,13 @@ def test_format_thesis_with_author_orcid(inspire_app, datadir):
 
 
 def test_external_identifiers(inspire_app, datadir):
-    data = json.loads((datadir / "1375491.json").read_text())
+    data = orjson.loads((datadir / "1375491.json").read_text())
     del data["deleted_records"]
     record = create_record("lit", data=data)
     with inspire_app.test_client() as client:
         response = client.get("/literature/1375491")
     assert response.status_code == 200
-    inbook = json.loads(response.data)
+    inbook = orjson.loads(response.data)
 
     converter = OrcidConverter(
         inbook["metadata"], url_pattern="http://inspirehep.net/record/{recid}"
@@ -511,7 +511,7 @@ def test_external_identifiers(inspire_app, datadir):
 
 
 def test_bibtex_do_add_bibtex_citation(inspire_app, datadir):
-    data = json.loads(
+    data = orjson.loads(
         (datadir / "test_orcid_converter_TestBibtexCitation.json").read_text()
     )
     record = create_record("lit", data=data)
@@ -524,7 +524,7 @@ def test_bibtex_do_add_bibtex_citation(inspire_app, datadir):
 
 
 def test_bibtext_do_not_add_bibtex_citation(inspire_app, datadir):
-    data = json.loads(
+    data = orjson.loads(
         (datadir / "test_orcid_converter_TestBibtexCitation.json").read_text()
     )
     record = create_record("lit", data=data)

--- a/backend/tests/integration/orcid/test_orcid_utils.py
+++ b/backend/tests/integration/orcid/test_orcid_utils.py
@@ -21,9 +21,9 @@
 # or submit itself to any jurisdiction.
 
 
-import json
 import time
 
+import orjson
 import pytest
 from celery import shared_task
 from helpers.utils import create_record
@@ -148,9 +148,9 @@ def test_orcids_for_push_orcid_in_author_with_claim(author_in_isolated_app):
 
 
 def test_get_literature_recids_for_orcid(inspire_app, datadir):
-    data_author = json.loads((datadir / "1061000.json").read_text())
+    data_author = orjson.loads((datadir / "1061000.json").read_text())
     create_record("aut", data=data_author)
-    data_literature = json.loads((datadir / "1496635.json").read_text())
+    data_literature = orjson.loads((datadir / "1496635.json").read_text())
     create_record("lit", data=data_literature)
     expected = [1496635]
     result = get_literature_recids_for_orcid("0000-0003-4792-9178")
@@ -166,7 +166,7 @@ def test_get_literature_recids_for_orcid_raises_if_no_author_is_found(inspire_ap
 def test_get_literature_recids_for_orcid_raises_if_two_authors_are_found(
     inspire_app, datadir
 ):
-    data = json.loads((datadir / "1061000.json").read_text())
+    data = orjson.loads((datadir / "1061000.json").read_text())
     create_record("aut", data=data)
     record = InspireRecord.get_record_by_pid_value(1061000, pid_type="aut")
     record["control_number"] = 1061001
@@ -178,7 +178,7 @@ def test_get_literature_recids_for_orcid_raises_if_two_authors_are_found(
 def test_get_literature_recids_for_orcid_still_works_if_author_has_no_ids(
     inspire_app, datadir
 ):
-    data = json.loads((datadir / "1061000.json").read_text())
+    data = orjson.loads((datadir / "1061000.json").read_text())
     create_record("aut", data=data)
     record = InspireRecord.get_record_by_pid_value(1061000, pid_type="aut")
     del record["ids"]
@@ -191,7 +191,7 @@ def test_get_literature_recids_for_orcid_still_works_if_author_has_no_ids(
 def test_get_literature_recids_for_orcid_still_works_if_author_has_no_orcid_id(
     inspire_app, datadir
 ):
-    data = json.loads((datadir / "1061000.json").read_text())
+    data = orjson.loads((datadir / "1061000.json").read_text())
     create_record("aut", data=data)
     record = InspireRecord.get_record_by_pid_value(1061000, pid_type="aut")
     record["ids"] = [{"schema": "INSPIRE BAI", "value": "Maurizio.Martinelli.1"}]

--- a/backend/tests/integration/records/api/test_api_authors.py
+++ b/backend/tests/integration/records/api/test_api_authors.py
@@ -4,9 +4,9 @@
 #
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
-import json
 import uuid
 
+import orjson
 import pytest
 from helpers.providers.faker import faker
 from helpers.utils import create_pidstore, create_record

--- a/backend/tests/integration/records/api/test_api_base.py
+++ b/backend/tests/integration/records/api/test_api_base.py
@@ -6,9 +6,9 @@
 # the terms of the MIT License; see LICENSE file for more details.
 
 """INSPIRE module that adds more fun to the platform."""
-import json
 from copy import copy, deepcopy
 
+import orjson
 import pytest
 from helpers.providers.faker import faker
 from helpers.utils import create_pidstore, create_record, create_record_factory
@@ -275,7 +275,7 @@ def test_create_record_throws_exception_if_wrong_subclass_used(inspire_app):
 
 
 def test_earliest_date(inspire_app, datadir):
-    data = json.loads((datadir / "1366189.json").read_text())
+    data = orjson.loads((datadir / "1366189.json").read_text())
     record = LiteratureRecord.create(data=data)
 
     assert record.earliest_date == "2015-05-05"
@@ -427,7 +427,7 @@ def test_get_year_from_book_chapter_when_pubinfo_present(inspire_app):
 
 
 def test_get_enhanced_es_data_do_not_change_original_record(inspire_app, datadir):
-    data = json.loads((datadir / "788797.json").read_text())
+    data = orjson.loads((datadir / "788797.json").read_text())
 
     original_data = deepcopy(data)
 

--- a/backend/tests/integration/records/api/test_api_literature.py
+++ b/backend/tests/integration/records/api/test_api_literature.py
@@ -5,10 +5,10 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 import datetime
-import json
 from uuid import UUID, uuid4
 
 import mock
+import orjson
 import pytest
 import requests_mock
 from flask import current_app
@@ -375,7 +375,7 @@ def test_dump_for_es(inspire_app):
     assert record["control_number"] == dump["id"]
     assert expected_document_type == dump["document_type"]
 
-    ui_field = json.loads(dump["_ui_display"])
+    ui_field = orjson.loads(dump["_ui_display"])
     assert "titles" in ui_field
     assert "document_type" in ui_field
     assert record["titles"] == ui_field["titles"]

--- a/backend/tests/integration/records/serializers/json/test_authors.py
+++ b/backend/tests/integration/records/serializers/json/test_authors.py
@@ -5,8 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
-
+import orjson
 from helpers.utils import create_record, create_record_factory, create_user
 from invenio_accounts.testutils import login_user_via_session
 
@@ -16,7 +15,7 @@ from inspirehep.accounts.roles import Roles
 def test_authors_detail(inspire_app, datadir):
     headers = {"Accept": "application/vnd+inspire.record.ui+json"}
 
-    data = json.loads((datadir / "999108.json").read_text())
+    data = orjson.loads((datadir / "999108.json").read_text())
 
     record = create_record_factory("aut", data=data)
     record_control_number = record.json["control_number"]
@@ -95,7 +94,7 @@ def test_authors_detail(inspire_app, datadir):
         response = client.get(f"/authors/{record_control_number}", headers=headers)
 
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
 
     assert expected_status_code == response_status_code
     assert expected_metadata == response_data["metadata"]
@@ -118,7 +117,7 @@ def test_authors_detail_can_edit_true_if_users_own_profile(inspire_app):
         login_user_via_session(client, email=user.email)
         response = client.get(f"/authors/{record_control_number}", headers=headers)
 
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
 
     assert response_data_metadata["can_edit"]
@@ -137,7 +136,7 @@ def test_authors_detail_can_edit_false_if_not_users_own_profile(inspire_app):
         login_user_via_session(client, email=user.email)
         response = client.get(f"/authors/{record_control_number}", headers=headers)
 
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
 
     assert not response_data_metadata["can_edit"]
@@ -173,7 +172,7 @@ def test_authors_json_without_login(inspire_app):
         response = client.get(f"/authors/{record_control_number}", headers=headers)
 
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
     response_uuid = response_data["uuid"]
 
@@ -230,7 +229,7 @@ def test_authors_json_with_logged_in_cataloger(inspire_app):
         response = client.get(f"/authors/{record_control_number}", headers=headers)
 
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
 
     assert expected_status_code == response_status_code
@@ -240,7 +239,7 @@ def test_authors_json_with_logged_in_cataloger(inspire_app):
 def test_authors_only_control_number(inspire_app, datadir):
     headers = {"Accept": "application/vnd+inspire.record.control_number+json"}
 
-    data = json.loads((datadir / "999108.json").read_text())
+    data = orjson.loads((datadir / "999108.json").read_text())
 
     record = create_record_factory("aut", data=data)
     record_control_number = record.json["control_number"]
@@ -251,7 +250,7 @@ def test_authors_only_control_number(inspire_app, datadir):
         response = client.get(f"/authors/{record_control_number}", headers=headers)
 
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
 
     assert expected_status_code == response_status_code
@@ -297,7 +296,7 @@ def test_authors_search_json(inspire_app):
         response = client.get("/authors", headers=headers)
 
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_hits = response_data["hits"]["hits"]
     response_data_hits_metadata = response_data_hits[0]["metadata"]
     response_data_hits_id = response_data_hits[0]["id"]
@@ -346,7 +345,7 @@ def test_authors_search_list(inspire_app):
         response = client.get("/authors", headers=headers)
 
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_hits = response_data["hits"]["hits"]
     response_data_hits_metadata = response_data_hits[0]["metadata"]
 
@@ -425,7 +424,7 @@ def test_authors_search_json_with_logged_in_cataloger(inspire_app):
         response = client.get("/authors".format(record_control_number), headers=headers)
 
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_hits = response_data["hits"]["hits"]
     response_data_hits_metadata = response_data_hits[0]["metadata"]
 

--- a/backend/tests/integration/records/serializers/json/test_conferences.py
+++ b/backend/tests/integration/records/serializers/json/test_conferences.py
@@ -5,8 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
-
+import orjson
 from helpers.utils import create_record, create_user
 from invenio_accounts.testutils import login_user_via_session
 from marshmallow import utils
@@ -17,7 +16,7 @@ from inspirehep.accounts.roles import Roles
 def test_conferences_json_without_login(inspire_app, datadir):
     headers = {"Accept": "application/json"}
 
-    data = json.loads((datadir / "1185692.json").read_text())
+    data = orjson.loads((datadir / "1185692.json").read_text())
 
     record = create_record("con", data=data)
     record_control_number = record["control_number"]
@@ -52,7 +51,7 @@ def test_conferences_json_without_login(inspire_app, datadir):
     with inspire_app.test_client() as client:
         response = client.get(f"/conferences/{record_control_number}", headers=headers)
 
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
     response_created = response_data["created"]
     response_updated = response_data["updated"]
@@ -91,7 +90,7 @@ def test_conferences_json_with_logged_in_cataloger(inspire_app):
         login_user_via_session(client, email=user.email)
         response = client.get(f"/conferences/{record_control_number}", headers=headers)
 
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
 
     assert expected_metadata == response_data_metadata
@@ -100,7 +99,7 @@ def test_conferences_json_with_logged_in_cataloger(inspire_app):
 def test_conferences_detail(inspire_app, datadir):
     headers = {"Accept": "application/vnd+inspire.record.ui+json"}
 
-    data = json.loads((datadir / "1185692.json").read_text())
+    data = orjson.loads((datadir / "1185692.json").read_text())
 
     record = create_record("con", data=data)
     record_control_number = record["control_number"]
@@ -135,7 +134,7 @@ def test_conferences_detail(inspire_app, datadir):
     with inspire_app.test_client() as client:
         response = client.get(f"/conferences/{record_control_number}", headers=headers)
 
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
     response_created = response_data["created"]
     response_updated = response_data["updated"]
@@ -148,7 +147,7 @@ def test_conferences_detail(inspire_app, datadir):
 def test_conferences_search_json(inspire_app, datadir):
     headers = {"Accept": "application/vnd+inspire.record.ui+json"}
 
-    data = json.loads((datadir / "1185692.json").read_text())
+    data = orjson.loads((datadir / "1185692.json").read_text())
 
     record = create_record("con", data=data)
 
@@ -182,7 +181,7 @@ def test_conferences_search_json(inspire_app, datadir):
     with inspire_app.test_client() as client:
         response = client.get("/conferences", headers=headers)
 
-    response_data_hit = json.loads(response.data)["hits"]["hits"][0]
+    response_data_hit = orjson.loads(response.data)["hits"]["hits"][0]
 
     response_created = response_data_hit["created"]
     response_updated = response_data_hit["updated"]
@@ -261,7 +260,7 @@ def test_conferences_json_search_doesnt_return_emails(inspire_app, datadir):
     with inspire_app.test_client() as client:
         response = client.get("/conferences", headers=headers)
 
-    response_data_hit = json.loads(response.data)["hits"]["hits"][0]
+    response_data_hit = orjson.loads(response.data)["hits"]["hits"][0]
     response_metadata = response_data_hit["metadata"]
 
     assert "email" not in response_metadata["contact_details"][0]

--- a/backend/tests/integration/records/serializers/json/test_data.py
+++ b/backend/tests/integration/records/serializers/json/test_data.py
@@ -5,9 +5,9 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
 from copy import deepcopy
 
+import orjson
 from helpers.utils import create_record, create_record_factory
 from marshmallow import utils
 
@@ -15,7 +15,7 @@ from marshmallow import utils
 def test_data_json(inspire_app, datadir):
     headers = {"Accept": "application/json"}
 
-    data = json.loads((datadir / "1.json").read_text())
+    data = orjson.loads((datadir / "1.json").read_text())
 
     record = create_record_factory("dat", data=data)
     record_control_number = record.json["control_number"]
@@ -26,7 +26,7 @@ def test_data_json(inspire_app, datadir):
     with inspire_app.test_client() as client:
         response = client.get(f"/data/{record_control_number}", headers=headers)
 
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
     response_created = response_data["created"]
     response_updated = response_data["updated"]
@@ -39,7 +39,7 @@ def test_data_json(inspire_app, datadir):
 def test_data_search_json(inspire_app, datadir):
     headers = {"Accept": "application/json"}
 
-    data = json.loads((datadir / "1.json").read_text())
+    data = orjson.loads((datadir / "1.json").read_text())
 
     record = create_record("dat", data=data)
 

--- a/backend/tests/integration/records/serializers/json/test_experiments.py
+++ b/backend/tests/integration/records/serializers/json/test_experiments.py
@@ -5,9 +5,9 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
 from copy import deepcopy
 
+import orjson
 from helpers.utils import create_record, create_record_factory, create_user
 from invenio_accounts.testutils import login_user_via_session
 from marshmallow import utils
@@ -18,7 +18,7 @@ from inspirehep.accounts.roles import Roles
 def test_experiments_json_without_login(inspire_app, datadir):
     headers = {"Accept": "application/json"}
 
-    data = json.loads((datadir / "1108739.json").read_text())
+    data = orjson.loads((datadir / "1108739.json").read_text())
 
     record = create_record_factory("exp", data=data)
     record_control_number = record.json["control_number"]
@@ -32,7 +32,7 @@ def test_experiments_json_without_login(inspire_app, datadir):
     with inspire_app.test_client() as client:
         response = client.get(f"/experiments/{record_control_number}", headers=headers)
 
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
     response_created = response_data["created"]
     response_updated = response_data["updated"]
@@ -47,7 +47,7 @@ def test_experiments_json_with_loggedin_cataloger(inspire_app, datadir):
 
     headers = {"Accept": "application/json"}
 
-    data = json.loads((datadir / "1108739.json").read_text())
+    data = orjson.loads((datadir / "1108739.json").read_text())
 
     record = create_record_factory("exp", data=data)
     record_control_number = record.json["control_number"]
@@ -60,7 +60,7 @@ def test_experiments_json_with_loggedin_cataloger(inspire_app, datadir):
         login_user_via_session(client, email=user.email)
         response = client.get(f"/experiments/{record_control_number}", headers=headers)
 
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
     response_created = response_data["created"]
     response_updated = response_data["updated"]
@@ -73,7 +73,7 @@ def test_experiments_json_with_loggedin_cataloger(inspire_app, datadir):
 def test_experiments_json_search(inspire_app, datadir):
     headers = {"Accept": "application/json"}
 
-    data = json.loads((datadir / "1108739.json").read_text())
+    data = orjson.loads((datadir / "1108739.json").read_text())
 
     record = create_record("exp", data=data)
 
@@ -100,7 +100,7 @@ def test_experiments_json_search(inspire_app, datadir):
 def test_experiments_detail(inspire_app, datadir):
     headers = {"Accept": "application/vnd+inspire.record.ui+json"}
 
-    data = json.loads((datadir / "1108739.json").read_text())
+    data = orjson.loads((datadir / "1108739.json").read_text())
 
     record = create_record_factory("exp", data=data)
     record_control_number = record.json["control_number"]
@@ -114,7 +114,7 @@ def test_experiments_detail(inspire_app, datadir):
     with inspire_app.test_client() as client:
         response = client.get(f"/experiments/{record_control_number}", headers=headers)
 
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
     response_created = response_data["created"]
     response_updated = response_data["updated"]
@@ -154,7 +154,7 @@ def test_parent_experiments_in_detail_page(inspire_app):
     record_control_number = record.json["control_number"]
     with inspire_app.test_client() as client:
         response = client.get(f"/experiments/{record_control_number}", headers=headers)
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
     assert (
         response_data_metadata["parent_experiments"]
@@ -188,7 +188,7 @@ def test_successor_experiments_in_detail_page(inspire_app):
     record_control_number = record.json["control_number"]
     with inspire_app.test_client() as client:
         response = client.get(f"/experiments/{record_control_number}", headers=headers)
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
     assert (
         response_data_metadata["successor_experiments"]
@@ -222,7 +222,7 @@ def test_predecessor_experiments_in_detail_page(inspire_app):
     record_control_number = record.json["control_number"]
     with inspire_app.test_client() as client:
         response = client.get(f"/experiments/{record_control_number}", headers=headers)
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
     assert (
         response_data_metadata["predecessor_experiments"]
@@ -276,7 +276,7 @@ def test_subsidiary_experiments_in_detail_page(inspire_app):
     ]
     with inspire_app.test_client() as client:
         response = client.get(f"/experiments/{record_control_number}", headers=headers)
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
     assert (
         response_data_metadata["subsidiary_experiments"] == expected_subsidiary_records

--- a/backend/tests/integration/records/serializers/json/test_institutions.py
+++ b/backend/tests/integration/records/serializers/json/test_institutions.py
@@ -5,9 +5,9 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
 from copy import deepcopy
 
+import orjson
 from helpers.utils import create_record, create_record_factory, create_user
 from invenio_accounts.testutils import login_user_via_session
 from marshmallow import utils
@@ -18,7 +18,7 @@ from inspirehep.accounts.roles import Roles
 def test_institutions_json_without_login(inspire_app, datadir):
     headers = {"Accept": "application/json"}
 
-    data = json.loads((datadir / "903324.json").read_text())
+    data = orjson.loads((datadir / "903324.json").read_text())
 
     record = create_record("ins", data=data)
     record_control_number = record["control_number"]
@@ -33,7 +33,7 @@ def test_institutions_json_without_login(inspire_app, datadir):
     with inspire_app.test_client() as client:
         response = client.get(f"/institutions/{record_control_number}", headers=headers)
 
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
     response_created = response_data["created"]
     response_updated = response_data["updated"]
@@ -48,7 +48,7 @@ def test_institutions_json_with_logged_in_cataloger(inspire_app, datadir):
 
     headers = {"Accept": "application/json"}
 
-    data = json.loads((datadir / "903324.json").read_text())
+    data = orjson.loads((datadir / "903324.json").read_text())
 
     record = create_record("ins", data=data)
     record_control_number = record["control_number"]
@@ -62,7 +62,7 @@ def test_institutions_json_with_logged_in_cataloger(inspire_app, datadir):
         login_user_via_session(client, email=user.email)
         response = client.get(f"/institutions/{record_control_number}", headers=headers)
 
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
     response_created = response_data["created"]
     response_updated = response_data["updated"]
@@ -75,7 +75,7 @@ def test_institutions_json_with_logged_in_cataloger(inspire_app, datadir):
 def test_institutions_search_json(inspire_app, datadir):
     headers = {"Accept": "application/json"}
 
-    data = json.loads((datadir / "903324.json").read_text())
+    data = orjson.loads((datadir / "903324.json").read_text())
 
     record = create_record("ins", data=data)
 
@@ -104,7 +104,7 @@ def test_institutions_search_json(inspire_app, datadir):
 def test_institutions_detail(inspire_app, datadir):
     headers = {"Accept": "application/vnd+inspire.record.ui+json"}
 
-    data = json.loads((datadir / "903324.json").read_text())
+    data = orjson.loads((datadir / "903324.json").read_text())
 
     record = create_record("ins", data=data)
     record_control_number = record["control_number"]
@@ -136,7 +136,7 @@ def test_institutions_detail(inspire_app, datadir):
     with inspire_app.test_client() as client:
         response = client.get(f"/institutions/{record_control_number}", headers=headers)
 
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
     response_created = response_data["created"]
     response_updated = response_data["updated"]
@@ -177,7 +177,7 @@ def test_parent_institutions_in_detail_page(inspire_app):
     record_control_number = record.json["control_number"]
     with inspire_app.test_client() as client:
         response = client.get(f"/institutions/{record_control_number}", headers=headers)
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
     assert (
         response_data_metadata["parent_institutions"]
@@ -211,7 +211,7 @@ def test_successor_institutions_in_detail_page(inspire_app):
     record_control_number = record.json["control_number"]
     with inspire_app.test_client() as client:
         response = client.get(f"/institutions/{record_control_number}", headers=headers)
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
     assert (
         response_data_metadata["successor_institutions"]
@@ -246,7 +246,7 @@ def test_predecessor_institutions_in_detail_page(inspire_app):
     record_control_number = record.json["control_number"]
     with inspire_app.test_client() as client:
         response = client.get(f"/institutions/{record_control_number}", headers=headers)
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
     assert (
         response_data_metadata["predecessor_institutions"]
@@ -300,7 +300,7 @@ def test_subsidiary_institutions_in_detail_page(inspire_app):
     ]
     with inspire_app.test_client() as client:
         response = client.get(f"/institutions/{record_control_number}", headers=headers)
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
     assert (
         response_data_metadata["subsidiary_institutions"] == expected_subsidiary_records

--- a/backend/tests/integration/records/serializers/json/test_jobs.py
+++ b/backend/tests/integration/records/serializers/json/test_jobs.py
@@ -4,10 +4,10 @@
 #
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
-import json
 from copy import deepcopy
 
 import mock
+import orjson
 from freezegun import freeze_time
 from helpers.utils import create_record, create_user, logout
 from invenio_accounts.testutils import login_user_via_session
@@ -21,7 +21,7 @@ from inspirehep.records.marshmallow.jobs.base import JobsPublicListSchema
 def test_jobs_json(inspire_app, datadir):
     headers = {"Accept": "application/json"}
 
-    data = json.loads((datadir / "955427.json").read_text())
+    data = orjson.loads((datadir / "955427.json").read_text())
 
     record = create_record("job", data=data)
     record_control_number = record["control_number"]
@@ -35,7 +35,7 @@ def test_jobs_json(inspire_app, datadir):
     with inspire_app.test_client() as client:
         response = client.get(f"/jobs/{record_control_number}", headers=headers)
 
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
     response_data_uuid = response_data["uuid"]
     response_created = response_data["created"]
@@ -49,7 +49,7 @@ def test_jobs_json(inspire_app, datadir):
 def test_jobs_json_cataloger_can_edit(inspire_app, datadir):
     headers = {"Accept": "application/vnd+inspire.record.ui+json"}
 
-    data = json.loads((datadir / "955427.json").read_text())
+    data = orjson.loads((datadir / "955427.json").read_text())
 
     record = create_record("job", data=data)
     record_control_number = record["control_number"]
@@ -64,7 +64,7 @@ def test_jobs_json_cataloger_can_edit(inspire_app, datadir):
         response = client.get(f"/jobs/{record_control_number}", headers=headers)
 
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
 
     assert expected_status_code == response_status_code
@@ -82,7 +82,7 @@ def test_jobs_json_author_can_edit_but_random_user_cant(
     jobs_author = create_user(role="user", orcid=user_orcid, allow_push=True)
     mock_current_user.return_value = jobs_author
 
-    data = json.loads((datadir / "955427.json").read_text())
+    data = orjson.loads((datadir / "955427.json").read_text())
 
     record = create_record("job", data=data)
     record_control_number = record["control_number"]
@@ -95,7 +95,7 @@ def test_jobs_json_author_can_edit_but_random_user_cant(
         response = client.get(f"/jobs/{record_control_number}", headers=headers)
 
         response_status_code = response.status_code
-        response_data_metadata = json.loads(response.data)["metadata"]
+        response_data_metadata = orjson.loads(response.data)["metadata"]
 
         assert expected_status_code == response_status_code
         assert expected_result == response_data_metadata
@@ -104,7 +104,7 @@ def test_jobs_json_author_can_edit_but_random_user_cant(
         mock_current_user.return_value = random_user
 
         response = client.get(f"/jobs/{record_control_number}", headers=headers)
-        response_data_metadata = json.loads(response.data)["metadata"]
+        response_data_metadata = orjson.loads(response.data)["metadata"]
 
     assert not response_data_metadata["can_edit"]
 
@@ -115,7 +115,7 @@ def test_jobs_json_author_can_edit_if_closed_and_less_than_30_days_after_deadlin
 ):
     headers = {"Accept": "application/vnd+inspire.record.ui+json"}
 
-    data = json.loads((datadir / "955427.json").read_text())
+    data = orjson.loads((datadir / "955427.json").read_text())
     data["deadline_date"] = "2020-01-15"
     data["status"] = "closed"
 
@@ -132,7 +132,7 @@ def test_jobs_json_author_can_edit_if_closed_and_less_than_30_days_after_deadlin
         response = client.get(f"/jobs/{record_control_number}", headers=headers)
 
     response_status_code = response.status_code
-    response_data_metadata = json.loads(response.data)["metadata"]
+    response_data_metadata = orjson.loads(response.data)["metadata"]
 
     assert expected_status_code == response_status_code
     assert expected_result == response_data_metadata
@@ -145,7 +145,7 @@ def test_jobs_json_author_cannot_edit_if_is_closed_and_more_than_30_days_after_d
 ):
     headers = {"Accept": "application/vnd+inspire.record.ui+json"}
 
-    data = json.loads((datadir / "955427.json").read_text())
+    data = orjson.loads((datadir / "955427.json").read_text())
     data["deadline_date"] = "2019-06-01"
     data["status"] = "closed"
     record = create_record("job", data=data)
@@ -163,7 +163,7 @@ def test_jobs_json_author_cannot_edit_if_is_closed_and_more_than_30_days_after_d
         response = client.get(f"/jobs/{record_control_number}", headers=headers)
 
     response_status_code = response.status_code
-    response_data_metadata = json.loads(response.data)["metadata"]
+    response_data_metadata = orjson.loads(response.data)["metadata"]
 
     assert expected_status_code == response_status_code
     assert expected_result == response_data_metadata
@@ -172,7 +172,7 @@ def test_jobs_json_author_cannot_edit_if_is_closed_and_more_than_30_days_after_d
 def test_jobs_search_json(inspire_app, datadir):
     headers = {"Accept": "application/json"}
 
-    data = json.loads((datadir / "955427.json").read_text())
+    data = orjson.loads((datadir / "955427.json").read_text())
 
     record = create_record("job", data=data)
 

--- a/backend/tests/integration/records/serializers/json/test_journals.py
+++ b/backend/tests/integration/records/serializers/json/test_journals.py
@@ -5,9 +5,9 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
 from copy import deepcopy
 
+import orjson
 from helpers.utils import create_record, create_record_factory
 from marshmallow import utils
 
@@ -15,7 +15,7 @@ from marshmallow import utils
 def test_journals_json(inspire_app, datadir):
     headers = {"Accept": "application/json"}
 
-    data = json.loads((datadir / "1212042.json").read_text())
+    data = orjson.loads((datadir / "1212042.json").read_text())
 
     record = create_record_factory("jou", data=data)
     record_control_number = record.json["control_number"]
@@ -26,7 +26,7 @@ def test_journals_json(inspire_app, datadir):
     with inspire_app.test_client() as client:
         response = client.get(f"/journals/{record_control_number}", headers=headers)
 
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
     response_created = response_data["created"]
     response_updated = response_data["updated"]
@@ -39,7 +39,7 @@ def test_journals_json(inspire_app, datadir):
 def test_journals_search_json(inspire_app, datadir):
     headers = {"Accept": "application/json"}
 
-    data = json.loads((datadir / "1212042.json").read_text())
+    data = orjson.loads((datadir / "1212042.json").read_text())
 
     record = create_record("jou", data=data)
 

--- a/backend/tests/integration/records/serializers/json/test_literature.py
+++ b/backend/tests/integration/records/serializers/json/test_literature.py
@@ -5,10 +5,10 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
 from uuid import UUID
 
 import mock
+import orjson
 from helpers.providers.faker import faker
 from helpers.utils import create_record, create_record_factory, create_user
 from invenio_accounts.testutils import login_user_via_session
@@ -48,7 +48,7 @@ def test_literature_authors_json(mock_uuid4, inspire_app):
         )
 
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
 
     assert expected_status_code == response_status_code
@@ -105,7 +105,7 @@ def test_literature_json_without_login(inspire_app):
         response = client.get(f"/literature/{record_control_number}", headers=headers)
 
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     assert expected_status_code == response_status_code
     assert expected_metadata == response_data["metadata"]
     assert expected_uuid == response_data["uuid"]
@@ -182,7 +182,7 @@ def test_literature_json_with_logged_in_cataloger(inspire_app):
         response = client.get(f"/literature/{record_control_number}", headers=headers)
 
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
 
     assert expected_status_code == response_status_code
     assert expected_result == response_data["metadata"]
@@ -241,7 +241,7 @@ def test_literature_search_json_without_login(inspire_app):
         response = client.get("/literature", headers=headers)
 
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_hits = response_data["hits"]["hits"]
     response_data_hits_len = len(response_data_hits)
     response_data_hits_metadata = response_data_hits[0]["metadata"]
@@ -322,7 +322,7 @@ def test_literature_search_json_with_cataloger_login(inspire_app):
         response = client.get("/literature", headers=headers)
 
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_hits = response_data["hits"]["hits"]
     response_data_hits_len = len(response_data_hits)
     response_data_hits_metadata = response_data_hits[0]["metadata"]
@@ -354,7 +354,7 @@ def test_literature_detail(inspire_app):
         response = client.get(f"/literature/{record_control_number}", headers=headers)
 
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
     response_data_uuid = response_data["uuid"]
     response_data_id = response_data["id"]
@@ -386,7 +386,7 @@ def test_literature_list(inspire_app):
     with inspire_app.test_client() as client:
         response = client.get("/literature", headers=headers)
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
 
     assert response_data["hits"]["total"] == 1
 
@@ -417,7 +417,7 @@ def test_literature_list_with_cataloger_can_edit(inspire_app):
         login_user_via_session(client, email=user.email)
         response = client.get("/literature", headers=headers)
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
 
     assert response_data["hits"]["total"] == 1
 
@@ -442,7 +442,7 @@ def test_literature_list_has_sort_options(inspire_app):
         response = client.get("/literature", headers=headers)
 
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     sort_options = response_data["sort_options"]
 
     assert expected_status_code == response_status_code
@@ -510,7 +510,7 @@ def test_literature_references_json_with_empty_and_unlinked_and_duplicated_linke
             f"/literature/{record_control_number}/references", headers=headers
         )
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
 
     assert expected_status_code == response_status_code
@@ -540,7 +540,7 @@ def test_literature_references_pagination(inspire_app):
             headers=headers,
         )
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
     expected_result = {
         "references": [
@@ -577,7 +577,7 @@ def test_literature_references_pagination_with_size_more_than_results(inspire_ap
             headers=headers,
         )
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
     expected_result = {
         "references": [
@@ -616,7 +616,7 @@ def test_literature_references_pagination_with_page_with_no_results(inspire_app)
             headers=headers,
         )
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
     expected_result = {"references": [], "references_count": 4}
     expected_status_code = 200
@@ -647,7 +647,7 @@ def test_literature_references_with_size_bigger_than_maximum(
             f"/literature/{record['control_number']}/references?size=5", headers=headers
         )
     response_status_code = response.status_code
-    response_data = json.loads(response.get_data())
+    response_data = orjson.loads(response.get_data())
     expected_status_code = 400
     expected_response = MaxResultWindowRESTError().description
     assert expected_status_code == response_status_code
@@ -663,7 +663,7 @@ def test_literature_references_no_references(inspire_app):
             headers=headers,
         )
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
     expected_result = {"references": [], "references_count": 0}
     expected_status_code = 200
@@ -674,7 +674,7 @@ def test_literature_references_no_references(inspire_app):
 def test_literature_detail_serialize_experiment_with_referenced_record(
     inspire_app, datadir
 ):
-    data = json.loads((datadir / "1630825.json").read_text())
+    data = orjson.loads((datadir / "1630825.json").read_text())
     record = create_record("lit", data=data)
     experiment_data = {
         "accelerator": {"value": "Accelerator"},
@@ -714,7 +714,7 @@ def test_literature_detail_serialize_experiment_with_referenced_record(
         )
 
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_accelerator_experiments = response_data["metadata"][
         "accelerator_experiments"
     ]
@@ -782,7 +782,7 @@ def test_literature_detail_serializes_conference_info(inspire_app):
         )
 
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_conference_info = response_data["metadata"]["conference_info"]
 
     assert response_status_code == expected_status_code
@@ -868,7 +868,7 @@ def test_literature_search_lowercased_doi_in_references(inspire_app):
         )
 
     response1_status_code = response1.status_code
-    response1_data = json.loads(response1.data)
+    response1_data = orjson.loads(response1.data)
     response1_data_hits = response1_data["hits"]["hits"]
     response1_data_hits_len = len(response1_data_hits)
     response1_data_hits_metadata = response1_data_hits[0]["metadata"]
@@ -877,7 +877,7 @@ def test_literature_search_lowercased_doi_in_references(inspire_app):
     ][0]
 
     response2_status_code = response2.status_code
-    response2_data = json.loads(response1.data)
+    response2_data = orjson.loads(response1.data)
     response2_data_hits = response2_data["hits"]["hits"]
     response2_data_hits_len = len(response2_data_hits)
     response2_data_hits_metadata = response2_data_hits[0]["metadata"]
@@ -1060,7 +1060,7 @@ def test_literature_list_with_cataloger_and_author_curated_relation(inspire_app)
             headers=headers,
         )
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
 
     hits = response.json["hits"]["hits"]
     curated_hit = next(
@@ -1131,7 +1131,7 @@ def test_literature_list_with_normal_user_doesnt_have_curated_relation(inspire_a
             headers=headers,
         )
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
 
     hits = response.json["hits"]["hits"]
     curated_hit = next(
@@ -1184,7 +1184,7 @@ def test_literature_list_for_non_author_publication_search_doesnt_have_curated_r
             f"/literature?author={author['control_number']}_John%20Doe", headers=headers
         )
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
 
     hits = response.json["hits"]["hits"]
 

--- a/backend/tests/integration/records/serializers/json/test_seminars.py
+++ b/backend/tests/integration/records/serializers/json/test_seminars.py
@@ -5,8 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
-
+import orjson
 from helpers.utils import create_record, create_user
 from invenio_accounts.testutils import login_user_via_session
 from marshmallow import utils
@@ -27,7 +26,7 @@ from inspirehep.records.marshmallow.seminars.base import (
 def test_seminars_json_without_login(inspire_app, datadir):
     headers = {"Accept": "application/json"}
 
-    data = json.loads((datadir / "1.json").read_text())
+    data = orjson.loads((datadir / "1.json").read_text())
 
     record = create_record("sem", data=data)
     record_control_number = record["control_number"]
@@ -38,7 +37,7 @@ def test_seminars_json_without_login(inspire_app, datadir):
     with inspire_app.test_client() as client:
         response = client.get(f"/seminars/{record_control_number}", headers=headers)
 
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
     response_created = response_data["created"]
     response_updated = response_data["updated"]
@@ -53,7 +52,7 @@ def test_seminars_json_with_logged_in_cataloger(inspire_app, datadir):
 
     headers = {"Accept": "application/json"}
 
-    data = json.loads((datadir / "1.json").read_text())
+    data = orjson.loads((datadir / "1.json").read_text())
 
     record = create_record("sem", data=data)
     record_control_number = record["control_number"]
@@ -64,7 +63,7 @@ def test_seminars_json_with_logged_in_cataloger(inspire_app, datadir):
     with inspire_app.test_client() as client:
         login_user_via_session(client, email=user.email)
         response = client.get(f"/seminars/{record_control_number}", headers=headers)
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
     response_created = response_data["created"]
     response_updated = response_data["updated"]
@@ -77,7 +76,7 @@ def test_seminars_json_with_logged_in_cataloger(inspire_app, datadir):
 def test_seminars_search_json(inspire_app, datadir):
     headers = {"Accept": "application/json"}
 
-    data = json.loads((datadir / "1.json").read_text())
+    data = orjson.loads((datadir / "1.json").read_text())
 
     record = create_record("sem", data=data)
 
@@ -106,7 +105,7 @@ def test_seminars_logged_in_search_json(inspire_app, datadir):
 
         headers = {"Accept": "application/json"}
 
-        data = json.loads((datadir / "1.json").read_text())
+        data = orjson.loads((datadir / "1.json").read_text())
 
         record = create_record("sem", data=data)
 
@@ -131,7 +130,7 @@ def test_seminars_detail(inspire_app, datadir):
     with inspire_app.test_client() as client:
         headers = {"Accept": "application/vnd+inspire.record.ui+json"}
 
-        data = json.loads((datadir / "1.json").read_text())
+        data = orjson.loads((datadir / "1.json").read_text())
 
         record = create_record("sem", data=data)
         record_control_number = record["control_number"]
@@ -143,7 +142,7 @@ def test_seminars_detail(inspire_app, datadir):
 
         response = client.get(f"/seminars/{record_control_number}", headers=headers)
 
-        response_data = json.loads(response.data)
+        response_data = orjson.loads(response.data)
         response_data_metadata = response_data["metadata"]
         response_created = response_data["created"]
         response_updated = response_data["updated"]
@@ -157,7 +156,7 @@ def test_seminars_search(inspire_app, datadir):
     with inspire_app.test_client() as client:
         headers = {"Accept": "application/vnd+inspire.record.ui+json"}
 
-        data = json.loads((datadir / "1.json").read_text())
+        data = orjson.loads((datadir / "1.json").read_text())
 
         record = create_record("sem", data=data)
 
@@ -168,7 +167,7 @@ def test_seminars_search(inspire_app, datadir):
 
         response = client.get(f"/seminars", headers=headers)
 
-        response_data = json.loads(response.data)
+        response_data = orjson.loads(response.data)
         response_data_metadata = response_data["hits"]["hits"][0]["metadata"]
         response_created = response_data["hits"]["hits"][0]["created"]
         response_updated = response_data["hits"]["hits"][0]["updated"]
@@ -314,7 +313,7 @@ def test_seminars_list_search_doesnt_return_email_adress(inspire_app):
 
         response = client.get(f"/seminars", headers=headers)
 
-        response_data = json.loads(response.data)
+        response_data = orjson.loads(response.data)
         response_data_metadata = response_data["hits"]["hits"][0]["metadata"]
         response_created = response_data["hits"]["hits"][0]["created"]
         response_updated = response_data["hits"]["hits"][0]["updated"]
@@ -345,7 +344,7 @@ def test_seminars_search_doesnt_return_email_adress(inspire_app):
 
         response = client.get("/seminars", headers=headers)
 
-        response_data = json.loads(response.data)
+        response_data = orjson.loads(response.data)
         response_data_metadata = response_data["hits"]["hits"][0]["metadata"]
         response_created = response_data["hits"]["hits"][0]["created"]
         response_updated = response_data["hits"]["hits"][0]["updated"]

--- a/backend/tests/integration/records/test_cli.py
+++ b/backend/tests/integration/records/test_cli.py
@@ -5,10 +5,10 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
 import os
 
 import mock
+import orjson
 import pytest
 from freezegun import freeze_time
 from helpers.providers.faker import faker
@@ -94,8 +94,8 @@ def test_create_record_with_one_file(inspire_app, cli):
     control_number = data["control_number"]
 
     with cli.isolated_filesystem():
-        with open(f"{control_number}.json", "w") as f:
-            f.write(json.dumps(data))
+        with open(f"{control_number}.json", "wb") as f:
+            f.write(orjson.dumps(data))
 
         result = cli.invoke(["importer", "records", "-f", f"{control_number}.json"])
         result_record = LiteratureRecord.get_record_by_pid_value(control_number)
@@ -111,11 +111,10 @@ def test_create_record_with_multiple_files(inspire_app, cli):
     control_number_author = data_author["control_number"]
 
     with cli.isolated_filesystem():
-        with open(f"{control_number_literature}.json", "w") as f:
-            f.write(json.dumps(data_literature))
-        with open(f"{control_number_author}.json", "w") as f:
-            f.write(json.dumps(data_author))
-
+        with open(f"{control_number_literature}.json", "wb") as f:
+            f.write(orjson.dumps(data_literature))
+        with open(f"{control_number_author}.json", "wb") as f:
+            f.write(orjson.dumps(data_author))
         result = cli.invoke(
             [
                 "importer",
@@ -146,10 +145,10 @@ def test_create_record_with_directory(inspire_app, cli):
 
     with cli.isolated_filesystem():
         os.mkdir("test_directory/")
-        with open(f"test_directory/{control_number_literature}.json", "w") as f:
-            f.write(json.dumps(data_literature))
-        with open(f"test_directory/{control_number_author}.json", "w") as f:
-            f.write(json.dumps(data_author))
+        with open(f"test_directory/{control_number_literature}.json", "wb") as f:
+            f.write(orjson.dumps(data_literature))
+        with open(f"test_directory/{control_number_author}.json", "wb") as f:
+            f.write(orjson.dumps(data_author))
 
         result = cli.invoke(["importer", "records", "-d", "test_directory"])
         result_record_literature = LiteratureRecord.get_record_by_pid_value(

--- a/backend/tests/integration/records/views/test_views.py
+++ b/backend/tests/integration/records/views/test_views.py
@@ -5,8 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
-
+import orjson
 from helpers.providers.faker import faker
 from helpers.utils import (
     create_record,
@@ -27,7 +26,7 @@ def test_error_message_on_pid_already_exists(inspire_app):
             "/literature",
             headers=headers,
             content_type="application/json",
-            data=json.dumps(record),
+            data=orjson.dumps(record),
         )
 
     response_status_code = response.status_code
@@ -82,7 +81,7 @@ def test_does_not_update_stale(inspire_app):
         first_put_response = client.put(
             "/conferences/{}".format(record_control_number),
             content_type="application/json",
-            data=json.dumps(
+            data=orjson.dumps(
                 faker.record("con", data={"control_number": record_control_number})
             ),
             headers={"If-Match": etag},
@@ -93,7 +92,7 @@ def test_does_not_update_stale(inspire_app):
         stale_put_response = client.put(
             f"/conferences/{record_control_number}",
             content_type="application/json",
-            data=json.dumps(
+            data=orjson.dumps(
                 faker.record("con", data={"control_number": record_control_number})
             ),
             headers={"If-Match": etag},

--- a/backend/tests/integration/records/views/test_views_article.py
+++ b/backend/tests/integration/records/views/test_views_article.py
@@ -5,9 +5,9 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
 import os
 
+import orjson
 import pytest
 import requests_mock
 from helpers.providers.faker import faker
@@ -19,7 +19,7 @@ def test_import_article_view_400_bad_arxiv(inspire_app):
         resp = client.get("/literature/import/bad_arxiv:0000.0000")
 
     expected_msg = "bad_arxiv:0000.0000 is not a recognized identifier."
-    resp_msg = json.loads(resp.data)["message"]
+    resp_msg = orjson.loads(resp.data)["message"]
 
     assert expected_msg == resp_msg
     assert resp.status_code == 400
@@ -31,7 +31,7 @@ def test_import_article_view_404_non_existing_doi(inspire_app):
         resp = client.get("/literature/import/10.1016/j.physletb.2099.08.020")
 
     expected_msg = "No article found for 10.1016/j.physletb.2099.08.020"
-    result_msg = json.loads(resp.data)["message"]
+    result_msg = orjson.loads(resp.data)["message"]
 
     assert expected_msg == result_msg
     assert resp.status_code == 404
@@ -48,8 +48,8 @@ def test_import_article_view_409_because_article_already_exists(inspire_app):
 
     expected_msg = f"The article arXiv:{arxiv_value} already exists in Inspire"
     expected_recid = str(record["control_number"])
-    result_msg = json.loads(resp.data)["message"]
-    result_recid = json.loads(resp.data)["recid"]
+    result_msg = orjson.loads(resp.data)["message"]
+    result_recid = orjson.loads(resp.data)["recid"]
 
     assert expected_msg == result_msg
     assert expected_recid == result_recid

--- a/backend/tests/integration/records/views/test_views_authors.py
+++ b/backend/tests/integration/records/views/test_views_authors.py
@@ -5,8 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
-
+import orjson
 from helpers.providers.faker import faker
 from helpers.utils import create_record, create_user, create_user_and_token
 from invenio_accounts.testutils import login_user_via_session
@@ -21,7 +20,7 @@ def test_author_facets(inspire_app):
             f"/literature/facets?facet_name=hep-author-publication&author_recid=9999"
         )
 
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_status_code = response.status_code
     response_data_facet_keys = list(response_data.get("aggregations").keys())
 
@@ -51,7 +50,7 @@ def test_author_cataloger_facets(inspire_app):
             f"/literature/facets?facet_name=hep-author-publication&author_recid=9999"
         )
 
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_status_code = response.status_code
     response_data_facet_keys = list(response_data.get("aggregations").keys())
 

--- a/backend/tests/integration/records/views/test_views_citations.py
+++ b/backend/tests/integration/records/views/test_views_citations.py
@@ -5,8 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
-
+import orjson
 from helpers.utils import create_record_factory
 
 
@@ -106,7 +105,7 @@ def test_citation_summary_facet(inspire_app):
             }
         },
     }
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_status_code = response.status_code
     response_data_citation_summary = response_data["aggregations"]["citation_summary"]
     assert response_status_code == 200
@@ -212,7 +211,7 @@ def test_citation_summary_without_self_citations_facet(
             }
         },
     }
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_status_code = response.status_code
     response_data_citation_summary = response_data["aggregations"]["citation_summary"]
     assert response_status_code == 200
@@ -238,7 +237,7 @@ def test_h_index_with_more_papers_than_citations(inspire_app):
 
     expected_h_index = {"value": {"all": 2, "published": 2}}
 
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_status_code = response.status_code
     response_data_h_index = response_data["aggregations"]["citation_summary"]["h-index"]
     assert response_status_code == 200
@@ -263,7 +262,7 @@ def test_h_index_with_as_many_papers_as_citations(inspire_app):
 
     expected_h_index = {"value": {"all": 5, "published": 5}}
 
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_status_code = response.status_code
     response_data_h_index = response_data["aggregations"]["citation_summary"]["h-index"]
     assert response_status_code == 200
@@ -365,7 +364,7 @@ def test_citation_summary_facet_filters(inspire_app):
             }
         },
     }
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_status_code = response.status_code
     response_data_citation_summary = response_data["aggregations"]["citation_summary"]
     assert response_status_code == 200
@@ -395,7 +394,7 @@ def test_citation_summary_facet_excluded_filters(inspire_app):
         response = client.get(
             "/literature/facets?author=NOREC_N.%20Girard&facet_name=citation-summary&refereed=True&citeable=False&citation_count=500--505"
         )
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_status_code = response.status_code
     assert response_status_code == 200
     assert response_data["aggregations"]["citation_summary"]["doc_count"] == 8

--- a/backend/tests/integration/records/views/test_views_conferences.py
+++ b/backend/tests/integration/records/views/test_views_conferences.py
@@ -4,10 +4,10 @@
 #
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
-import json
 from datetime import datetime
 from operator import itemgetter
 
+import orjson
 from freezegun import freeze_time
 from helpers.utils import create_record, create_record_factory, create_user
 from invenio_accounts.testutils import login_user_via_session
@@ -154,7 +154,7 @@ def test_conferences_application_json_put_with_cataloger_logged_in(inspire_app):
         response = client.put(
             "/conferences/{}".format(record_control_number),
             content_type="application/json",
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "control_number": record_control_number,
                     "$schema": "http://localhost:5000/schemas/records/conferences.json",

--- a/backend/tests/integration/records/views/test_views_institutions.py
+++ b/backend/tests/integration/records/views/test_views_institutions.py
@@ -4,8 +4,7 @@
 #
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
-import json
-
+import orjson
 from helpers.utils import create_record, create_record_factory, create_user
 from invenio_accounts.testutils import login_user_via_session
 
@@ -120,7 +119,7 @@ def test_institutions_application_json_put_with_cataloger_logged_in(inspire_app)
         response = client.put(
             "/institutions/{}".format(record_control_number),
             content_type="application/json",
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "control_number": record_control_number,
                     "$schema": "http://localhost:5000/schemas/records/institutions.json",

--- a/backend/tests/integration/records/views/test_views_jobs.py
+++ b/backend/tests/integration/records/views/test_views_jobs.py
@@ -5,8 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
-
+import orjson
 from helpers.utils import create_record, create_user, logout
 from invenio_accounts.testutils import login_user_via_session
 
@@ -70,10 +69,10 @@ def test_jobs_search_json_get(inspire_app):
 
 
 def test_jobs_facets(inspire_app, datadir):
-    data = json.loads((datadir / "1735925.json").read_text())
+    data = orjson.loads((datadir / "1735925.json").read_text())
     create_record("job", data=data)
 
-    expected_aggregations = json.loads(
+    expected_aggregations = orjson.loads(
         (datadir / "es_aggregations_for_1735925.json").read_text()
     )
     with inspire_app.test_client() as client:
@@ -93,10 +92,10 @@ def test_jobs_facets(inspire_app, datadir):
 def test_jobs_facets_cataloger(inspire_app, datadir):
     user = create_user(role=Roles.cataloger.value)
 
-    data = json.loads((datadir / "1735925.json").read_text())
+    data = orjson.loads((datadir / "1735925.json").read_text())
     create_record("job", data=data)
 
-    expected_aggregations = json.loads(
+    expected_aggregations = orjson.loads(
         (datadir / "es_aggregations_cataloger_for_1735925.json").read_text()
     )
     with inspire_app.test_client() as client:
@@ -114,7 +113,7 @@ def test_jobs_facets_cataloger(inspire_app, datadir):
 
 
 def test_jobs_sort_options(inspire_app, datadir):
-    data = json.loads((datadir / "1735925.json").read_text())
+    data = orjson.loads((datadir / "1735925.json").read_text())
     record = create_record("job", data=data)
 
     with inspire_app.test_client() as client:
@@ -132,7 +131,7 @@ def test_jobs_sort_options(inspire_app, datadir):
 
 
 def test_jobs_accelerator_experiments(inspire_app, datadir):
-    data = json.loads((datadir / "1735925.json").read_text())
+    data = orjson.loads((datadir / "1735925.json").read_text())
     create_record("job", data=data)
     exp1 = create_record(
         "exp", data={"control_number": 1_108_209, "legacy_name": "FNAL-E-0973"}
@@ -214,7 +213,7 @@ def test_jobs_search_permissions(inspire_app):
     create_record("job", data={"status": "open"})
     with inspire_app.test_client() as client:
         response = client.get("/jobs")
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     assert response_data["hits"]["total"] == 1
 
     user = create_user(role=Roles.cataloger.value)
@@ -222,19 +221,19 @@ def test_jobs_search_permissions(inspire_app):
         login_user_via_session(client, email=user.email)
 
         response = client.get("/jobs")
-        response_data = json.loads(response.data)
+        response_data = orjson.loads(response.data)
 
         assert response_data["hits"]["total"] == 2
 
         logout(client)
 
         response = client.get("/jobs")
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     assert response_data["hits"]["total"] == 1
 
 
 def test_jobs_sort_options(inspire_app, datadir):
-    data = json.loads((datadir / "1735925.json").read_text())
+    data = orjson.loads((datadir / "1735925.json").read_text())
     record = create_record("job", data=data)
 
     with inspire_app.test_client() as client:
@@ -254,7 +253,7 @@ def test_jobs_sort_options(inspire_app, datadir):
 
 
 def test_jobs_sort_by_deadline(inspire_app, datadir):
-    data = json.loads((datadir / "1735925.json").read_text())
+    data = orjson.loads((datadir / "1735925.json").read_text())
     create_record("job", data=data)
     data["deadline_date"] = "2020-12-31"
     data["control_number"] = 1_735_926

--- a/backend/tests/integration/records/views/test_views_literature.py
+++ b/backend/tests/integration/records/views/test_views_literature.py
@@ -5,10 +5,10 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
 from urllib.parse import urlencode
 
 import mock
+import orjson
 from flask import current_app
 from helpers.providers.faker import faker
 from helpers.utils import (
@@ -50,7 +50,7 @@ def test_literature_search_application_json_get(inspire_app):
     with inspire_app.test_client() as client:
         response = client.get("/literature", headers=headers)
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["hits"]["hits"][0]["metadata"]
 
     assert expected_status_code == response_status_code
@@ -79,7 +79,7 @@ def test_literature_search_application_json_ui_get(inspire_app):
     with inspire_app.test_client() as client:
         response = client.get("/literature", headers=headers)
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["hits"]["hits"][0]["metadata"]
 
     assert expected_status_code == response_status_code
@@ -259,7 +259,7 @@ def test_literature_citations(inspire_app):
     with inspire_app.test_client() as client:
         response = client.get("/literature/{}/citations".format(record_control_number))
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
 
     assert expected_status_code == response_status_code
     assert expected_data == response_data
@@ -323,7 +323,7 @@ def test_literature_citations_with_superseded_citing_records(inspire_app):
     with inspire_app.test_client() as client:
         response = client.get(f"/literature/{record_control_number}/citations")
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_data_metadata = response_data["metadata"]
 
     assert expected_status_code == response_status_code
@@ -374,7 +374,7 @@ def test_literature_citations_with_non_citeable_collection(inspire_app):
     with inspire_app.test_client() as client:
         response = client.get(f"/literature/{record_control_number}/citations")
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
 
     assert expected_status_code == response_status_code
     assert record_with_no_citable_collection["control_number"] not in [
@@ -389,7 +389,7 @@ def test_literature_citations_empty(inspire_app):
     with inspire_app.test_client() as client:
         response = client.get("/literature/{}/citations".format(record_control_number))
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
 
     expected_status_code = 200
     expected_data = {"metadata": {"citation_count": 0, "citations": []}}
@@ -420,7 +420,7 @@ def test_literature_citations_with_size_bigger_than_maximum(
             f"/literature/{record['control_number']}/citations?size=5", headers=headers
         )
     response_status_code = response.status_code
-    response_data = json.loads(response.get_data())
+    response_data = orjson.loads(response.get_data())
     expected_status_code = 400
     expected_response = MaxResultWindowRESTError().description
     assert expected_status_code == response_status_code
@@ -432,7 +432,7 @@ def test_literature_facets(inspire_app):
 
     with inspire_app.test_client() as client:
         response = client.get("/literature/facets")
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_status_code = response.status_code
     response_data_facet_keys = list(response_data.get("aggregations").keys())
 
@@ -463,7 +463,7 @@ def test_literature_cataloger_facets(inspire_app):
         login_user_via_session(client, email=user.email)
         response = client.get("/literature/facets")
 
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_status_code = response.status_code
     response_data_facet_keys = list(response_data.get("aggregations").keys())
 
@@ -489,7 +489,7 @@ def test_literature_cataloger_facets(inspire_app):
 def test_literature_facets_author_count_does_not_have_empty_bucket(inspire_app):
     with inspire_app.test_client() as client:
         response = client.get("/literature/facets")
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     author_count_agg = response_data.get("aggregations")["author_count"]
     assert author_count_agg["buckets"] == []
 
@@ -501,7 +501,7 @@ def test_literature_facets_author_count_returns_non_empty_bucket(inspire_app):
     )
     with inspire_app.test_client() as client:
         response = client.get("/literature/facets")
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     author_count_agg = response_data.get("aggregations")["author_count"]
     buckets = author_count_agg["buckets"]
     assert len(buckets) == 1
@@ -511,7 +511,7 @@ def test_literature_facets_author_count_returns_non_empty_bucket(inspire_app):
 def test_literature_facets_doc_type_has_bucket_help(inspire_app):
     with inspire_app.test_client() as client:
         response = client.get("/literature/facets")
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_status_code = response.status_code
     response_data_facet_bucket_help = (
         response_data.get("aggregations").get("doc_type").get("meta").get("bucket_help")
@@ -541,7 +541,7 @@ def test_literature_search_citation_count_filter(inspire_app):
     with inspire_app.test_client() as client:
         response = client.get("/literature?citation_count=101--102")
 
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_status_code = response.status_code
     assert response_status_code == 200
     assert response_data["hits"]["total"] == 1
@@ -560,7 +560,7 @@ def test_literature_search_refereed_filter(inspire_app):
 
     with inspire_app.test_client() as client:
         response = client.get("/literature?refereed=true")
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_status_code = response.status_code
     assert response_status_code == 200
     assert response_data["hits"]["total"] == 1
@@ -579,7 +579,7 @@ def test_literature_search_citeable_filter(inspire_app):
 
     with inspire_app.test_client() as client:
         response = client.get("/literature?citeable=true")
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     response_status_code = response.status_code
     assert response_status_code == 200
     assert response_data["hits"]["total"] == 1
@@ -689,7 +689,7 @@ def test_literature_search_user_does_not_get_fermilab_collection(inspire_app):
     with inspire_app.test_client() as client:
         response = client.get("/literature")
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
 
     assert response_data["hits"]["total"] == 0
     assert expected_status_code == response_status_code
@@ -724,7 +724,7 @@ def test_literature_search_cataloger_gets_fermilab_collection(inspire_app):
         login_user_via_session(client, email=user.email)
         response = client.get("/literature")
     response_status_code = response.status_code
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     assert response_data["hits"]["total"] == 1
 
     response_data_metadata = response_data["hits"]["hits"][0]["metadata"]
@@ -739,7 +739,7 @@ def test_literature_search_permissions(inspire_app):
 
     with inspire_app.test_client() as client:
         response = client.get("/literature")
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     assert response_data["hits"]["total"] == 1
     assert (
         response_data["hits"]["hits"][0]["metadata"]["control_number"]
@@ -750,13 +750,13 @@ def test_literature_search_permissions(inspire_app):
     with inspire_app.test_client() as client:
         login_user_via_session(client, email=user.email)
         response = client.get("/literature")
-        response_data = json.loads(response.data)
+        response_data = orjson.loads(response.data)
         assert response_data["hits"]["total"] == 2
 
         logout(client)
 
         response = client.get("/literature")
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
     assert response_data["hits"]["total"] == 1
     assert (
         response_data["hits"]["hits"][0]["metadata"]["control_number"]

--- a/backend/tests/integration/search/test_api.py
+++ b/backend/tests/integration/search/test_api.py
@@ -5,10 +5,10 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
 import urllib
 
 import mock
+import orjson
 import pytest
 from helpers.utils import create_record
 from requests.exceptions import RequestException
@@ -25,7 +25,8 @@ def test_literature_get_records_by_pids_returns_correct_record(inspire_app):
     result = LiteratureSearch().get_records_by_pids([("lit", record1_control_number)])
     assert len(result) == 1
     assert (
-        json.loads(result[0]._ui_display)["control_number"] == record1["control_number"]
+        orjson.loads(result[0]._ui_display)["control_number"]
+        == record1["control_number"]
     )
 
     result = LiteratureSearch().get_records_by_pids(

--- a/backend/tests/integration/submissions/test_submissions_views.py
+++ b/backend/tests/integration/submissions/test_submissions_views.py
@@ -5,10 +5,10 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
 from copy import deepcopy
 from datetime import datetime, timedelta
 
+import orjson
 import pytest
 import requests_mock
 from flask import current_app, url_for
@@ -39,7 +39,7 @@ def test_author_submit_requires_authentication(inspire_app):
         response = client.post(
             "/submissions/authors",
             content_type="application/json",
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "data": {
                         "given_name": "John",
@@ -57,7 +57,7 @@ def test_author_update_requires_authentication(inspire_app):
         response = client.put(
             "/submissions/authors/123",
             content_type="application/json",
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "data": {
                         "given_name": "John",
@@ -90,7 +90,7 @@ def test_new_author_submit(inspire_app, requests_mock):
         response = client.post(
             "/submissions/authors",
             content_type="application/json",
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "data": {
                         "given_name": "John",
@@ -138,7 +138,7 @@ def test_new_author_submit_with_workflows_error(inspire_app, requests_mock):
         response = client.post(
             "/submissions/authors",
             content_type="application/json",
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "data": {
                         "given_name": "John",
@@ -163,7 +163,7 @@ def test_new_author_submit_works_with_session_login(inspire_app, requests_mock):
         response = client.post(
             "/submissions/authors",
             content_type="application/json",
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "data": {
                         "given_name": "John",
@@ -224,7 +224,7 @@ def test_get_author_update_data_of_same_author(inspire_app):
         response = client.get(
             "/submissions/authors/123", headers={"Accept": "application/json"}
         )
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
 
     assert response_data == expected_data
 
@@ -269,7 +269,7 @@ def test_update_author(create_ticket_mock, inspire_app):
         response = client.put(
             "/submissions/authors/123",
             content_type="application/json",
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "data": {
                         "given_name": "John, Updated",
@@ -347,7 +347,7 @@ def test_update_author_creates_new_workflow(
         response = client.put(
             "/submissions/authors/123",
             content_type="application/json",
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "data": {
                         "given_name": "John, Updated",
@@ -374,7 +374,7 @@ def test_new_literature_submit_no_merge(inspire_app, requests_mock):
         response = client.post(
             "/submissions/literature",
             content_type="application/json",
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "data": {
                         "arxiv_id": "1701.00006",
@@ -443,7 +443,7 @@ def test_new_literature_submit_arxiv_urls(inspire_app, requests_mock):
         response = client.post(
             "/submissions/literature",
             content_type="application/json",
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "data": {
                         "arxiv_id": "1701.00006",
@@ -510,7 +510,7 @@ def test_new_literature_submit_works_with_session_login(inspire_app, requests_mo
         response = client.post(
             "/submissions/literature",
             content_type="application/json",
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "data": {
                         "document_type": "article",
@@ -529,7 +529,7 @@ def test_new_literature_submit_requires_authentication(inspire_app):
         response = client.post(
             "/submissions/literature",
             content_type="application/json",
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "data": {
                         "document_type": "article",
@@ -555,7 +555,7 @@ def test_new_literature_submit_with_workflows_api_error(inspire_app, requests_mo
         response = client.post(
             "/submissions/literature",
             content_type="application/json",
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "data": {
                         "document_type": "article",
@@ -581,7 +581,7 @@ def test_new_literature_submit_with_private_notes(inspire_app, requests_mock):
         response = client.post(
             "/submissions/literature",
             content_type="application/json",
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "data": {
                         "arxiv_id": "1701.00006",
@@ -636,7 +636,7 @@ def test_new_literature_submit_with_private_notes_and_conference_record(
         response = client.post(
             "/submissions/literature",
             content_type="application/json",
-            data=json.dumps(
+            data=orjson.dumps(
                 {
                     "data": {
                         "arxiv_id": "1701.00006",
@@ -696,7 +696,7 @@ def test_job_submit_requires_authentication(ticket_mock, inspire_app):
         response = client.post(
             "/submissions/jobs",
             content_type="application/json",
-            data=json.dumps(DEFAULT_EXAMPLE_JOB_DATA),
+            data=orjson.dumps(DEFAULT_EXAMPLE_JOB_DATA),
         )
     assert response.status_code == 401
 
@@ -707,7 +707,7 @@ def test_job_update_requires_authentication(ticket_mock, inspire_app):
         response = client.post(
             "/submissions/jobs/1234",
             content_type="application/json",
-            data=json.dumps(DEFAULT_EXAMPLE_JOB_DATA),
+            data=orjson.dumps(DEFAULT_EXAMPLE_JOB_DATA),
         )
 
     assert response.status_code == 401
@@ -728,11 +728,11 @@ def test_new_job_submit_by_user(create_ticket_mock, inspire_app):
         response = client.post(
             "/submissions/jobs",
             content_type="application/json",
-            data=json.dumps({"data": DEFAULT_EXAMPLE_JOB_DATA}),
+            data=orjson.dumps({"data": DEFAULT_EXAMPLE_JOB_DATA}),
         )
     assert response.status_code == 201
 
-    job_id = json.loads(response.data)["pid_value"]
+    job_id = orjson.loads(response.data)["pid_value"]
     job_data = JobsRecord.get_record_by_pid_value(job_id)
 
     assert job_data["status"] == "pending"
@@ -749,11 +749,11 @@ def test_new_job_submit_by_cataloger(ticket_mock, inspire_app):
         response = client.post(
             "/submissions/jobs",
             content_type="application/json",
-            data=json.dumps({"data": post_data}),
+            data=orjson.dumps({"data": post_data}),
         )
     assert response.status_code == 201
 
-    job_id = json.loads(response.data)["pid_value"]
+    job_id = orjson.loads(response.data)["pid_value"]
     job_data = JobsRecord.get_record_by_pid_value(job_id)
 
     assert job_data["status"] == "open"
@@ -768,7 +768,7 @@ def test_new_job_submit_with_wrong_field_value(ticket_mock, inspire_app):
         response = client.post(
             "/submissions/jobs",
             content_type="application/json",
-            data=json.dumps({"data": data}),
+            data=orjson.dumps({"data": data}),
         )
     assert response.status_code == 400
 
@@ -782,7 +782,7 @@ def test_new_job_submit_with_wrong_status_value(ticket_mock, inspire_app):
         response = client.post(
             "/submissions/jobs",
             content_type="application/json",
-            data=json.dumps({"data": data}),
+            data=orjson.dumps({"data": data}),
         )
         assert response.status_code == 201
         pid_value = response.json["pid_value"]
@@ -803,7 +803,7 @@ def test_update_job(create_ticket_mock, inspire_app):
         response = client.post(
             "/submissions/jobs",
             content_type="application/json",
-            data=json.dumps({"data": data}),
+            data=orjson.dumps({"data": data}),
         )
 
         assert response.status_code == 201
@@ -816,7 +816,9 @@ def test_update_job(create_ticket_mock, inspire_app):
         )
         data["title"] = "New test title"
         response2 = client.put(
-            record_url, content_type="application/json", data=json.dumps({"data": data})
+            record_url,
+            content_type="application/json",
+            data=orjson.dumps({"data": data}),
         )
 
         assert response2.status_code == 200
@@ -835,7 +837,7 @@ def test_update_job_status_from_pending_not_curator(ticket_mock, inspire_app):
         response = client.post(
             "/submissions/jobs",
             content_type="application/json",
-            data=json.dumps({"data": data}),
+            data=orjson.dumps({"data": data}),
         )
 
         assert response.status_code == 201
@@ -846,7 +848,9 @@ def test_update_job_status_from_pending_not_curator(ticket_mock, inspire_app):
         )
         data["status"] = "open"
         response2 = client.put(
-            record_url, content_type="application/json", data=json.dumps({"data": data})
+            record_url,
+            content_type="application/json",
+            data=orjson.dumps({"data": data}),
         )
 
         assert response2.status_code == 400
@@ -864,7 +868,7 @@ def test_update_job_status_from_pending_curator(create_ticket_mock, inspire_app)
         response = client.post(
             "/submissions/jobs",
             content_type="application/json",
-            data=json.dumps({"data": data}),
+            data=orjson.dumps({"data": data}),
         )
 
     assert response.status_code == 201
@@ -882,7 +886,9 @@ def test_update_job_status_from_pending_curator(create_ticket_mock, inspire_app)
 
         data["status"] = "open"
         response2 = client.put(
-            record_url, content_type="application/json", data=json.dumps({"data": data})
+            record_url,
+            content_type="application/json",
+            data=orjson.dumps({"data": data}),
         )
 
         assert response2.status_code == 200
@@ -901,7 +907,7 @@ def test_update_job_data_from_different_user(ticket_mock, inspire_app):
         response = client.post(
             "/submissions/jobs",
             content_type="application/json",
-            data=json.dumps({"data": data}),
+            data=orjson.dumps({"data": data}),
         )
     assert response.status_code == 201
     pid_value = response.json["pid_value"]
@@ -912,7 +918,9 @@ def test_update_job_data_from_different_user(ticket_mock, inspire_app):
         login_user_via_session(client, email=user2.email)
         data["title"] = "Title2"
         response2 = client.put(
-            record_url, content_type="application/json", data=json.dumps({"data": data})
+            record_url,
+            content_type="application/json",
+            data=orjson.dumps({"data": data}),
         )
     assert response2.status_code == 403
 
@@ -927,7 +935,7 @@ def test_update_job_status_from_open(ticket_mock, inspire_app):
         response = client.post(
             "/submissions/jobs",
             content_type="application/json",
-            data=json.dumps({"data": data}),
+            data=orjson.dumps({"data": data}),
         )
         assert response.status_code == 201
         pid_value = response.json["pid_value"]
@@ -939,14 +947,18 @@ def test_update_job_status_from_open(ticket_mock, inspire_app):
         login_user_via_session(client, email=curator.email)
         data["status"] = "open"
         response2 = client.put(
-            record_url, content_type="application/json", data=json.dumps({"data": data})
+            record_url,
+            content_type="application/json",
+            data=orjson.dumps({"data": data}),
         )
         assert response2.status_code == 200
         #  Login as user again to update job from open to closed
         login_user_via_session(client, email=user.email)
         data["status"] = "closed"
         response3 = client.put(
-            record_url, content_type="application/json", data=json.dumps({"data": data})
+            record_url,
+            content_type="application/json",
+            data=orjson.dumps({"data": data}),
         )
 
         assert response3.status_code == 200
@@ -964,7 +976,7 @@ def test_job_update_data_30_days_after_deadline(inspire_app):
         response = client.post(
             "/submissions/jobs",
             content_type="application/json",
-            data=json.dumps({"data": data}),
+            data=orjson.dumps({"data": data}),
         )
         assert response.status_code == 201
         pid_value = response.json["pid_value"]
@@ -986,7 +998,7 @@ def test_job_update_data_30_days_after_deadline_with_cataloger(inspire_app):
         response = client.post(
             "/submissions/jobs",
             content_type="application/json",
-            data=json.dumps({"data": data}),
+            data=orjson.dumps({"data": data}),
         )
         assert response.status_code == 201
         pid_value = response.json["pid_value"]
@@ -1008,7 +1020,7 @@ def test_job_update_data_less_than_30_days_after_deadline(inspire_app):
         response = client.post(
             "/submissions/jobs",
             content_type="application/json",
-            data=json.dumps({"data": data}),
+            data=orjson.dumps({"data": data}),
         )
         assert response.status_code == 201
         pid_value = response.json["pid_value"]
@@ -1032,7 +1044,7 @@ def test_update_job_from_closed_less_than_30_days_after_deadline_by_user(
         response = client.post(
             "/submissions/jobs",
             content_type="application/json",
-            data=json.dumps({"data": data}),
+            data=orjson.dumps({"data": data}),
         )
         assert response.status_code == 201
         pid_value = response.json["pid_value"]
@@ -1046,14 +1058,18 @@ def test_update_job_from_closed_less_than_30_days_after_deadline_by_user(
             "%Y-%m-%d"
         )  # yesterday
         response2 = client.put(
-            record_url, content_type="application/json", data=json.dumps({"data": data})
+            record_url,
+            content_type="application/json",
+            data=orjson.dumps({"data": data}),
         )
         assert response2.status_code == 200
         #  Login as user again to update job title
         login_user_via_session(client, email=user.email)
         data["title"] = "Another Title"
         response3 = client.put(
-            record_url, content_type="application/json", data=json.dumps({"data": data})
+            record_url,
+            content_type="application/json",
+            data=orjson.dumps({"data": data}),
         )
 
         assert response3.status_code == 200
@@ -1073,7 +1089,7 @@ def test_update_job_status_update_more_than_30_days_after_deadline_by_user(
         response = client.post(
             "/submissions/jobs",
             content_type="application/json",
-            data=json.dumps({"data": data}),
+            data=orjson.dumps({"data": data}),
         )
         assert response.status_code == 201
         pid_value = response.json["pid_value"]
@@ -1085,14 +1101,18 @@ def test_update_job_status_update_more_than_30_days_after_deadline_by_user(
         data["status"] = "closed"
         data["deadline_date"] = "2020-01-01"
         response2 = client.put(
-            record_url, content_type="application/json", data=json.dumps({"data": data})
+            record_url,
+            content_type="application/json",
+            data=orjson.dumps({"data": data}),
         )
         assert response2.status_code == 200
         #  Login as user again to update job title
         login_user_via_session(client, email=user.email)
         data["status"] = "open"
         response3 = client.put(
-            record_url, content_type="application/json", data=json.dumps({"data": data})
+            record_url,
+            content_type="application/json",
+            data=orjson.dumps({"data": data}),
         )
 
         assert response3.status_code == 400
@@ -1128,7 +1148,7 @@ def test_update_job_remove_not_compulsory_fields(ticket_mock, inspire_app):
         response = client.post(
             "/submissions/jobs",
             content_type="application/json",
-            data=json.dumps({"data": data}),
+            data=orjson.dumps({"data": data}),
         )
         pid_value = response.json["pid_value"]
         record_url = url_for(
@@ -1136,7 +1156,9 @@ def test_update_job_remove_not_compulsory_fields(ticket_mock, inspire_app):
         )
         data = {**DEFAULT_EXAMPLE_JOB_DATA}
         response2 = client.put(
-            record_url, content_type="application/json", data=json.dumps({"data": data})
+            record_url,
+            content_type="application/json",
+            data=orjson.dumps({"data": data}),
         )
 
         assert response2.status_code == 200
@@ -1177,7 +1199,9 @@ def test_regression_update_job_without_acquisition_source_doesnt_give_500(
         )
 
         response = client.put(
-            record_url, content_type="application/json", data=json.dumps({"data": data})
+            record_url,
+            content_type="application/json",
+            data=orjson.dumps({"data": data}),
         )
     assert response.status_code == 403
 
@@ -1212,11 +1236,11 @@ def test_new_user_conference_submission_full_form_is_in_db_and_es_and_has_all_fi
         response = client.post(
             "/submissions/conferences",
             content_type="application/json",
-            data=json.dumps({"data": CONFERENCE_FORM_DATA}),
+            data=orjson.dumps({"data": CONFERENCE_FORM_DATA}),
         )
     assert response.status_code == 201
 
-    payload = json.loads(response.data)
+    payload = orjson.loads(response.data)
     conference_id = payload["pid_value"]
     conference_cnum = payload["cnum"]
 
@@ -1292,10 +1316,10 @@ def test_new_user_conference_submission_missing_dates_has_no_cnum(
         response = client.post(
             "/submissions/conferences",
             content_type="application/json",
-            data=json.dumps({"data": form_data}),
+            data=orjson.dumps({"data": form_data}),
         )
 
-    payload = json.loads(response.data)
+    payload = orjson.loads(response.data)
     conference_id = payload["pid_value"]
     conference_cnum = payload["cnum"]
     conference_record = ConferencesRecord.get_record_by_pid_value(conference_id)
@@ -1314,7 +1338,7 @@ def test_non_logged_in_user_tries_to_submit(ticket_mock, inspire_app):
         response = client.post(
             "/submissions/conferences",
             content_type="application/json",
-            data=json.dumps({"data": form_data}),
+            data=orjson.dumps({"data": form_data}),
         )
 
     assert response.status_code == 401
@@ -1331,7 +1355,7 @@ def test_rt_ticket_when_cataloger_submits_conference(ticket_mock, inspire_app):
         response = client.post(
             "/submissions/conferences",
             content_type="application/json",
-            data=json.dumps({"data": form_data}),
+            data=orjson.dumps({"data": form_data}),
         )
 
     assert response.status_code == 201
@@ -1347,7 +1371,7 @@ def test_rt_ticket_when_superuser_submits_conference(ticket_mock, inspire_app):
         response = client.post(
             "/submissions/conferences",
             content_type="application/json",
-            data=json.dumps({"data": form_data}),
+            data=orjson.dumps({"data": form_data}),
         )
 
     assert response.status_code == 201
@@ -1365,7 +1389,7 @@ def test_confirmation_email_not_sent_when_user_is_superuser(
         response = client.post(
             "/submissions/conferences",
             content_type="application/json",
-            data=json.dumps({"data": form_data}),
+            data=orjson.dumps({"data": form_data}),
         )
 
     assert response.status_code == 201
@@ -1383,7 +1407,7 @@ def test_confirmation_email_not_sent_when_user_is_cataloger(
         response = client.post(
             "/submissions/conferences",
             content_type="application/json",
-            data=json.dumps({"data": form_data}),
+            data=orjson.dumps({"data": form_data}),
         )
 
     assert response.status_code == 201
@@ -1401,7 +1425,7 @@ def test_confirmation_email_sent_for_regular_user(
         response = client.post(
             "/submissions/conferences",
             content_type="application/json",
-            data=json.dumps({"data": form_data}),
+            data=orjson.dumps({"data": form_data}),
         )
 
     conference_rec = ConferencesRecord.get_record_by_pid_value(
@@ -1421,7 +1445,7 @@ def test_conference_raise_loader_error(ticket_mock, inspire_app):
         response = client.post(
             "/submissions/conferences",
             content_type="application/json",
-            data=json.dumps({"data": DATA}),
+            data=orjson.dumps({"data": DATA}),
         )
     assert response.status_code == 400
 
@@ -1529,7 +1553,7 @@ def test_get_seminar_update_data(form_data, record_data, inspire_app):
         response = client.get(
             "/submissions/seminars/123", headers={"Accept": "application/json"}
         )
-    response_data = json.loads(response.data)
+    response_data = orjson.loads(response.data)
 
     assert response_data == expected_data
 
@@ -1579,12 +1603,12 @@ def test_new_seminar_submission(
         response = client.post(
             "/submissions/seminars",
             content_type="application/json",
-            data=json.dumps({"data": form_data}),
+            data=orjson.dumps({"data": form_data}),
         )
 
     assert response.status_code == 201
 
-    payload = json.loads(response.data)
+    payload = orjson.loads(response.data)
     seminar_id = payload["pid_value"]
     seminar_record = SeminarsRecord.get_record_by_pid_value(seminar_id)
     seminar_record_data = {
@@ -1613,12 +1637,12 @@ def test_new_seminar_submission_with_cataloger_login(
         response = client.post(
             "/submissions/seminars",
             content_type="application/json",
-            data=json.dumps({"data": form_data}),
+            data=orjson.dumps({"data": form_data}),
         )
 
     assert response.status_code == 201
 
-    payload = json.loads(response.data)
+    payload = orjson.loads(response.data)
     seminar_id = payload["pid_value"]
     seminar_record = SeminarsRecord.get_record_by_pid_value(seminar_id)
     seminar_record_data = {
@@ -1667,11 +1691,11 @@ def test_seminar_update_submission(
         response = client.put(
             "/submissions/seminars/123",
             content_type="application/json",
-            data=json.dumps({"data": update_form_data}),
+            data=orjson.dumps({"data": update_form_data}),
         )
     assert response.status_code == 200
 
-    payload = json.loads(response.data)
+    payload = orjson.loads(response.data)
     seminar_id = payload["pid_value"]
     seminar_record = SeminarsRecord.get_record_by_pid_value(seminar_id)
     seminar_record_data = {
@@ -1706,11 +1730,11 @@ def test_seminar_update_submission_with_cataloger_login(
         response = client.put(
             "/submissions/seminars/123",
             content_type="application/json",
-            data=json.dumps({"data": form_data}),
+            data=orjson.dumps({"data": form_data}),
         )
     assert response.status_code == 200
 
-    payload = json.loads(response.data)
+    payload = orjson.loads(response.data)
     seminar_id = payload["pid_value"]
     seminar_record = SeminarsRecord.get_record_by_pid_value(seminar_id)
     seminar_record_data = {
@@ -1738,7 +1762,7 @@ def test_seminar_update_submission_without_login(inspire_app):
         response = client.put(
             "/submissions/seminars/123",
             content_type="application/json",
-            data=json.dumps({"data": form_data}),
+            data=orjson.dumps({"data": form_data}),
         )
     assert response.status_code == 401
 
@@ -1759,7 +1783,7 @@ def test_seminar_update_submission_with_different_user(inspire_app):
         response = client.put(
             "/submissions/seminars/123",
             content_type="application/json",
-            data=json.dumps({"data": form_data}),
+            data=orjson.dumps({"data": form_data}),
         )
     assert response.status_code == 403
 
@@ -1780,12 +1804,12 @@ def test_new_seminar_submission_with_valid_lit_record(
         response = client.post(
             "/submissions/seminars",
             content_type="application/json",
-            data=json.dumps({"data": data}),
+            data=orjson.dumps({"data": data}),
         )
 
     assert response.status_code == 201
 
-    payload = json.loads(response.data)
+    payload = orjson.loads(response.data)
     seminar_id = payload["pid_value"]
     seminar_record = SeminarsRecord.get_record_by_pid_value(seminar_id)
     assert seminar_record["literature_records"] == [
@@ -1812,7 +1836,7 @@ def test_new_seminar_submission_with_invalid_lit_record(
         response = client.post(
             "/submissions/seminars",
             content_type="application/json",
-            data=json.dumps({"data": data}),
+            data=orjson.dumps({"data": data}),
         )
         assert response.status_code == 400
         assert response.json["message"][0] == "3 is not a valid literature record."

--- a/backend/tests/unit/records/marshmallow/author/common/test_position.py
+++ b/backend/tests/unit/records/marshmallow/author/common/test_position.py
@@ -5,8 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
-
+import orjson
 from inspire_schemas.api import load_schema, validate
 
 from inspirehep.records.marshmallow.authors.common import PositionSchemaV1
@@ -32,7 +31,7 @@ def test_returns_display_date_if_start_and_end_date_present():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_returns_display_date_if_start_date_present_and_current_set():
@@ -46,7 +45,7 @@ def test_returns_display_date_if_start_date_present_and_current_set():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_returns_display_date_if_only_current_set():
@@ -60,7 +59,7 @@ def test_returns_display_date_if_only_current_set():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_returns_display_date_if_start_date_present():
@@ -74,7 +73,7 @@ def test_returns_display_date_if_start_date_present():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_returns_display_date_if_end_date_present():
@@ -88,7 +87,7 @@ def test_returns_display_date_if_end_date_present():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_returns_display_date_rank_institution_and_current():
@@ -107,4 +106,4 @@ def test_returns_display_date_rank_institution_and_current():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)

--- a/backend/tests/unit/records/marshmallow/author/test_base.py
+++ b/backend/tests/unit/records/marshmallow/author/test_base.py
@@ -5,8 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
-
+import orjson
 from helpers.providers.faker import faker
 
 from inspirehep.records.marshmallow.authors import (
@@ -29,7 +28,7 @@ def test_public_schema_does_not_return_hidden_emails():
     expected_emails = [{"value": "public@cern.ch"}]
 
     result = schema.dumps(author).data
-    result_data = json.loads(result)
+    result_data = orjson.loads(result)
 
     assert result_data["email_addresses"] == expected_emails
 
@@ -40,7 +39,7 @@ def test_public_schema_excludes_private_notes():
     author = faker.record("aut", data=data, with_control_number=True)
 
     result = schema.dumps(author).data
-    result_data = json.loads(result)
+    result_data = orjson.loads(result)
 
     assert "_private_notes" not in result_data
 
@@ -60,7 +59,7 @@ def test_admin_schema_returns_all_emails():
     ]
 
     result = schema.dumps(author).data
-    result_data = json.loads(result)
+    result_data = orjson.loads(result)
 
     assert result_data["email_addresses"] == expected_emails
 
@@ -75,7 +74,7 @@ def test_only_control_number_schema_ignores_other_fields():
     expected_result = {"control_number": author["control_number"]}
 
     result = schema.dumps(author).data
-    result_data = json.loads(result)
+    result_data = orjson.loads(result)
 
     assert result_data == expected_result
 
@@ -92,7 +91,7 @@ def test_authors_api_schema_doesnt_return_acquisition_source_email():
     author = faker.record("aut", data=data, with_control_number=True)
 
     result = schema.dumps(author).data
-    result_data = json.loads(result)
+    result_data = orjson.loads(result)
 
     assert "acquisition_source" not in result_data
 
@@ -109,6 +108,6 @@ def test_authors_api_schema_doesnt_return_emails_adresses():
     author = faker.record("aut", data=data, with_control_number=True)
 
     result = schema.dumps(author).data
-    result_data = json.loads(result)
+    result_data = orjson.loads(result)
 
     assert "email_adresses" not in result_data

--- a/backend/tests/unit/records/marshmallow/author/test_ui.py
+++ b/backend/tests/unit/records/marshmallow/author/test_ui.py
@@ -5,9 +5,8 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
-
 import mock
+import orjson
 from helpers.providers.faker import faker
 
 from inspirehep.records.marshmallow.authors import (
@@ -30,7 +29,7 @@ def test_should_display_positions_without_positions(can_edit):
     expected_result = False
 
     result = schema.dumps(author).data
-    result_data = json.loads(result)
+    result_data = orjson.loads(result)
     result_should_display_positions = result_data.get("should_display_positions")
 
     assert expected_result == result_should_display_positions
@@ -51,7 +50,7 @@ def test_should_display_positions_with_multiple_positions(can_edit):
     expected_result = True
 
     result = schema.dumps(author).data
-    result_data = json.loads(result)
+    result_data = orjson.loads(result)
     result_should_display_positions = result_data.get("should_display_positions")
 
     assert expected_result == result_should_display_positions
@@ -72,7 +71,7 @@ def test_should_display_positions_with_multiple_positions_with_rank(can_edit):
     expected_result = True
 
     result = schema.dumps(author).data
-    result_data = json.loads(result)
+    result_data = orjson.loads(result)
     result_should_display_positions = result_data.get("should_display_positions")
 
     assert expected_result == result_should_display_positions
@@ -93,7 +92,7 @@ def test_should_display_positions_with_multiple_positions_with_start_date(can_ed
     expected_result = True
 
     result = schema.dumps(author).data
-    result_data = json.loads(result)
+    result_data = orjson.loads(result)
     result_should_display_positions = result_data.get("should_display_positions")
 
     assert expected_result == result_should_display_positions
@@ -114,7 +113,7 @@ def test_should_display_positions_with_multiple_positions_if_is_not_current(can_
     expected_result = True
 
     result = schema.dumps(author).data
-    result_data = json.loads(result)
+    result_data = orjson.loads(result)
     result_should_display_positions = result_data.get("should_display_positions")
 
     assert expected_result == result_should_display_positions
@@ -135,7 +134,7 @@ def test_returns_should_display_position_false_if_position_is_current(can_edit):
     expected_result = False
 
     result = schema.dumps(author).data
-    result_data = json.loads(result)
+    result_data = orjson.loads(result)
     result_should_display_positions = result_data.get("should_display_positions")
 
     assert expected_result == result_should_display_positions
@@ -155,7 +154,7 @@ def test_facet_author_name_with_preferred_name_and_control_number(can_edit):
     expected_result = "1_J Doe"
 
     result = schema.dumps(author).data
-    result_data = json.loads(result)
+    result_data = orjson.loads(result)
     result_facet_author_name = result_data.get("facet_author_name")
 
     assert expected_result == result_facet_author_name
@@ -172,7 +171,7 @@ def test_facet_author_name_without_preferred_name(can_edit):
     expected_result = "1_John Doe"
 
     result = schema.dumps(author).data
-    result_data = json.loads(result)
+    result_data = orjson.loads(result)
     result_facet_author_name = result_data.get("facet_author_name")
 
     assert expected_result == result_facet_author_name
@@ -188,7 +187,7 @@ def test_author_twitter(can_edit):
     expected_twitter = "harunurhan"
 
     result = schema.dumps(author).data
-    result_data = json.loads(result)
+    result_data = orjson.loads(result)
     result_twitter = result_data.get("twitter")
 
     assert expected_twitter == result_twitter
@@ -204,7 +203,7 @@ def test_author_linkedin(can_edit):
     expected_linkedin = "harunurhan"
 
     result = schema.dumps(author).data
-    result_data = json.loads(result)
+    result_data = orjson.loads(result)
     result_linkedin = result_data.get("linkedin")
 
     assert expected_linkedin == result_linkedin
@@ -218,7 +217,7 @@ def test_author_does_not_have_id_fields(can_edit):
     author = faker.record("aut", with_control_number=True)
 
     result = schema.dumps(author).data
-    result_data = json.loads(result)
+    result_data = orjson.loads(result)
 
     assert "linkedin" not in result_data
     assert "twitter" not in result_data
@@ -236,7 +235,7 @@ def test_author_bai(can_edit):
     expected_bai = "John.Doe.1"
 
     result = schema.dumps(author).data
-    result_data = json.loads(result)
+    result_data = orjson.loads(result)
     result_bai = result_data.get("bai")
 
     assert expected_bai == result_bai
@@ -252,7 +251,7 @@ def test_author_orcid(can_edit):
     expected_orcid = "0000-0001-8058-0014"
 
     result = schema.dumps(author).data
-    result_data = json.loads(result)
+    result_data = orjson.loads(result)
     result_orcid = result_data.get("orcid")
 
     assert expected_orcid == result_orcid
@@ -277,7 +276,7 @@ def test_only_public_and_current_emails(can_edit):
     ]
 
     result = schema.dumps(author).data
-    result_data = json.loads(result)
+    result_data = orjson.loads(result)
     result_email_addresses = result_data.get("email_addresses")
 
     assert expected_email_addresses == result_email_addresses
@@ -316,7 +315,7 @@ def test_author_advisors_has_first_and_last_names(can_edit):
     ]
 
     result = schema.dumps(author).data
-    result_data = json.loads(result)
+    result_data = orjson.loads(result)
     result_advisors = result_data.get("advisors")
 
     assert expected_advisors == result_advisors
@@ -337,7 +336,7 @@ def test_authors_search_schema_doesnt_return_acquisition_source_email(can_edit):
     author = faker.record("aut", data=data, with_control_number=True)
 
     result = schema.dumps(author).data
-    result_data = json.loads(result)
+    result_data = orjson.loads(result)
 
     assert "acquisition_source" not in result_data
 
@@ -356,6 +355,6 @@ def test_authors_api_schema_doesnt_return_email_adresses(can_edit):
     }
     author = faker.record("aut", data=data, with_control_number=True)
     result = schema.dumps(author).data
-    result_data = json.loads(result)
+    result_data = orjson.loads(result)
 
     assert "email_adresses" not in result_data

--- a/backend/tests/unit/records/marshmallow/common/test_accelerator_experiment.py
+++ b/backend/tests/unit/records/marshmallow/common/test_accelerator_experiment.py
@@ -5,9 +5,8 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
-
 import mock
+import orjson
 
 from inspirehep.records.api import LiteratureRecord
 from inspirehep.records.marshmallow.common import AcceleratorExperimentSchemaV1
@@ -23,7 +22,7 @@ def test_returns_legacy_name_as_name(get_records_mock):
     expected = {"name": "Test"}
     result = schema.dumps(record).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 @mock.patch("inspirehep.records.api.base.InspireRecord.get_records_by_pids")
@@ -42,7 +41,7 @@ def test_returns_dashed_institution_accelerator_experiment_as_name_if_all_presen
     record = LiteratureRecord(dump)
     result = schema.dumps(record).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 @mock.patch("inspirehep.records.api.base.InspireRecord.get_records_by_pids")
@@ -58,7 +57,7 @@ def test_returns_legacy_name_as_name_if_accelerator_missing(get_records_mock):
     record = LiteratureRecord(dump)
     result = schema.dumps(record).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 @mock.patch("inspirehep.records.api.base.InspireRecord.get_records_by_pids")
@@ -74,7 +73,7 @@ def test_returns_legacy_name_as_name_if_institutions_missing(get_records_mock):
     record = LiteratureRecord(dump)
     result = schema.dumps(record).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 @mock.patch("inspirehep.records.api.base.InspireRecord.get_records_by_pids")
@@ -90,7 +89,7 @@ def test_returns_legacy_name_as_name_if_experiment_missing(get_records_mock):
     record = LiteratureRecord(dump)
     result = schema.dumps(record).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 @mock.patch("inspirehep.records.api.base.InspireRecord.get_records_by_pids")
@@ -102,7 +101,7 @@ def test_returns_none_as_name_if_empty_present(get_records_mock):
     record = LiteratureRecord(dump)
     result = schema.dumps(record).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 @mock.patch("inspirehep.records.api.base.InspireRecord.get_records_by_pids")
@@ -121,7 +120,7 @@ def test_returns_dashed_institution_accelerator_experiment_as_name_with_unicode(
     record = LiteratureRecord(dump)
     result = schema.dumps(record).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 @mock.patch("inspirehep.records.api.base.InspireRecord.get_records_by_pids")
@@ -143,4 +142,4 @@ def test_accelerator_experiment_many(get_records_mock):
 
     result = schema.dumps([dump1, dump2], many=True).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)

--- a/backend/tests/unit/records/marshmallow/conferences/test_base.py
+++ b/backend/tests/unit/records/marshmallow/conferences/test_base.py
@@ -4,8 +4,7 @@
 #
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
-import json
-
+import orjson
 from helpers.providers.faker import faker
 
 from inspirehep.records.marshmallow.conferences.base import (
@@ -115,10 +114,10 @@ def test_admin_schema():
 
 
 def test_api_schema_doesnt_include_email_in_contact_details():
-    data = [{"email": "test.test.test@cern.ch", "name": "Test, Contact",}]
+    data = [{"email": "test.test.test@cern.ch", "name": "Test, Contact"}]
 
     job = faker.record("con", data={"contact_details": data})
     result = ConferencesPublicListSchema().dumps(job).data
-    result_data = json.loads(result)
+    result_data = orjson.loads(result)
 
     assert "emails" not in result_data["contact_details"]

--- a/backend/tests/unit/records/marshmallow/conferences/test_ui.py
+++ b/backend/tests/unit/records/marshmallow/conferences/test_ui.py
@@ -1,15 +1,14 @@
-import json
-
+import orjson
 from helpers.providers.faker import faker
 
 from inspirehep.records.marshmallow.conferences.ui import ConferencesListSchema
 
 
 def test_api_schema_doesnt_include_email_in_contact_details():
-    data = [{"email": "test.test.test@cern.ch", "name": "Test, Contact",}]
+    data = [{"email": "test.test.test@cern.ch", "name": "Test, Contact"}]
 
     job = faker.record("con", data={"contact_details": data})
     result = ConferencesListSchema().dumps(job).data
-    result_data = json.loads(result)
+    result_data = orjson.loads(result)
 
     assert "emails" not in result_data["contact_details"]

--- a/backend/tests/unit/records/marshmallow/fields/test_list_with_limit.py
+++ b/backend/tests/unit/records/marshmallow/fields/test_list_with_limit.py
@@ -5,8 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
-
+import orjson
 from marshmallow import Schema, fields
 
 from inspirehep.records.marshmallow.fields import ListWithLimit
@@ -32,7 +31,7 @@ def test_list_with_limit_five():
 
     result = schema.dumps(data).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_list_with_limit_one():
@@ -43,7 +42,7 @@ def test_list_with_limit_one():
 
     result = schema.dumps(data).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_list_with_no_limit():
@@ -54,4 +53,4 @@ def test_list_with_no_limit():
 
     result = schema.dumps(data).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)

--- a/backend/tests/unit/records/marshmallow/fields/test_nested_without_empty_objects.py
+++ b/backend/tests/unit/records/marshmallow/fields/test_nested_without_empty_objects.py
@@ -5,8 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
-
+import orjson
 from marshmallow import Schema, fields
 
 from inspirehep.records.marshmallow.fields import NestedWithoutEmptyObjects
@@ -28,7 +27,7 @@ def test_nested_without_empty_objects():
 
     result = schema.dumps(data).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_nested_without_empty_objects_with_one_empty():
@@ -39,7 +38,7 @@ def test_nested_without_empty_objects_with_one_empty():
 
     result = schema.dumps(data).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_nested_without_empty_objects_with_all_empty():
@@ -50,4 +49,4 @@ def test_nested_without_empty_objects_with_all_empty():
 
     result = schema.dumps(data).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)

--- a/backend/tests/unit/records/marshmallow/fields/test_non_hidden.py
+++ b/backend/tests/unit/records/marshmallow/fields/test_non_hidden.py
@@ -5,8 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
-
+import orjson
 from marshmallow import Schema, fields
 
 from inspirehep.records.marshmallow.fields import NonHiddenNested, NonHiddenRaw
@@ -35,7 +34,7 @@ def test_nested_returns_only_not_hidden_items_with_many_true():
 
     result = schema.dumps(data).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_raw_returns_only_not_hidden_items_with_list():
@@ -60,7 +59,7 @@ def test_raw_returns_only_not_hidden_items_with_list():
 
     result = schema.dumps(data).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_raw_returns_empty_for_hidden_field():
@@ -78,4 +77,4 @@ def test_raw_returns_empty_for_hidden_field():
 
     result = schema.dumps(data).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)

--- a/backend/tests/unit/records/marshmallow/jobs/test_base.py
+++ b/backend/tests/unit/records/marshmallow/jobs/test_base.py
@@ -4,8 +4,7 @@
 #
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
-import json
-
+import orjson
 from helpers.providers.faker import faker
 
 from inspirehep.records.api import JobsRecord
@@ -34,17 +33,17 @@ def test_jobs_api_serializer_doesent_return_reference_letters():
     data = {"emails": ["test.test.test@cern.ch", "test@cern.ch"]}
     job = faker.record("job", data={"reference_letters": data})
     result = JobsPublicListSchema().dumps(job).data
-    result_data = json.loads(result)
+    result_data = orjson.loads(result)
 
     assert "reference_letters" not in result_data
 
 
 def test_jobs_api_serializer_doesent_return_email_in_contact_details():
-    data = [{"email": "test.test.test@cern.ch", "name": "Test, Contact",}]
+    data = [{"email": "test.test.test@cern.ch", "name": "Test, Contact"}]
 
     job = faker.record("job", data={"contact_details": data})
     result = JobsPublicListSchema().dumps(job).data
-    result_data = json.loads(result)
+    result_data = orjson.loads(result)
 
     assert "emails" not in result_data["contact_details"]
 
@@ -61,6 +60,6 @@ def test_jobs_api_serializer_doesent_return_email_in_acquisition_source():
 
     job = faker.record("job", data={"acquisition_source": acquisition_source})
     result = JobsPublicListSchema().dumps(job).data
-    result_data = json.loads(result)
+    result_data = orjson.loads(result)
 
     assert "email" not in result_data["acquisition_source"]

--- a/backend/tests/unit/records/marshmallow/literature/common/test_abstract_source.py
+++ b/backend/tests/unit/records/marshmallow/literature/common/test_abstract_source.py
@@ -5,10 +5,10 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
 from copy import deepcopy
 
 import mock
+import orjson
 from helpers.providers.faker import faker
 
 from inspirehep.records.marshmallow.literature import LiteratureElasticSearchSchema
@@ -43,7 +43,7 @@ def test_abstract_source_full(
     expected_abstracts = deepcopy(data["abstracts"])
     expected_abstracts[0]["abstract_source_suggest"] = {"input": "submitter"}
     expected_abstracts[1]["abstract_source_suggest"] = {"input": "arXiv"}
-    result = json.loads(schema().dumps(record).data)
+    result = orjson.loads(schema().dumps(record).data)
     assert result["abstracts"] == expected_abstracts
 
 
@@ -74,7 +74,7 @@ def test_abstract_source_one_missing_source(
     record = faker.record("lit", data=data)
     expected_abstracts = deepcopy(data["abstracts"])
     expected_abstracts[1]["abstract_source_suggest"] = {"input": "arXiv"}
-    result = json.loads(schema().dumps(record).data)
+    result = orjson.loads(schema().dumps(record).data)
     assert result["abstracts"] == expected_abstracts
 
 
@@ -91,7 +91,7 @@ def test_abstract_source_missing(
     schema = LiteratureElasticSearchSchema
 
     record = faker.record("lit")
-    result = json.loads(schema().dumps(record).data)
+    result = orjson.loads(schema().dumps(record).data)
     assert result.get("abstracts") is None
 
 
@@ -118,5 +118,5 @@ def test_abstract_source_one_only(
     record = faker.record("lit", data=data)
     expected_abstracts = deepcopy(data["abstracts"])
     expected_abstracts[0]["abstract_source_suggest"] = {"input": "arXiv"}
-    result = json.loads(schema().dumps(record).data)
+    result = orjson.loads(schema().dumps(record).data)
     assert result["abstracts"] == expected_abstracts

--- a/backend/tests/unit/records/marshmallow/literature/common/test_author.py
+++ b/backend/tests/unit/records/marshmallow/literature/common/test_author.py
@@ -5,7 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
+import orjson
 
 from inspirehep.records.marshmallow.literature.common import (
     AuthorSchemaV1,
@@ -28,7 +28,7 @@ def test_author():
     }
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_author_without_last_name():
@@ -38,7 +38,7 @@ def test_author_without_last_name():
     expected = {"full_name": "Frank Castle", "first_name": "Frank Castle"}
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_author_with_bai():
@@ -56,7 +56,7 @@ def test_author_with_bai():
     }
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_author_with_with_inspire_roles():
@@ -70,7 +70,7 @@ def test_author_with_with_inspire_roles():
     }
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_author_es_enchancement():
@@ -91,7 +91,7 @@ def test_author_es_enchancement():
         ]
     )
 
-    result = json.loads(schema.dumps(dump).data)
+    result = orjson.loads(schema.dumps(dump).data)
 
     assert "input" in result["name_suggest"]
     assert sorted(result["name_suggest"]["input"]) == expected_name_suggest
@@ -115,7 +115,7 @@ def test_author_es_enchancement_without_last_name():
         ]
     )
 
-    result = json.loads(schema.dumps(dump).data)
+    result = orjson.loads(schema.dumps(dump).data)
 
     assert "input" in result["name_suggest"]
     assert sorted(result["name_suggest"]["input"]) == expected_name_suggest
@@ -126,7 +126,7 @@ def test_author_schema_returns_empty_for_supervisor():
     dump = {"full_name": "Smith, John", "inspire_roles": ["supervisor"]}
     result = schema.dumps(dump).data
 
-    assert json.loads(result) == {}
+    assert orjson.loads(result) == {}
 
 
 def test_supervisor_schema():
@@ -140,7 +140,7 @@ def test_supervisor_schema():
     }
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_supervisor_schema_returns_empty_for_non_supervisor():
@@ -148,7 +148,7 @@ def test_supervisor_schema_returns_empty_for_non_supervisor():
     dump = {"full_name": "Smith, John", "inspire_roles": ["author"]}
     result = schema.dumps(dump).data
 
-    assert json.loads(result) == {}
+    assert orjson.loads(result) == {}
 
 
 def test_first_author():
@@ -184,4 +184,4 @@ def test_first_author():
     }
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)

--- a/backend/tests/unit/records/marshmallow/literature/common/test_citation_item.py
+++ b/backend/tests/unit/records/marshmallow/literature/common/test_citation_item.py
@@ -5,7 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
+import orjson
 
 from inspirehep.records.marshmallow.literature.common import CitationItemSchemaV1
 
@@ -30,7 +30,7 @@ def test_returns_non_empty_fields():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_returns_max_10_authors():
@@ -69,7 +69,7 @@ def test_returns_max_10_authors():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_returns_non_empty_fields_if_some_fields_missing():
@@ -78,4 +78,4 @@ def test_returns_non_empty_fields_if_some_fields_missing():
     expected = {"control_number": 123}
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)

--- a/backend/tests/unit/records/marshmallow/literature/common/test_collaboration.py
+++ b/backend/tests/unit/records/marshmallow/literature/common/test_collaboration.py
@@ -5,7 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
+import orjson
 
 from inspirehep.records.marshmallow.literature.common import (
     CollaborationSchemaV1,
@@ -20,7 +20,7 @@ def test_collaboration_with_suffix_returns_empty_if_value_has_no_suffix():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_collaboration_with_suffix_returns_value_if_value_has_suffix():
@@ -30,7 +30,7 @@ def test_collaboration_with_suffix_returns_value_if_value_has_suffix():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_collaboration_returns_empty_if_value_has_suffix():
@@ -40,7 +40,7 @@ def test_collaboration_returns_empty_if_value_has_suffix():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_collaboration_returns_value_if_value_has_no_suffix():
@@ -50,4 +50,4 @@ def test_collaboration_returns_value_if_value_has_no_suffix():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)

--- a/backend/tests/unit/records/marshmallow/literature/common/test_conference_info_item.py
+++ b/backend/tests/unit/records/marshmallow/literature/common/test_conference_info_item.py
@@ -5,8 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
-
+import orjson
 from invenio_pidstore.errors import PIDDoesNotExistError
 from mock import patch
 
@@ -20,7 +19,7 @@ def test_returns_empty_if_conference_record_is_missing():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 @patch("inspirehep.records.api.base.InspireRecord.get_record_by_pid_value")
@@ -50,7 +49,7 @@ def test_returns_non_empty_fields_if_conference_record_found(
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def side_effect_get_record_by_pid_value(pid_value, pid_type):
@@ -74,7 +73,7 @@ def test_returns_empty_if_conference_record_not_found(mock_get_record_by_pid_val
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 @patch("inspirehep.records.api.base.InspireRecord.get_record_by_pid_value")
@@ -93,4 +92,4 @@ def test_returns_empty_if_titles_is_missing(mock_get_record_by_pid_value):
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)

--- a/backend/tests/unit/records/marshmallow/literature/common/test_doi.py
+++ b/backend/tests/unit/records/marshmallow/literature/common/test_doi.py
@@ -6,8 +6,7 @@
 # the terms of the MIT License; see LICENSE file for more details.
 
 
-import json
-
+import orjson
 from marshmallow import Schema, fields
 
 from inspirehep.records.marshmallow.literature.common import DOISchemaV1
@@ -23,7 +22,7 @@ def test_returns_value_and_material_for_doi():
     expected = {"value": "10.1016/j.nuclphysb.2017.05.003", "material": "publication"}
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_same_doi_value_from_different_source_is_ignored():
@@ -47,4 +46,4 @@ def test_same_doi_value_from_different_source_is_ignored():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)

--- a/backend/tests/unit/records/marshmallow/literature/common/test_external_system_identifier.py
+++ b/backend/tests/unit/records/marshmallow/literature/common/test_external_system_identifier.py
@@ -5,8 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
-
+import orjson
 from marshmallow import Schema, fields
 
 from inspirehep.records.marshmallow.literature.common import (
@@ -67,7 +66,7 @@ def test_all_schema_types_except_kekscan():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_takes_first_id_foreach_url_name():
@@ -94,7 +93,7 @@ def test_takes_first_id_foreach_url_name():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_takes_ids_that_have_configured_url():
@@ -121,7 +120,7 @@ def test_takes_ids_that_have_configured_url():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_kekscan_with_9_chars_value():
@@ -145,7 +144,7 @@ def test_kekscan_with_9_chars_value():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_kekscan_with_dashes():
@@ -169,7 +168,7 @@ def test_kekscan_with_dashes():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_kekscan_with_7_chars_value_that_does_not_start_with_19_and_20():
@@ -191,7 +190,7 @@ def test_kekscan_with_7_chars_value_that_does_not_start_with_19_and_20():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_kekscan_with_not_9_or_7_chars_is_ignored():
@@ -208,7 +207,7 @@ def test_kekscan_with_not_9_or_7_chars_is_ignored():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_works_without_many_is_true():
@@ -229,7 +228,7 @@ def test_works_without_many_is_true():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_returns_empty_without_many_is_true_if_does_not_have_configured_url():
@@ -247,4 +246,4 @@ def test_returns_empty_without_many_is_true_if_does_not_have_configured_url():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)

--- a/backend/tests/unit/records/marshmallow/literature/common/test_isbn.py
+++ b/backend/tests/unit/records/marshmallow/literature/common/test_isbn.py
@@ -5,7 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
+import orjson
 
 from inspirehep.records.marshmallow.literature.common import IsbnSchemaV1
 
@@ -17,7 +17,7 @@ def test_isbn_medium_online_becomes_eBook():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_isbn_medium_titleized_if_not_online():
@@ -27,7 +27,7 @@ def test_isbn_medium_titleized_if_not_online():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_none_fields():
@@ -37,4 +37,4 @@ def test_none_fields():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)

--- a/backend/tests/unit/records/marshmallow/literature/common/test_publication_info_item.py
+++ b/backend/tests/unit/records/marshmallow/literature/common/test_publication_info_item.py
@@ -5,8 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
-
+import orjson
 import pytest
 
 from inspirehep.records.marshmallow.literature.common import PublicationInfoItemSchemaV1
@@ -19,7 +18,7 @@ def test_returns_empty_if_display_fields_missing():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_returns_non_empty_fields_if_jonurnal_title_present():
@@ -29,7 +28,7 @@ def test_returns_non_empty_fields_if_jonurnal_title_present():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_returns_non_empty_fields_if_pubinfo_freetext_present():
@@ -39,4 +38,4 @@ def test_returns_non_empty_fields_if_pubinfo_freetext_present():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)

--- a/backend/tests/unit/records/marshmallow/literature/common/test_reference_item.py
+++ b/backend/tests/unit/records/marshmallow/literature/common/test_reference_item.py
@@ -5,9 +5,8 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
-
 import mock
+import orjson
 from inspire_schemas.api import load_schema, validate
 from marshmallow import Schema, fields
 
@@ -55,7 +54,7 @@ def test_returns_non_empty_fields(get_records_mock):
     }
     record = LiteratureRecord(dump)
     result = schema.dumps(record).data
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 @mock.patch("inspirehep.records.api.base.InspireRecord.get_records_by_pids")
@@ -66,7 +65,7 @@ def test_forces_collaborations_to_be_object_if_reference_not_linked(get_records_
 
     record = LiteratureRecord(dump)
     result = schema.dumps(record).data
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 @mock.patch("inspirehep.records.api.base.InspireRecord.get_records_by_pids")
@@ -85,7 +84,7 @@ def test_forces_collaborations_to_be_object_if_reference_not_linked_with_many_tr
     record = LiteratureRecord(dump)
     result = schema.dumps(record).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 @mock.patch("inspirehep.records.api.base.InspireRecord.get_records_by_pids")
@@ -97,7 +96,7 @@ def test_returns_empty_if_no_reference_or_record_field(get_records_mock):
     record = LiteratureRecord(dump)
     result = schema.dumps(record).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 @mock.patch("inspirehep.records.api.base.InspireRecord.get_records_by_pids")
@@ -109,7 +108,7 @@ def test_returns_empty_if_empty_reference_or_record_field(get_records_mock):
     record = LiteratureRecord(dump)
     result = schema.dumps(record).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 @mock.patch("inspirehep.records.api.base.InspireRecord.get_records_by_pids")
@@ -121,7 +120,7 @@ def test_returns_non_empty_fields_if_some_fields_missing(get_records_mock):
     record = LiteratureRecord(dump)
     result = schema.dumps(record).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 @mock.patch("inspirehep.records.api.base.InspireRecord.get_records_by_pids")
@@ -137,7 +136,7 @@ def test_returns_no_misc_if_title_persent(get_records_mock):
     record = LiteratureRecord(dump)
     result = schema.dumps(record).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 @mock.patch(
@@ -174,7 +173,7 @@ def test_returns_no_misc_if_titles_persent_in_the_resolved_record(
     assert validate([dump], subschema) is None
 
     result = schema.dumps(dump).data
-    assert "misc" not in json.loads(result)
+    assert "misc" not in orjson.loads(result)
 
 
 @mock.patch("inspirehep.records.api.base.InspireRecord.get_records_by_pids")
@@ -191,7 +190,7 @@ def test_returns_only_first_misc(get_records_mock):
     record = LiteratureRecord(dump)
     result = schema.dumps(record).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 @mock.patch(
@@ -215,7 +214,7 @@ def test_returns_dois_from_the_resolved_record(mock_get_linked_records_in_field)
         "dois": [{"value": "10.1103/PhysRevD.94.054021"}],
     }
     result = schema.dumps(dump).data
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 @mock.patch(
@@ -241,4 +240,4 @@ def test_returns_arxiv_eprints_from_the_resolved_record(
 
     expected = {"control_number": 123, "arxiv_eprint": [{"value": "1606.09129"}]}
     result = schema.dumps(dump).data
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)

--- a/backend/tests/unit/records/marshmallow/literature/common/test_thesis_info.py
+++ b/backend/tests/unit/records/marshmallow/literature/common/test_thesis_info.py
@@ -5,9 +5,8 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
-
 import mock
+import orjson
 
 from inspirehep.records.marshmallow.literature.common import ThesisInfoSchemaV1
 
@@ -19,7 +18,7 @@ def test_degree_type_phd_becomes_PhD():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_degree_type_titleized_if_not_phd():
@@ -29,7 +28,7 @@ def test_degree_type_titleized_if_not_phd():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_none_fields():
@@ -39,7 +38,7 @@ def test_none_fields():
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 @mock.patch("inspirehep.records.marshmallow.literature.common.thesis_info.format_date")
@@ -51,7 +50,7 @@ def test_formatted_date(format_date):
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 @mock.patch("inspirehep.records.marshmallow.literature.common.thesis_info.format_date")
@@ -63,4 +62,4 @@ def test_formatted_defense_date(format_date):
 
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)

--- a/backend/tests/unit/records/marshmallow/literature/test_authors_schema.py
+++ b/backend/tests/unit/records/marshmallow/literature/test_authors_schema.py
@@ -5,8 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
-
+import orjson
 from helpers.providers.faker import faker
 
 from inspirehep.records.marshmallow.literature import LiteratureAuthorsSchema
@@ -48,7 +47,7 @@ def test_authors_schema():
         ],
         "collaborations": [{"value": "LHCb"}],
     }
-    result = json.loads(schema.dumps(data).data)
+    result = orjson.loads(schema.dumps(data).data)
     assert expected == result
 
 
@@ -60,7 +59,7 @@ def test_authors_schema_without_authors():
     data = faker.record("lit", data=data)
 
     expected = {"collaborations": [{"value": "LHCb"}]}
-    result = json.loads(schema.dumps(data).data)
+    result = orjson.loads(schema.dumps(data).data)
     assert expected == result
 
 
@@ -68,5 +67,5 @@ def test_authors_schema_without_authors_and_collaborations():
     schema = LiteratureAuthorsSchema()
     data = faker.record("lit")
     expected = {"authors": [], "collaborations": [], "supervisors": []}
-    result = json.loads(schema.dumps(data).data)
+    result = orjson.loads(schema.dumps(data).data)
     assert expected == result

--- a/backend/tests/unit/records/marshmallow/literature/test_base_schema.py
+++ b/backend/tests/unit/records/marshmallow/literature/test_base_schema.py
@@ -5,8 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
-
+import orjson
 from helpers.providers.faker import faker
 
 from inspirehep.records.marshmallow.literature import LiteratureListWrappedSchema
@@ -33,7 +32,7 @@ def test_literature_related_records():
 
 def test_literature_ui_schema():
     data_record = faker.record("lit")
-    data_record_json = json.dumps(data_record)
+    data_record_json = orjson.dumps(data_record)
     data = {"metadata": {"_ui_display": data_record_json}}
     expected_result = {"metadata": data_record}
     result = LiteratureListWrappedSchema().dump(data).data
@@ -43,7 +42,7 @@ def test_literature_ui_schema():
 
 def test_literature_ui_schema_missing_ui_display_field():
     data_record = faker.record("lit")
-    data_record_json = json.dumps(data_record)
+    data_record_json = orjson.dumps(data_record)
     data = {"metadata": {"NOT_A_UI_DISPLAY_FIELD": data_record_json}}
     expected_result = {"metadata": {}}
     result = LiteratureListWrappedSchema().dump(data).data
@@ -85,7 +84,7 @@ def test_literature_ui_schema_hides_emails_from_author_list():
 
     data = {"authors": authors}
     data_record = faker.record("lit", data=data)
-    data_record_json = json.dumps(data_record)
+    data_record_json = orjson.dumps(data_record)
     data = {"metadata": {"_ui_display": data_record_json}}
     result = LiteratureListWrappedSchema().dump(data).data
 
@@ -97,7 +96,7 @@ def test_literature_ui_schema_hides_acquisition_source():
 
     data = {"acquisition_source": acquisition_source}
     data_record = faker.record("lit", data=data)
-    data_record_json = json.dumps(data_record)
+    data_record_json = orjson.dumps(data_record)
     data = {"metadata": {"_ui_display": data_record_json}}
     result = LiteratureListWrappedSchema().dump(data).data
 

--- a/backend/tests/unit/records/marshmallow/literature/test_es_schema.py
+++ b/backend/tests/unit/records/marshmallow/literature/test_es_schema.py
@@ -5,8 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
-
+import orjson
 from helpers.providers.faker import faker
 from mock import patch
 
@@ -26,7 +25,7 @@ def test_es_schema_removes_supervisors_from_authors(mock_referenced_authors):
     data = {"authors": authors}
     data = faker.record("lit", data=data)
     expected_author = "Frank Castle"
-    result = json.loads(schema.dumps(data).data)["authors"]
+    result = orjson.loads(schema.dumps(data).data)["authors"]
     assert len(result) == 1
     assert expected_author == result[0]["full_name"]
 
@@ -44,5 +43,5 @@ def test_es_schema_removes_supervisors_from_facet_author_name(mock_referenced_au
     data = {"authors": authors}
     data = faker.record("lit", data=data)
     expected_facet_author_name = ["NOREC_Frank Castle"]
-    result = json.loads(schema.dumps(data).data)["facet_author_name"]
+    result = orjson.loads(schema.dumps(data).data)["facet_author_name"]
     assert expected_facet_author_name == result

--- a/backend/tests/unit/records/marshmallow/literature/test_latex_schema.py
+++ b/backend/tests/unit/records/marshmallow/literature/test_latex_schema.py
@@ -5,9 +5,9 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
 from copy import deepcopy
 
+import orjson
 from freezegun import freeze_time
 
 from inspirehep.records.marshmallow.literature.latex import LatexSchema
@@ -61,7 +61,7 @@ def test_full_schema():
         "today": TODAY,
         "notes": None,
     }
-    result = json.loads(schema.dumps(record).data)
+    result = orjson.loads(schema.dumps(record).data)
     assert expected == result
 
 
@@ -84,7 +84,7 @@ def test_authors_schema():
         "Jimmy",
         "A.~M.~E.~Dinkelbach",
     ]
-    result = json.loads(schema.dumps(record).data)
+    result = orjson.loads(schema.dumps(record).data)
     assert expected == result["authors"]
 
 
@@ -112,7 +112,7 @@ def test_publication_info_schema():
         "artid": "17920",
         "year": "2014",
     }
-    result = json.loads(schema.dumps(record).data)
+    result = orjson.loads(schema.dumps(record).data)
     assert expected == result["publication_info"]
 
 
@@ -137,7 +137,7 @@ def test_publication_info_does_not_generate_page_range_with_page_end():
         "artid": "17920",
         "year": "2014",
     }
-    result = json.loads(schema.dumps(record).data)
+    result = orjson.loads(schema.dumps(record).data)
     assert expected == result["publication_info"]
 
 
@@ -163,7 +163,7 @@ def test_publication_info_generates_page_range_with_page_start():
         "artid": "17920",
         "year": "2014",
     }
-    result = json.loads(schema.dumps(record).data)
+    result = orjson.loads(schema.dumps(record).data)
     assert expected == result["publication_info"]
 
 
@@ -189,7 +189,7 @@ def test_publication_info_without_journal_title_schema():
         "artid": "17920",
         "year": "2014",
     }
-    result = json.loads(schema.dumps(record).data)
+    result = orjson.loads(schema.dumps(record).data)
     assert expected == result["publication_info"]
 
 
@@ -197,7 +197,7 @@ def test_schema_takes_control_number_when_texkeys_not_present():
     schema = LatexSchema()
     record = {"control_number": "123456"}
     expected = "123456"
-    result = json.loads(schema.dumps(record).data)
+    result = orjson.loads(schema.dumps(record).data)
     assert expected == result["texkeys"]
 
 
@@ -235,7 +235,7 @@ def test_schema_gets_erratum():
     expected = deepcopy(record["publication_info"][1:])
     expected[0]["journal_title"] = "Phys. Rev. D"
     expected[1]["journal_title"] = "Phys. Rev. C"
-    result = json.loads(schema.dumps(record).data)
+    result = orjson.loads(schema.dumps(record).data)
 
     assert expected == result["notes"]
 
@@ -260,7 +260,7 @@ def test_schema_handles_missing_info_in_erratum():
 
     expected = deepcopy(record["publication_info"][1:])
     expected[1]["journal_title"] = "Phys. Rev. D"
-    result = json.loads(schema.dumps(record).data)
+    result = orjson.loads(schema.dumps(record).data)
 
     assert expected == result["notes"]
 
@@ -278,6 +278,6 @@ def test_schema_replaces_underscore_in_doi():
         {"value": "10.1142/9789811219313\\_0086"},
         {"source": "Springer", "value": "10.1007/978-981-15-6292-1\\_4"},
     ]
-    result = json.loads(schema.dumps(record).data)
+    result = orjson.loads(schema.dumps(record).data)
 
     assert expected == result["dois"]

--- a/backend/tests/unit/records/marshmallow/literature/test_references_schema.py
+++ b/backend/tests/unit/records/marshmallow/literature/test_references_schema.py
@@ -5,7 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
+import orjson
 
 from inspirehep.records.marshmallow.literature import LiteratureReferencesSchema
 
@@ -14,5 +14,5 @@ def test_references_schema_without_references():
     schema = LiteratureReferencesSchema()
     record = {"titles": [{"title": "Jessica Jones"}]}
     expected = {"references": []}
-    result = json.loads(schema.dumps(record).data)
+    result = orjson.loads(schema.dumps(record).data)
     assert expected == result

--- a/backend/tests/unit/records/marshmallow/seminars/common/test_speaker.py
+++ b/backend/tests/unit/records/marshmallow/seminars/common/test_speaker.py
@@ -5,7 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-import json
+import orjson
 
 from inspirehep.records.marshmallow.seminars.common.speaker import SpeakerSchemaV1
 
@@ -17,7 +17,7 @@ def test_speaker_with_first_and_last_name():
     expected = {"name": "Castle, Frank", "first_name": "Frank", "last_name": "Castle"}
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_speaker_without_last_name():
@@ -27,7 +27,7 @@ def test_speaker_without_last_name():
     expected = {"name": "Frank Castle", "first_name": "Frank Castle"}
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)
 
 
 def test_speaker():
@@ -79,4 +79,4 @@ def test_speaker():
     }
     result = schema.dumps(dump).data
 
-    assert expected == json.loads(result)
+    assert expected == orjson.loads(result)

--- a/backend/tests/unit/test_serializers.py
+++ b/backend/tests/unit/test_serializers.py
@@ -1,5 +1,4 @@
-import json
-
+import orjson
 from invenio_pidstore.models import PersistentIdentifier
 from marshmallow import Schema, fields
 
@@ -34,7 +33,7 @@ def test_uses_first_schema_that_returns_true_for_condition_that_uses_data():
             (lambda data: 3 in data["metadata"]["types"], Schema3),
         ]
     )
-    serialized = json.loads(
+    serialized = orjson.loads(
         serializer.serialize(
             PersistentIdentifier(pid_type="recid", pid_value="1"), InspireRecord(data)
         )
@@ -59,7 +58,7 @@ def test_first_conditionless_schema_if_others_do_not_return_true():
     serializer = ConditionalMultiSchemaJSONSerializer(
         [(lambda _: False, Schema1), (None, Schema2)]
     )
-    serialized = json.loads(
+    serialized = orjson.loads(
         serializer.serialize(
             PersistentIdentifier(pid_type="recid", pid_value="1"), InspireRecord(data)
         )


### PR DESCRIPTION
* inspirehep: Replaced all calls for json to orjson
* sqlalchemy: Replaced json serializer to use orjson
* jsonify: Replace flask jsonify with inspirehep jsonify which is using
orjson
* es: Replace JSONSerializer with our json serializer which is using
orjson

* Inspire Hackaton