### PR TITLE
ui: remove unnecesary use-resize-observer hook

### DIFF
--- a/e2e/cypress/support/index.js
+++ b/e2e/cypress/support/index.js
@@ -5,7 +5,7 @@ import './commands';
 
 const ALLOWED_UNCAUGHT_ERROR_MESSAGES = [
   "Cannot read property 'focus' of null", // TODO: explain why
-  'ResizeObserver loop limit exceeded',
+  "ResizeObserver loop limit exceeded",
   "ResizeObserver loop completed with undelivered notifications."
 ];
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -85,7 +85,6 @@
     "typescript": "^4.0.3",
     "use-async-effect": "^2.2.1",
     "use-media": "^1.4.0",
-    "use-resize-observer": "^4.0.0",
     "uuid": "^7.0.3",
     "yup": "^0.26.0"
   },

--- a/ui/src/common/layouts/Header/Header.jsx
+++ b/ui/src/common/layouts/Header/Header.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Layout, Row, Col } from 'antd';
 import PropTypes from 'prop-types';
-import useResizeObserver from 'use-resize-observer';
 
 import SearchBoxContainer from '../../containers/SearchBoxContainer';
 import './Header.less';
@@ -12,11 +11,9 @@ import CollectionsMenu from '../CollectionsMenu';
 import Banners from './Banners';
 
 function Header({ isHomePage, isSubmissionsPage, isBetaPage }) {
-  const [stickyContainerRef, , stickyContainerHeight] = useResizeObserver();
-
   return (
     <div className="__Header__">
-      <div ref={stickyContainerRef} className="sticky" data-test-id="sticky">
+      <div className="sticky" data-test-id="sticky">
         <Banners />
         {isBetaPage && <BetaRibbon />}
         <Layout.Header className="header">
@@ -48,7 +45,7 @@ function Header({ isHomePage, isSubmissionsPage, isBetaPage }) {
           </Row>
         </Layout.Header>
       </div>
-      <div className="non-sticky" style={{ marginTop: stickyContainerHeight }}>
+      <div className="non-sticky">
         <CollectionsMenu />
       </div>
     </div>

--- a/ui/src/common/layouts/Header/Header.less
+++ b/ui/src/common/layouts/Header/Header.less
@@ -32,12 +32,12 @@
 
   .non-sticky {
     background-color: @layout-header-background;
+    margin-top: 4rem;
 
     // remove the margin top for mobile
     // because .sticky is not stick anymore
     @media (max-width: @screen-xs-max) {
-      margin-top: -1px !important;
-      padding-top: 1px;
+      margin-top: 0;
     }
   }
 }

--- a/ui/src/common/layouts/Header/__tests__/__snapshots__/Header.test.jsx.snap
+++ b/ui/src/common/layouts/Header/__tests__/__snapshots__/Header.test.jsx.snap
@@ -85,11 +85,6 @@ exports[`Header renders with Banner and Ribbon if it is on beta page 1`] = `
   </div>
   <div
     className="non-sticky"
-    style={
-      Object {
-        "marginTop": 1,
-      }
-    }
   >
     <Connect(CollectionsMenu) />
   </div>
@@ -180,11 +175,6 @@ exports[`Header renders with search box if it is not on home or submission 1`] =
   </div>
   <div
     className="non-sticky"
-    style={
-      Object {
-        "marginTop": 1,
-      }
-    }
   >
     <Connect(CollectionsMenu) />
   </div>
@@ -271,11 +261,6 @@ exports[`Header renders without search box if it is on homepage \`/\` 1`] = `
   </div>
   <div
     className="non-sticky"
-    style={
-      Object {
-        "marginTop": 1,
-      }
-    }
   >
     <Connect(CollectionsMenu) />
   </div>
@@ -362,11 +347,6 @@ exports[`Header renders without search box if it is on submission page 1`] = `
   </div>
   <div
     className="non-sticky"
-    style={
-      Object {
-        "marginTop": 1,
-      }
-    }
   >
     <Connect(CollectionsMenu) />
   </div>

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -23,6 +23,7 @@ Sentry.init({
   dsn: getConfigFor('REACT_APP_SENTRY_DSN'),
   release: process.env.REACT_APP_VERSION,
   environment: getConfigFor('REACT_APP_SENTRY_ENVIRONMENT'),
+  ignoreErrors: ['ResizeObserver loop limit exceeded']
 });
 Sentry.setUser({ id: getClientId() });
 

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -11762,7 +11762,7 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
 
-resize-observer-polyfill@^1.5.0, resize-observer-polyfill@^1.5.1:
+resize-observer-polyfill@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
   integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
@@ -13304,13 +13304,6 @@ use-media@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/use-media/-/use-media-1.4.0.tgz#e777bf1f382a7aacabbd1f9ce3da2b62e58b2a98"
   integrity sha512-XsgyUAf3nhzZmEfhc5MqLHwyaPjs78bgytpVJ/xDl0TF4Bptf3vEpBNBBT/EIKOmsOc8UbuECq3mrP3mt1QANA==
-
-use-resize-observer@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/use-resize-observer/-/use-resize-observer-4.0.0.tgz#9976763c37658e84d6e4f1172e7c146816907ece"
-  integrity sha512-q97g2NISwPZ7a1Y2cbcoVePPaq7HuBu44rkWpzKZNmY8bV69MydaFLNsOSBOu7Jk7mdjiRL4C0/rAks8goLdhQ==
-  dependencies:
-    resize-observer-polyfill "^1.5.0"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
- remove use-resize-observer hook and use css instead
- ignore resize observer error in Sentry (as suggested [here](https://stackoverflow.com/questions/65732703/resizeobserver-loop-limit-exceeded-stop-exception))

* ref: cern-sis/issues-inspire#197