### PR TITLE
ui: bug in select all checkbox in authors

### DIFF
--- a/ui/src/authors/components/PublicationsSelect.jsx
+++ b/ui/src/authors/components/PublicationsSelect.jsx
@@ -10,6 +10,7 @@ function PublicationsSelect({
   claimed,
   canClaim,
   disabled,
+  checked,
 }) {
   const onChange = (event) => {
     onSelectPapers(event);
@@ -28,6 +29,7 @@ function PublicationsSelect({
         onChange(event);
       }}
       disabled={disabled}
+      checked={checked}
     />
   );
 }
@@ -40,6 +42,7 @@ PublicationsSelect.propTypes = {
   onSelectUnclaimedPapers: PropTypes.func.isRequired,
   onSelectPapers: PropTypes.func.isRequired,
   disabled: PropTypes.bool,
+  checked: PropTypes.bool,
 };
 
 export default PublicationsSelect;

--- a/ui/src/authors/components/__tests__/PublicationsSelect.test.jsx
+++ b/ui/src/authors/components/__tests__/PublicationsSelect.test.jsx
@@ -27,4 +27,40 @@ describe('PublicationsSelect', () => {
     expect(onSelectClaimedPapers).toHaveBeenCalled();
     expect(onSelectPapers).toHaveBeenCalled();
   });
