### PR TITLE
ui: remove force render parameter to trigger fetching searchAggregations

### DIFF
--- a/ui/src/authors/containers/DetailPageContainer/DetailPageContainer.tsx
+++ b/ui/src/authors/containers/DetailPageContainer/DetailPageContainer.tsx
@@ -211,7 +211,6 @@ function DetailPage({
                     </Tooltip>
                   }
                   key="2"
-                  forceRender
                 >
                   <ContentBox className="remove-top-border-of-card">
                     <AuthorCitationsContainer />


### PR DESCRIPTION
* restoring  lazy render after clicking on tabs in order to trigger fetching search aggregations 

* ref: cern-sis/issues-inspire#187