### PR TITLE
ui: fix for error in signup form

### DIFF
--- a/ui/src/jobs/components/SubscribeJobsForm.jsx
+++ b/ui/src/jobs/components/SubscribeJobsForm.jsx
@@ -25,7 +25,7 @@ const FULL_ROW = { span: 24 };
 
 function SubscribeJobsForm({ onSubmit }) {
   const renderForm = useCallback(
-    ({ isValid }) => (
+    ({ isValid, dirty }) => (
       <Form>
         <Field
           wrapperCol={FULL_ROW}
@@ -48,7 +48,7 @@ function SubscribeJobsForm({ onSubmit }) {
         />
         <Row type="flex" justify="end">
           <Col>
-            <Button disabled={!isValid} type="primary" htmlType="submit">
+            <Button disabled={!isValid || !dirty} type="primary" htmlType="submit">
               Subscribe
             </Button>
           </Col>
@@ -59,7 +59,7 @@ function SubscribeJobsForm({ onSubmit }) {
   );
 
   return (
-    <Formik validationSchema={SCHEMA} initialValues={{}} onSubmit={onSubmit}>
+    <Formik validationSchema={SCHEMA} initialValues={{}} onSubmit={onSubmit} validateOnChange={false}>
       {renderForm}
     </Formik>
   );

--- a/ui/src/jobs/components/__tests__/__snapshots__/SubscribeJobsForm.test.jsx.snap
+++ b/ui/src/jobs/components/__tests__/__snapshots__/SubscribeJobsForm.test.jsx.snap
@@ -39,7 +39,7 @@ exports[`SubscribeJobsForm renders 1`] = `
       "validateField": [Function],
       "validateForm": [Function],
       "validateOnBlur": true,
-      "validateOnChange": true,
+      "validateOnChange": false,
       "validateOnMount": false,
       "values": Object {},
     }
@@ -83,7 +83,7 @@ exports[`SubscribeJobsForm renders 1`] = `
     >
       <Col>
         <Button
-          disabled={false}
+          disabled={true}
           htmlType="submit"
           type="primary"
         >

--- a/ui/src/user/components/SignUpPage.tsx
+++ b/ui/src/user/components/SignUpPage.tsx
@@ -6,14 +6,14 @@ import SingUpForm from './SingUpForm';
 import DocumentHead from '../../common/components/DocumentHead';
 
 const SignUpPage: React.FC<{
-  onSubmit: ((
+  onSignUp: ((
     values: {},
     formikHelpers: FormikHelpers<{}>
   ) => void | Promise<any>) &
     Function;
   loading: boolean;
   error?: { message: string };
-}> = ({ onSubmit, loading, error }) => {
+}> = ({ onSignUp, loading, error }) => {
   return (
     <>
       <DocumentHead title="Sign up" />
@@ -36,7 +36,7 @@ const SignUpPage: React.FC<{
             </Row>
           )}
           <div data-testid={loading}>
-            <SingUpForm onSignUp={onSubmit} loading={loading} />
+            <SingUpForm onSignUp={onSignUp} loading={loading} />
           </div>
         </Card>
       </Row>

--- a/ui/src/user/components/SingUpForm.tsx
+++ b/ui/src/user/components/SingUpForm.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import { Row, Col, Button } from 'antd';
 import { Field, Form, Formik, FormikHelpers } from 'formik';
 import { object, string } from 'yup';
@@ -23,7 +23,7 @@ function SingUpForm({
     Function;
 }) {
   return (
-    <Formik validationSchema={SCHEMA} initialValues={{}} onSubmit={onSignUp}>
+    <Formik validationSchema={SCHEMA} initialValues={{}} onSubmit={onSignUp} validateOnChange={false}>
       {(props) => (
         <Form>
           <Field
@@ -39,7 +39,7 @@ function SingUpForm({
             <Col>
               <Button
                 loading={loading}
-                disabled={!props.isValid}
+                disabled={!props.isValid || !props.dirty}
                 type="primary"
                 htmlType="submit"
                 data-testid="submit"

--- a/ui/src/user/components/__tests__/__snapshots__/SignUpPage.test.tsx.snap
+++ b/ui/src/user/components/__tests__/__snapshots__/SignUpPage.test.tsx.snap
@@ -60,6 +60,7 @@ exports[`SignUpPage renders page 1`] = `
                 <button
                   class="ant-btn ant-btn-primary"
                   data-testid="submit"
+                  disabled=""
                   type="submit"
                 >
                   <span>
@@ -204,6 +205,7 @@ exports[`SignUpPage renders page with errors 1`] = `
                 <button
                   class="ant-btn ant-btn-primary"
                   data-testid="submit"
+                  disabled=""
                   type="submit"
                 >
                   <span>
@@ -281,6 +283,7 @@ exports[`SignUpPage renders page with loading 1`] = `
                 <button
                   class="ant-btn ant-btn-primary ant-btn-loading"
                   data-testid="submit"
+                  disabled=""
                   type="submit"
                 >
                   <span

--- a/ui/src/user/components/__tests__/__snapshots__/SingUpForm.test.tsx.snap
+++ b/ui/src/user/components/__tests__/__snapshots__/SingUpForm.test.tsx.snap
@@ -45,6 +45,7 @@ exports[`SingUpForm disable email input and display loading on the button while 
         <button
           class="ant-btn ant-btn-primary ant-btn-loading"
           data-testid="submit"
+          disabled=""
           type="submit"
         >
           <span
@@ -124,6 +125,7 @@ exports[`SingUpForm renders the form 1`] = `
         <button
           class="ant-btn ant-btn-primary"
           data-testid="submit"
+          disabled=""
           type="submit"
         >
           <span>

--- a/ui/src/user/containers/__tests__/SignUpPageContainer.test.tsx
+++ b/ui/src/user/containers/__tests__/SignUpPageContainer.test.tsx
@@ -29,8 +29,6 @@ describe('SignUpPageContainer', () => {
     const submitButton = getByTestId('submit');
     await userEvent.click(submitButton);
 
-    // TODO
-    await store.dispatch(userSignUpRequest());
     const expectedActions = [
       {
         type: USER_SIGN_UP_REQUEST,


### PR DESCRIPTION
* ref: cern-sis/issues-inspire#284

The issue was wrong prop name passed to signup component. Additionally fixed input loosing focus after first letter was typed in signup form as well as in jobs subscribe form.