### PR TITLE
UI: fix for broken styles in 

### DIFF
--- a/ui/src/common/layouts/Header/HeaderMenu.jsx
+++ b/ui/src/common/layouts/Header/HeaderMenu.jsx
@@ -69,14 +69,14 @@ class HeaderMenu extends Component {
             <Link to={SUBMISSIONS_CONFERENCE}>Conference</Link>
           </Menu.Item>
           { isCatalogerLoggedIn && (
-            <>
-              <Menu.Item key="submit.institution">
-                <Link to={SUBMISSIONS_INSTITUTION}>Institution</Link>
-              </Menu.Item>)
-              <Menu.Item key="submit.experiment">
-                <Link to={SUBMISSIONS_EXPERIMENT}>Experiment</Link>
-              </Menu.Item>
-            </>)
+            <Menu.Item key="submit.institution">
+              <Link to={SUBMISSIONS_INSTITUTION}>Institution</Link>
+            </Menu.Item>)
+          }
+          { isCatalogerLoggedIn && (
+            <Menu.Item key="submit.experiment">
+              <Link to={SUBMISSIONS_EXPERIMENT}>Experiment</Link>
+            </Menu.Item>)
           }
         </Menu.SubMenu>
         <Menu.Item key="login-logout">


### PR DESCRIPTION
Wrapping menu items in react fragments caused ant not to recognise them as menu items and gave them class 'undefined-item' instead of 'ant-menu-item' which resulted in breaking the CSS. 