### PR TITLE
poetry: update to v1.1.6

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Build and push
         uses: ./.github/actions/backend-build
         with:
-          lock-hash: ${{ hashFiles('backend/poetry.lock') }}
+          lock-hash: ${{ hashFiles('backend/poetry.lock', 'backend/pyproject.yaml', 'backend/Dockerfile') }}
 
   ui_build:
     name: UI build

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -26,7 +26,7 @@ RUN update-ca-certificates \
 RUN apt update && apt install poppler-utils -y
 
 ARG POETRY_VERSION
-ENV POETRY_VERSION="${POETRY_VERSION:-1.0.10}"
+ENV POETRY_VERSION="${POETRY_VERSION:-1.1.6}"
 RUN curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py \
   | python - --version "${POETRY_VERSION}" \
  && poetry --version

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -228,4 +228,4 @@ norecursedirs = "tests/integration/orcid/helpers"
 
 [build-system]
 requires = ["poetry_core>=1.0.0"]
-build-backend = "poetry.masonry.api"
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
* Also makes the Github CI cache depend on `Dockerfile` and
  `pyproject.toml` to avoid incorrect caching as happened during the
  Python 3.6 to 3.8 transition.
* Ref #1849.