### PR TITLE
disambiguation cli: reduce group size for celery task & put group tasks in default queue

### DIFF
--- a/backend/tests/integration-async/disambiguation/test_disambiguation_cli.py
+++ b/backend/tests/integration-async/disambiguation/test_disambiguation_cli.py
@@ -63,7 +63,7 @@ def test_disambiguate_all(inspire_app, cli, clean_celery_session, override_confi
         )
         db.session.commit()
 
-        cli.invoke(["disambiguation", "not-disambiguated", "-bs", "2"])
+        cli.invoke(["disambiguation", "not-disambiguated", "-gs", "50", "-bs", "2"])
 
         def assert_disambiguation_cli():
             records = LiteratureSearch().get_records(record_uuids).execute()


### PR DESCRIPTION
* reduces group size for celery tasks since all the tasks in a group are applied in parallel
* sends tasks to the default queue in order to keep track of group tasks & disambiguation tasks better (now they end up in the same queue which is confusing)