### PR TITLE
release workflow: fix release step to use a correct tag name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,3 +90,4 @@ jobs:
         with:
           prerelease: false
           draft: false
+          tag_name: ${{ github.event.inputs.tag }}


### PR DESCRIPTION
* fix the release workflow:
  * action `softprops/action-gh-release@v1` by default uses `tag_name` equal to [`github.ref`](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) where `github.ref` seems not to be a tag for the event [`workflow_dispatch`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch) which is triggering workflow - instead, tag name is in the `github.event.inputs.tag` field