### PR TITLE
ui: fix for always plural version of label and tooltip

### DIFF
--- a/ui/src/authors/components/AssignAction.jsx
+++ b/ui/src/authors/components/AssignAction.jsx
@@ -76,4 +76,8 @@ AssignAction.propTypes = {
   numberOfSelected: PropTypes.number,
 };
 
+AssignAction.defaultProps = {
+  numberOfSelected: 1,
+};
+
 export default AssignAction;

--- a/ui/src/authors/components/AssignOwnProfileAction.jsx
+++ b/ui/src/authors/components/AssignOwnProfileAction.jsx
@@ -13,6 +13,7 @@ function AssignOwnProfileAction({
   disabled,
   disabledAssignAction,
   numberOfSelected,
+  claimingTooltip,
 }) {
   const currentAuthorId = Number(useParams().id);
   const onSelfAssign = useCallback(() => {
@@ -55,7 +56,7 @@ function AssignOwnProfileAction({
           <Tooltip
             title={
               disabledAssignAction
-                ? 'All selected papers are already claimed!'
+                ? claimingTooltip
                 : null
             }
           >
@@ -81,6 +82,12 @@ AssignOwnProfileAction.propTypes = {
   disabled: PropTypes.bool,
   disabledAssignAction: PropTypes.bool,
   numberOfSelected: PropTypes.number,
+  claimingTooltip: PropTypes.string,
+};
+
+AssignOwnProfileAction.defaultProps = {
+  claimingTooltip: 'This paper is already claimed',
+  numberOfSelected: 1,
 };
 
 export default AssignOwnProfileAction;

--- a/ui/src/authors/components/__tests__/__snapshots__/AssignAction.test.jsx.snap
+++ b/ui/src/authors/components/__tests__/__snapshots__/AssignAction.test.jsx.snap
@@ -33,14 +33,14 @@ exports[`AssignAction renders 1`] = `
       key="assign-self"
       onClick={[Function]}
     >
-      These are my papers
+      This is my paper
     </MenuItem>
     <MenuItem
       data-test-id="unassign"
       key="unassign"
       onClick={[Function]}
     >
-      These are not my papers
+      This is not my paper
     </MenuItem>
     <MenuItem
       data-test-id="assign-another"
@@ -86,14 +86,14 @@ exports[`AssignAction renders disabled 1`] = `
       key="assign-self"
       onClick={[Function]}
     >
-      These are my papers
+      This is my paper
     </MenuItem>
     <MenuItem
       data-test-id="unassign"
       key="unassign"
       onClick={[Function]}
     >
-      These are not my papers
+      This is not my paper
     </MenuItem>
     <MenuItem
       data-test-id="assign-another"

--- a/ui/src/authors/components/__tests__/__snapshots__/AssignOwnProfileAction.test.jsx.snap
+++ b/ui/src/authors/components/__tests__/__snapshots__/AssignOwnProfileAction.test.jsx.snap
@@ -43,7 +43,7 @@ exports[`AssignOwnProfileAction renders 1`] = `
         transitionName="zoom-big-fast"
       >
         <p>
-          These are my papers
+          This is my paper
         </p>
       </Tooltip>
     </MenuItem>
@@ -52,7 +52,7 @@ exports[`AssignOwnProfileAction renders 1`] = `
       key="unassign"
       onClick={[Function]}
     >
-      These are not my papers
+      This is not my paper
     </MenuItem>
   </DropdownMenu>
 </ListItemAction>
@@ -98,11 +98,11 @@ exports[`AssignOwnProfileAction renders disabled 1`] = `
         mouseEnterDelay={0.1}
         mouseLeaveDelay={0.1}
         placement="top"
-        title="All selected papers are already claimed!"
+        title="This paper is already claimed"
         transitionName="zoom-big-fast"
       >
         <p>
-          These are my papers
+          This is my paper
         </p>
       </Tooltip>
     </MenuItem>
@@ -111,7 +111,7 @@ exports[`AssignOwnProfileAction renders disabled 1`] = `
       key="unassign"
       onClick={[Function]}
     >
-      These are not my papers
+      This is not my paper
     </MenuItem>
   </DropdownMenu>
 </ListItemAction>
@@ -273,11 +273,11 @@ exports[`AssignOwnProfileAction renders with disabled assign action 1`] = `
         mouseEnterDelay={0.1}
         mouseLeaveDelay={0.1}
         placement="top"
-        title="All selected papers are already claimed!"
+        title="This paper is already claimed"
         transitionName="zoom-big-fast"
       >
         <p>
-          These are my papers
+          This is my paper
         </p>
       </Tooltip>
     </MenuItem>
@@ -286,7 +286,7 @@ exports[`AssignOwnProfileAction renders with disabled assign action 1`] = `
       key="unassign"
       onClick={[Function]}
     >
-      These are not my papers
+      This is not my paper
     </MenuItem>
   </DropdownMenu>
 </ListItemAction>

--- a/ui/src/authors/containers/AssignAllActionContainer.jsx
+++ b/ui/src/authors/containers/AssignAllActionContainer.jsx
@@ -6,6 +6,7 @@ import { setAssignDrawerVisibility, assignPapers } from '../../actions/authors';
 const stateToProps = state => ({
   disabled: state.authors.get('publicationSelection').size === 0,
   numberOfSelected: state.authors.get('publicationSelection').size,
+  claimingTooltip: 'All selected papers are already claimed',
 });
 
 const dispatchToProps = dispatch => ({

--- a/ui/src/authors/containers/AssignAllOwnProfileActionContainer.jsx
+++ b/ui/src/authors/containers/AssignAllOwnProfileActionContainer.jsx
@@ -9,6 +9,7 @@ const stateToProps = (state) => ({
     state.authors.get('publicationSelectionClaimed').size > 0 &&
     state.authors.get('publicationSelectionUnclaimed').size === 0,
   numberOfSelected: state.authors.get('publicationSelection').size,
+  claimingTooltip: 'All selected papers are already claimed',
 });
 
 const dispatchToProps = (dispatch) => ({


### PR DESCRIPTION
* on single paper claiming change plural version label and tooltip to singular

* ref: cern-sis/issues-inspire#55