### PR TITLE
ui: gracefully handle search queries

### DIFF
--- a/ui/src/actions/search.ts
+++ b/ui/src/actions/search.ts
@@ -38,8 +38,13 @@ function searchSuccess(namespace: string, data: {}) {
 }
 
 function searchError(namespace: string, errorPayload: { error: Error }) {
-  const { redirectableError } =
+  let { redirectableError } = 
     searchConfig[namespace as keyof typeof searchConfig];
+
+  if (errorPayload.error.message === 'The syntax of the search query is invalid.') {
+    redirectableError = false;
+  }
+
   return {
     type: SEARCH_ERROR,
     payload: { ...errorPayload, namespace },

--- a/ui/src/literature/containers/SearchPageContainer.jsx
+++ b/ui/src/literature/containers/SearchPageContainer.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Row, Col } from 'antd';
+import { Row, Col, Empty } from 'antd';
+import { WarningOutlined } from '@ant-design/icons';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
@@ -16,32 +17,55 @@ const META_DESCRIPTION =
   'Find articles, conference papers, proceedings, books, theses, reviews, lectures and reports in High Energy Physics';
 const TITLE = 'Literature Search';
 
-export function SearchPage({ assignView, numberOfSelected }) {
+export function SearchPage({ assignView, numberOfSelected, error }) {
   return (
     <>
       <DocumentHead title={TITLE} description={META_DESCRIPTION} />
-      <Row>
-        <Col xs={24} lg={22} xl={20} xxl={18}>
-          <AssignViewContext.Provider value={assignView}>
-            <LiteratureSearchContainer
-              namespace={LITERATURE_NS}
-              noResultsTitle="0 Results"
-              page="Literature search"
-              noResultsDescription={
-                <em>
-                  Oops! You might want to check out our{' '}
-                  <LinkWithTargetBlank href={PAPER_SEARCH_URL}>
-                    search tips
-                  </LinkWithTargetBlank>
-                  .
-                </em>
+      {error ? (
+        <Row justify="center" className="mv3">
+          <Col xs={24} lg={12}>
+            <Empty
+              className="invalid-query"
+              image={
+                <WarningOutlined
+                />
               }
-              numberOfSelected={numberOfSelected}
-            />
-            {assignView && <AssignConferencesDrawerContainer />}
-          </AssignViewContext.Provider>
-        </Col>
-      </Row>
+              description="The search query is malformed"
+            >
+              <em>
+                Oops! You might want to check out our{' '}
+                <LinkWithTargetBlank href={PAPER_SEARCH_URL}>
+                  search tips
+                </LinkWithTargetBlank>
+                .
+              </em>
+            </Empty>
+          </Col>
+        </Row>
+      ) : (
+        <Row>
+          <Col xs={24} lg={22} xl={20} xxl={18}>
+            <AssignViewContext.Provider value={assignView}>
+              <LiteratureSearchContainer
+                namespace={LITERATURE_NS}
+                noResultsTitle="0 Results"
+                page="Literature search"
+                noResultsDescription={
+                  <em>
+                    Oops! You might want to check out our{' '}
+                    <LinkWithTargetBlank href={PAPER_SEARCH_URL}>
+                      search tips
+                    </LinkWithTargetBlank>
+                    .
+                  </em>
+                }
+                numberOfSelected={numberOfSelected}
+              />
+              {assignView && <AssignConferencesDrawerContainer />}
+            </AssignViewContext.Provider>
+          </Col>
+        </Row>
+      )}
     </>
   );
 }
@@ -56,6 +80,7 @@ const stateToProps = (state) => ({
     isSuperUser(state.user.getIn(['data', 'roles'])) ||
     isCataloger(state.user.getIn(['data', 'roles'])),
   numberOfSelected: state.literature.get('literatureSelection').size,
+  error: state.search.getIn(['namespaces', 'literature', 'error']),
 });
 
 const SearchPageContainer = connect(stateToProps)(SearchPage);

--- a/ui/src/literature/index.less
+++ b/ui/src/literature/index.less
@@ -1,3 +1,11 @@
 .__Literature__ {
   width: 100%;
+
+  .invalid-query {
+    .ant-empty-image {
+      margin-bottom: 2rem;
+      margin-top: 1rem;
+      font-size: 5rem; 
+    }
+  }
 }


### PR DESCRIPTION
* ref: cern-sis/issues-inspire#189

<img width="1440" alt="Screenshot 2023-01-24 at 14 02 55" src="https://user-images.githubusercontent.com/55505399/214299886-deed6ea5-14a6-4b27-8733-d5b17eb10eef.png">
