### PR TITLE
search: exclude RPP based on flag-only

### DIFF
--- a/backend/inspirehep/search/aggregations.py
+++ b/backend/inspirehep/search/aggregations.py
@@ -239,16 +239,6 @@ def hep_rpp(order, title="Exclude RPP", agg_type="checkbox"):
                         "bool": {
                             "must_not": [
                                 {"match": {"rpp": "true"}},
-                                # TODO Remove this clause after all RPP records have been converted,
-                                # feature flag can't be used as this gets imported in the config
-                                {
-                                    "match": {
-                                        "titles.full_title": {
-                                            "query": "RPP",
-                                            "operator": "and",
-                                        }
-                                    }
-                                },
                             ]
                         }
                     }

--- a/backend/tests/integration/records/views/test_views_literature.py
+++ b/backend/tests/integration/records/views/test_views_literature.py
@@ -674,29 +674,6 @@ def test_literature_citation_annual_summary_for_many_records(inspire_app):
     assert response.json["aggregations"]["citations_by_year"] == expected_response
 
 
-def test_literature_rpp_facet(inspire_app):
-    rpp = create_record("lit", data={"rpp": True})
-
-    with inspire_app.test_client() as client:
-        response = client.get("/literature/facets")
-
-    assert response.json["aggregations"]["rpp"]["buckets"] == []
-
-    not_rpp = create_record("lit")
-
-    with inspire_app.test_client() as client:
-        response = client.get("/literature/facets")
-
-    expected = [
-        {
-            "doc_count": 1,
-            "key": "Exclude Review of Particle Physics",
-        }
-    ]
-
-    assert response.json["aggregations"]["rpp"]["buckets"] == expected
-
-
 def test_literature_search_user_does_not_get_fermilab_collection(inspire_app):
     data = {
         "$schema": "http://localhost:5000/schemas/records/hep.json",

--- a/backend/tests/integration/search/test_aggregations.py
+++ b/backend/tests/integration/search/test_aggregations.py
@@ -43,7 +43,7 @@ def test_hep_rpp_aggregation_and_filter(inspire_app, override_config):
     with override_config(**config):
         data = {"titles": [{"title": "This is my title"}]}
         expected_record = create_record("lit", data)
-        data = {"titles": [{"title": "RPP"}]}
+        data = {"rpp": True}
         create_record("lit", data)
         with inspire_app.test_client() as client:
             response = client.get("/literature/facets").json


### PR DESCRIPTION
All the metadata of the records has been modified to conform to the new
way of indicating RPP, so we can remove the old way.