### PR TITLE
record-editor: fix for loading author record issue.

### DIFF
--- a/record-editor/src/app/shared/config/authors.config.ts
+++ b/record-editor/src/app/shared/config/authors.config.ts
@@ -64,7 +64,6 @@ export const authors: JsonEditorConfig = {
             'start_date',
             'end_date',
             'rank',
-            'record',
             'hidden',
             'curated_relation',
           ],


### PR DESCRIPTION
`record` field removed from always show since some positions might have no record reference.
Ref: #2025