+  it('renders checked when selected', () => {
+    const onSelectPapersUserCanNotClaim = jest.fn();
+    const onSelectClaimedPapers = jest.fn();
+    const onSelectUnclaimedPapers = jest.fn();
+    const onSelectPapers = jest.fn();
+    const wrapper = shallow(
+      <PublicationsSelect
+        claimed
+        checked
+        canClaim={false}
+        onSelectPapersUserCanNotClaim={onSelectPapersUserCanNotClaim}
+        onSelectClaimedPapers={onSelectClaimedPapers}
+        onSelectUnclaimedPapers={onSelectUnclaimedPapers}
+        onSelectPapers={onSelectPapers}
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+  it('renders unchecked when not selected', () => {
+    const onSelectPapersUserCanNotClaim = jest.fn();
+    const onSelectClaimedPapers = jest.fn();
+    const onSelectUnclaimedPapers = jest.fn();
+    const onSelectPapers = jest.fn();
+    const wrapper = shallow(
+      <PublicationsSelect
+        claimed
+        checked={false}
+        canClaim={false}
+        onSelectPapersUserCanNotClaim={onSelectPapersUserCanNotClaim}
+        onSelectClaimedPapers={onSelectClaimedPapers}
+        onSelectUnclaimedPapers={onSelectUnclaimedPapers}
+        onSelectPapers={onSelectPapers}
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/ui/src/authors/components/__tests__/__snapshots__/PublicationsSelect.test.jsx.snap
+++ b/ui/src/authors/components/__tests__/__snapshots__/PublicationsSelect.test.jsx.snap
@@ -1,5 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`PublicationsSelect renders checked when selected 1`] = `
+<Checkbox
+  checked={true}
+  indeterminate={false}
+  onChange={[Function]}
+/>
+`;
+
+exports[`PublicationsSelect renders checked when selected 2`] = `
+<Checkbox
+  checked={true}
+  indeterminate={false}
+  onChange={[Function]}
+/>
+`;
+
+exports[`PublicationsSelect renders unchecked when not selected 1`] = `
+<Checkbox
+  checked={false}
+  indeterminate={false}
+  onChange={[Function]}
+/>
+`;
+
 exports[`PublicationsSelect sets publication selection on checkbox change 1`] = `
 <Checkbox
   indeterminate={false}

--- a/ui/src/authors/containers/PublicationSelectContainer.jsx
+++ b/ui/src/authors/containers/PublicationSelectContainer.jsx
@@ -27,7 +27,6 @@ const dispatchToProps = (dispatch, { recordId }) => ({
       setPublicationsUnclaimedSelection([recordId], event.target.checked)
     );
   },
-
   onSelectPapers(event) {
     dispatch(setPublicationSelection([recordId], event.target.checked));
   },

--- a/ui/src/authors/containers/__tests__/PublicationSelectContainer.test.jsx
+++ b/ui/src/authors/containers/__tests__/PublicationSelectContainer.test.jsx
@@ -2,9 +2,13 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
 import { Checkbox } from 'antd';
+import { fromJS } from 'immutable';
 
-import { getStore, mockActionCreator } from '../../../fixtures/store';
+import { initialState } from '../../../reducers/authors';
+import PublicationsSelect from '../../components/PublicationsSelect';
+import { getStore, mockActionCreator, getStoreWithState } from '../../../fixtures/store';
 import PublicationSelectContainer from '../PublicationSelectContainer';
+
 import {
   setPublicationSelection,
   setPublicationsClaimedSelection,
@@ -33,7 +37,7 @@ describe('PublicationSelectContainer', () => {
     ];
     expect(store.getActions()).toEqual(expectedActions);
   });
-  it('dispatches setPublicationsCanNotClaimSelection on change wneh user can not claim', () => {
+  it('dispatches setPublicationsCanNotClaimSelection on change when user can not claim', () => {
     const store = getStore();
     const wrapper = mount(
       <Provider store={store}>
@@ -61,5 +65,35 @@ describe('PublicationSelectContainer', () => {
       setPublicationsUnclaimedSelection([1], true),
     ];
     expect(store.getActions()).toEqual(expectedActions);
+  });
+  it('passes correct checked value if publication is selected', () => {
+    const store = getStoreWithState({
+      authors: fromJS({
+        ...initialState,
+        publicationSelection: [1, 2, 3],
+      }),
+    });
+    const wrapper = mount(
+      <Provider store={store}>
+        <PublicationSelectContainer recordId={1} claimed canClaim />
+      </Provider>
+    );
+    
+    expect(wrapper.find(PublicationsSelect).prop('checked')).toBe(true);
+  });
+  it('renders checkbox checked when select all is checked', () => {
+    const store = getStoreWithState({
+      authors: fromJS({
+        ...initialState,
+        publicationSelection: [1, 2, 3],
+      }),
+    });
+    const wrapper = mount(
+      <Provider store={store}>
+        <PublicationSelectContainer recordId={1} claimed canClaim />
+      </Provider>
+    );
+
+    expect(wrapper).toMatchSnapshot();
   });
 });

--- a/ui/src/authors/containers/__tests__/__snapshots__/PublicationSelectContainer.test.jsx.snap
+++ b/ui/src/authors/containers/__tests__/__snapshots__/PublicationSelectContainer.test.jsx.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PublicationSelectContainer checks all checkboxes when select all is checked 1`] = `
+<label
+  className="ant-checkbox-wrapper ant-checkbox-wrapper-checked"
+>
+  <span
+    className="ant-checkbox ant-checkbox-checked"
+    style={Object {}}
+  >
+    <input
+      checked={true}
+      className="ant-checkbox-input"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      type="checkbox"
+    />
+    <span
+      className="ant-checkbox-inner"
+    />
+  </span>
+</label>
+`;
+
+exports[`PublicationSelectContainer renders checkbox checked when select all is checked 1`] = `
+<label
+  className="ant-checkbox-wrapper ant-checkbox-wrapper-checked"
+>
+  <span
+    className="ant-checkbox ant-checkbox-checked"
+    style={Object {}}
+  >
+    <input
+      checked={true}
+      className="ant-checkbox-input"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      type="checkbox"
+    />
+    <span
+      className="ant-checkbox-inner"
+    />
+  </span>
+</label>
+`;


### PR DESCRIPTION
* 'select all' checkbox in authors didn't highlight selected papers checkboxes because of missing checked prop. Added missing prop to PublicationsSelect component

* ref: cern-sis/issues-inspire#16