### PR TITLE
ui: keep error causing url in history

### DIFF
--- a/ui/src/errors/components/Error401.jsx
+++ b/ui/src/errors/components/Error401.jsx
@@ -4,10 +4,12 @@ import ErrorPage from './ErrorPage';
 
 class Error401 extends Component {
   render() {
+    const previousURL = document.referrer;
     return (
       <ErrorPage
         message="Sorry, you are not authorised to view this page."
         imageSrc={error401Image}
+        url={previousURL}
       />
     );
   }

--- a/ui/src/errors/components/Error404.jsx
+++ b/ui/src/errors/components/Error404.jsx
@@ -4,10 +4,12 @@ import ErrorPage from './ErrorPage';
 
 class Error404 extends Component {
   render() {
+    const previousURL = document.referrer;
     return (
       <ErrorPage
         message="Sorry, we were not able to find what you were looking for..."
         imageSrc={error404Image}
+        url={previousURL}
       />
     );
   }

--- a/ui/src/errors/components/Error500.jsx
+++ b/ui/src/errors/components/Error500.jsx
@@ -6,6 +6,7 @@ import GoBackLinkContainer from '../../common/containers/GoBackLinkContainer';
 
 class Error500 extends Component {
   render() {
+    const previousURL = document.referrer;
     return (
       <ErrorPage
         message="Something went wrong"
@@ -15,6 +16,7 @@ class Error500 extends Component {
           </span>
         }
         imageSrc={error500Image}
+        url={previousURL}
       />
     );
   }

--- a/ui/src/errors/components/ErrorAppCrash.jsx
+++ b/ui/src/errors/components/ErrorAppCrash.jsx
@@ -6,6 +6,7 @@ import ErrorPage from './ErrorPage';
 
 class ErrorAppCrash extends Component {
   render() {
+    const previousURL = document.referrer;
     return (
       <Row type="flex" justify="center">
         <ErrorPage
@@ -16,6 +17,7 @@ class ErrorAppCrash extends Component {
             </span>
           }
           imageSrc={error500Image}
+          url={previousURL}
         />
       </Row>
     );

--- a/ui/src/errors/components/ErrorPage.jsx
+++ b/ui/src/errors/components/ErrorPage.jsx
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Row, Col } from 'antd';
+import { Link } from 'react-router-dom';
 
 class ErrorPage extends Component {
   render() {
-    const { detail, message, imageSrc } = this.props;
+    const { detail, message, imageSrc, url } = this.props;
     return (
       <Col className="mt3 mb3" span={14} justify="center" align="middle">
         <Row>
@@ -16,6 +17,15 @@ class ErrorPage extends Component {
           <Row>
             <Col span={24}>
               <h3 className="f3 normal sm-f4">{detail}</h3>
+            </Col>
+          </Row>
+        )}
+        {url && (
+          <Row>
+            <Col span={24}>
+              <p className="f5 normal">
+                Redirected from: <Link to={url}>{url}</Link>
+              </p>
             </Col>
           </Row>
         )}

--- a/ui/src/errors/components/__tests__/__snapshots__/Error401.test.jsx.snap
+++ b/ui/src/errors/components/__tests__/__snapshots__/Error401.test.jsx.snap
@@ -5,5 +5,6 @@ exports[`Error401 renders Error401 with correct props 1`] = `
   detail={null}
   imageSrc="401.svg"
   message="Sorry, you are not authorised to view this page."
+  url=""
 />
 `;

--- a/ui/src/errors/components/__tests__/__snapshots__/Error404.test.jsx.snap
+++ b/ui/src/errors/components/__tests__/__snapshots__/Error404.test.jsx.snap
@@ -5,5 +5,6 @@ exports[`Error404 renders Error404 with correct props 1`] = `
   detail={null}
   imageSrc="404.svg"
   message="Sorry, we were not able to find what you were looking for..."
+  url=""
 />
 `;

--- a/ui/src/errors/components/__tests__/__snapshots__/Error500.test.jsx.snap
+++ b/ui/src/errors/components/__tests__/__snapshots__/Error500.test.jsx.snap
@@ -12,5 +12,6 @@ exports[`Error500 renders Error500 1`] = `
   }
   imageSrc="500.svg"
   message="Something went wrong"
+  url=""
 />
 `;

--- a/ui/src/errors/components/__tests__/__snapshots__/ErrorAppCrash.test.jsx.snap
+++ b/ui/src/errors/components/__tests__/__snapshots__/ErrorAppCrash.test.jsx.snap
@@ -19,6 +19,7 @@ exports[`ErrorAppCrash renders ErrorAppCrash 1`] = `
     }
     imageSrc="500.svg"
     message="Something went wrong"
+    url=""
   />
 </Row>
 `;

--- a/ui/src/middlewares/__tests__/redirectToErrorPage.test.js
+++ b/ui/src/middlewares/__tests__/redirectToErrorPage.test.js
@@ -7,10 +7,13 @@ describe('redirectToErrorPage middleware', () => {
   let mirrorNext;
   let dispatch;
   let mockDispatch;
+  let mockLocationAssign;
 
   beforeEach(() => {
     mirrorNext = jest.fn(value => value);
     mockDispatch = jest.fn();
+    // eslint-disable-next-line no-multi-assign
+    mockLocationAssign = window.location.assign = jest.fn();
     dispatch = middleware({ dispatch: mockDispatch })(mirrorNext);
   });
 
@@ -24,7 +27,7 @@ describe('redirectToErrorPage middleware', () => {
     };
     const result = dispatch(action);
     expect(result).toBe(action);
-    expect(mockDispatch).toHaveBeenCalledWith(replace(`${ERRORS}/500`));
+    expect(mockLocationAssign).toBeCalledWith(`${ERRORS}/500`);
   });
 
   it('only returns result of next(action) when not a redirectable error', () => {

--- a/ui/src/middlewares/redirectToErrorPage.js
+++ b/ui/src/middlewares/redirectToErrorPage.js
@@ -1,12 +1,15 @@
-import { replace } from 'connected-react-router';
 import { ERRORS } from '../common/routes';
 
-export default function({ dispatch }) {
+export default function() {
   return next => action => {
     const { meta } = action;
     if (meta && meta.redirectableError) {
       const { error } = action.payload;
-      dispatch(replace(`${ERRORS}/${error.status}`));
+
+      // INFO: 'push' and 'replace' methods from 'connected-react-router' 
+      // remove error causing url from history. To be able to keep in 
+      // and retrieve it from history in error pages we use window API
+      window.location.assign(`${ERRORS}/${error.status}`);
     }
     return next(action);
   };


### PR DESCRIPTION
* add error causing url to history and display it on error error pages

* ref: cern-sis/issues-inspire#196

<img width="882" alt="Screenshot 2023-01-23 at 14 31 42" src="https://user-images.githubusercontent.com/55505399/214055117-88ce0681-5e4a-4827-8374-6a1f173c3193.png">
