### PR TITLE
ui: allow claiming mix of claimed and unclaimed papers

### DIFF
--- a/ui/src/authors/components/PublicationsSelect.jsx
+++ b/ui/src/authors/components/PublicationsSelect.jsx
@@ -19,10 +19,12 @@ function PublicationsSelect({
     }
     if (claimed) {
       onSelectClaimedPapers(event);
-    } else if (!claimed && canClaim) {
+    }
+    if (!claimed) {
       onSelectUnclaimedPapers(event);
     }
   };
+
   return (
     <Checkbox
       onChange={(event) => {


### PR DESCRIPTION
* when selecting claimed and unclaimed papers by checking individual checkboxes, the behaviour should be the same as when using select all checkbox (claiming mixed papers is then allowed)

* ref: cern-sis/issues-inspire#57