### PR TITLE
Configure record editor for all collections

### DIFF
--- a/record-editor/src/app/shared/config/authors.config.ts
+++ b/record-editor/src/app/shared/config/authors.config.ts
@@ -111,6 +111,33 @@ export const authors: JsonEditorConfig = {
           },
         },
       },
+      deleted_records: {
+        items: {
+          refFieldConfig: {
+            anchorBuilder: anchorBuilder,
+            displayInputField: true,
+          },
+        },
+      },
+      related_records: {
+        items: {
+          order: [
+            'record',
+            'curated_relation',
+            'relation',
+            'relation_freetext',
+          ],
+          alwaysShow: ['record', 'relation'],
+          properties: {
+            record: {
+              refFieldConfig: {
+                anchorBuilder: anchorBuilder,
+                displayInputField: true,
+              },
+            },
+          },
+        },
+      },
       $schema: {
         hidden: true,
       },

--- a/record-editor/src/app/shared/config/experiments.config.ts
+++ b/record-editor/src/app/shared/config/experiments.config.ts
@@ -22,49 +22,70 @@
 
 import { JsonEditorConfig } from 'ng2-json-editor';
 import { countryCodeToName } from 'inspire-schemas';
-import { customValidationForDateTypes, anchorBuilder } from './commons';
+import {
+  affiliationAutocompletionConfig,
+  customValidationForDateTypes,
+  anchorBuilder,
+} from './commons';
 import { environment } from '../../../environments/environment';
 
-export const conferences: JsonEditorConfig = {
+export const experiments: JsonEditorConfig = {
   customFormatValidation: customValidationForDateTypes,
   menuMaxDepth: 1,
   enableAdminModeSwitch: true,
   schemaOptions: {
     alwaysShowRegExp: new RegExp('value'),
     alwaysShow: [
-      'titles',
-      'acronyms',
-      'addresses',
-      'cnum',
-      'opening_date',
-      'closing_date',
-      'series',
-      'urls',
-      'contact_details',
-      'short_description',
+      'project_type',
+      'long_name',
+      'legacy_name',
+      'accelerator',
+      'experiment',
+      'collaboration',
+      'institutions',
+      'name_variants',
+      'date_proposed',
+      'date_approved',
+      'date_cancelled',
+      'date_started',
+      'date_completed',
+      'inspire_categories',
+      'inspire_classification',
+      'description',
       'public_notes',
       '_private_notes',
-      'alternative_titles',
-      'inspire_categories',
-      'keywords',
+      'urls',
+      '_full_ingestion',
+      'related_records',
+      'new_record',
+      'deleted_records',
+      'core',
       'deleted',
     ],
     order: [
-      'titles',
-      'acronyms',
-      'addresses',
-      'cnum',
-      'opening_date',
-      'closing_date',
-      'series',
-      'urls',
-      'contact_details',
-      'short_description',
+      'project_type',
+      'long_name',
+      'legacy_name',
+      'accelerator',
+      'experiment',
+      'collaboration',
+      'institutions',
+      'name_variants',
+      'date_proposed',
+      'date_approved',
+      'date_cancelled',
+      'date_started',
+      'date_completed',
+      'inspire_categories',
+      'inspire_classification',
+      'description',
       'public_notes',
       '_private_notes',
-      'alternative_titles',
-      'inspire_categories',
-      'keywords',
+      'urls',
+      '_full_ingestion',
+      'related_records',
+      'new_record',
+      'deleted_records',
       'core',
       'deleted',
     ],
@@ -75,64 +96,9 @@ export const conferences: JsonEditorConfig = {
       deleted: {
         toggleColor: '#e74c3c',
       },
-      titles: {
+      accelerator: {
         items: {
-          alwaysShow: ['title'],
-          order: ['title', 'subtitle', 'source'],
-        },
-      },
-      series: {
-        items: {
-          alwaysShow: ['name'],
-          order: ['name', 'number'],
-          properties: {
-            name: {
-              autocompletionConfig: {
-                url: `${environment.baseUrl}/api/conferences/_suggest?series_name=`,
-                path: '/series_name/0/options',
-                optionField: '/text',
-                size: 10,
-              },
-            },
-          },
-        },
-      },
-      inspire_categories: {
-        items: {
-          alwaysShow: ['term'],
-          order: ['term'],
-        },
-      },
-      addresses: {
-        items: {
-          order: ['cities', 'state', 'country_code', 'place_name'],
-          properties: {
-            country_code: {
-              enumDisplayValueMap: countryCodeToName,
-            },
-            postal_code: {
-              hidden: true,
-            },
-            postal_address: {
-              hidden: true,
-            },
-            longitude: {
-              hidden: true,
-            },
-            latitude: {
-              hidden: true,
-            },
-          },
-        },
-      },
-      urls: {
-        items: {
-          order: ['value', 'description'],
-        },
-      },
-      contact_details: {
-        items: {
-          order: ['email', 'name', 'curated_relation', 'hidden'],
+          order: ['value', 'record'],
           properties: {
             record: {
               refFieldConfig: {
@@ -143,28 +109,47 @@ export const conferences: JsonEditorConfig = {
           },
         },
       },
-      short_description: {
-        order: ['value'],
-      },
-      public_notes: {
-        items: {
-          order: ['value'],
+      collaboration: {
+        order: ['value', 'record', 'subgroup_names'],
+        alwaysShow: ['value', 'record', 'subgroup_names'],
+        properties: {
+          record: {
+            refFieldConfig: {
+              anchorBuilder: anchorBuilder,
+              displayInputField: true,
+            },
+          },
         },
       },
-      _private_notes: {
+      institutions: {
         items: {
-          order: ['value'],
+          order: ['value', 'record'],
+          properties: {
+            record: {
+              refFieldConfig: {
+                anchorBuilder: anchorBuilder,
+                displayInputField: true,
+              },
+            },
+            value: {
+              autocompletionConfig: affiliationAutocompletionConfig,
+            },
+          },
         },
       },
-      alternative_titles: {
+      experiment: {
+        order: ['value', 'short_name'],
+        alwaysShow: ['value', 'short_name'],
+      },
+      inspire_categories: {
         items: {
-          alwaysShow: ['title'],
-          order: ['title', 'subtitle', 'source'],
+          order: ['term', 'source'],
+          alwaysShow: ['term', 'source'],
         },
       },
-      keywords: {
+      urls: {
         items: {
-          order: ['value', 'schema'],
+          order: ['value', 'description'],
         },
       },
       deleted_records: {
@@ -193,9 +178,6 @@ export const conferences: JsonEditorConfig = {
             },
           },
         },
-      },
-      cnum: {
-        disabled: true,
       },
       new_record: {
         disabled: true,

--- a/record-editor/src/app/shared/config/hep/core.config.ts
+++ b/record-editor/src/app/shared/config/hep/core.config.ts
@@ -525,7 +525,8 @@ export const coreHep: JsonEditorConfig = {
                   properties: {
                     journal_title: {
                       onValueChange: splitPrimitiveReferenceField,
-                      autocompletionConfig: journalTitleAutocompletionConfigWithoutPopulatingRef,
+                      autocompletionConfig:
+                        journalTitleAutocompletionConfigWithoutPopulatingRef,
                     },
                     journal_volume: {
                       onValueChange: splitPrimitiveReferenceField,
@@ -620,10 +621,31 @@ export const coreHep: JsonEditorConfig = {
           alwaysShow: ['description'],
         },
       },
-      new_record: {
-        refFieldConfig: {
-          anchorBuilder: anchorBuilder,
-          displayInputField: true,
+      deleted_records: {
+        items: {
+          refFieldConfig: {
+            anchorBuilder: anchorBuilder,
+            displayInputField: true,
+          },
+        },
+      },
+      related_records: {
+        items: {
+          order: [
+            'record',
+            'curated_relation',
+            'relation',
+            'relation_freetext',
+          ],
+          alwaysShow: ['record', 'relation'],
+          properties: {
+            record: {
+              refFieldConfig: {
+                anchorBuilder: anchorBuilder,
+                displayInputField: true,
+              },
+            },
+          },
         },
       },
     },

--- a/record-editor/src/app/shared/config/index.ts
+++ b/record-editor/src/app/shared/config/index.ts
@@ -8,6 +8,9 @@ import {
 } from './hep';
 import { authors } from './authors.config';
 import { conferences } from './conferences.config';
+import { experiments } from './experiments.config';
+import { institutions } from './institutions.config';
+import { journals } from './journals.config';
 
 export const editorConfigs = {
   hep,
@@ -18,6 +21,9 @@ export const editorConfigs = {
   'conference paper': conferencePaper,
   authors,
   conferences,
+  experiments,
+  institutions,
+  journals,
 };
 
 export * from './api.config';

--- a/record-editor/src/app/shared/config/institutions.config.ts
+++ b/record-editor/src/app/shared/config/institutions.config.ts
@@ -25,7 +25,7 @@ import { countryCodeToName } from 'inspire-schemas';
 import { customValidationForDateTypes, anchorBuilder } from './commons';
 import { environment } from '../../../environments/environment';
 
-export const conferences: JsonEditorConfig = {
+export const institutions: JsonEditorConfig = {
   customFormatValidation: customValidationForDateTypes,
   menuMaxDepth: 1,
   enableAdminModeSwitch: true,
@@ -201,9 +201,6 @@ export const conferences: JsonEditorConfig = {
         disabled: true,
       },
       $schema: {
-        hidden: true,
-      },
-      _collections: {
         hidden: true,
       },
       self: {

--- a/record-editor/src/app/shared/config/journals.config.ts
+++ b/record-editor/src/app/shared/config/journals.config.ts
@@ -21,134 +21,93 @@
  */
 
 import { JsonEditorConfig } from 'ng2-json-editor';
-import { countryCodeToName } from 'inspire-schemas';
 import { customValidationForDateTypes, anchorBuilder } from './commons';
 import { environment } from '../../../environments/environment';
 
-export const conferences: JsonEditorConfig = {
+export const journals: JsonEditorConfig = {
   customFormatValidation: customValidationForDateTypes,
   menuMaxDepth: 1,
   enableAdminModeSwitch: true,
   schemaOptions: {
     alwaysShowRegExp: new RegExp('value'),
     alwaysShow: [
-      'titles',
-      'acronyms',
-      'addresses',
-      'cnum',
-      'opening_date',
-      'closing_date',
-      'series',
-      'urls',
-      'contact_details',
-      'short_description',
-      'public_notes',
       '_private_notes',
-      'alternative_titles',
+      'date_ended',
+      'date_started',
+      'deleted_records',
+      'doi_prefixes',
       'inspire_categories',
-      'keywords',
-      'deleted',
+      'issns',
+      'journal_title',
+      'legacy_creation_date',
+      'license',
+      'new_record',
+      'public_notes',
+      'publisher',
+      'related_records',
+      'short_title',
+      'title_variants',
+      'urls',
     ],
     order: [
-      'titles',
-      'acronyms',
-      'addresses',
-      'cnum',
-      'opening_date',
-      'closing_date',
-      'series',
-      'urls',
-      'contact_details',
-      'short_description',
+      'short_title',
+      'journal_title',
+      'title_variants',
+      'issns',
+      'doi_prefixes',
+      'publisher',
       'public_notes',
+      'date_started',
+      'date_ended',
       '_private_notes',
-      'alternative_titles',
       'inspire_categories',
-      'keywords',
-      'core',
+      'legacy_creation_date',
+      'license',
+      'urls',
+      'new_record',
+      'deleted_records',
+      'related_records',
+      'refereed',
+      'proceedings',
+      'book_series',
       'deleted',
     ],
     properties: {
-      core: {
-        toggleColor: '#27ae60',
+      refereed: {
+        toggleColor: '#34495e',
+      },
+      proceedings: {
+        toggleColor: '#f1c40f',
+      },
+      book_series: {
+        toggleColor: '#8e44ad',
       },
       deleted: {
         toggleColor: '#e74c3c',
       },
-      titles: {
+      journal_title: {
         items: {
           alwaysShow: ['title'],
-          order: ['title', 'subtitle', 'source'],
-        },
-      },
-      series: {
-        items: {
-          alwaysShow: ['name'],
-          order: ['name', 'number'],
-          properties: {
-            name: {
-              autocompletionConfig: {
-                url: `${environment.baseUrl}/api/conferences/_suggest?series_name=`,
-                path: '/series_name/0/options',
-                optionField: '/text',
-                size: 10,
-              },
-            },
-          },
         },
       },
       inspire_categories: {
         items: {
-          alwaysShow: ['term'],
-          order: ['term'],
-        },
-      },
-      addresses: {
-        items: {
-          order: ['cities', 'state', 'country_code', 'place_name'],
           properties: {
-            country_code: {
-              enumDisplayValueMap: countryCodeToName,
-            },
-            postal_code: {
-              hidden: true,
-            },
-            postal_address: {
-              hidden: true,
-            },
-            longitude: {
-              hidden: true,
-            },
-            latitude: {
-              hidden: true,
+            term: {
+              priority: 1,
             },
           },
         },
       },
-      urls: {
+      issns: {
         items: {
-          order: ['value', 'description'],
+          alwaysShow: ['medium'],
+          order: ['value', 'medium'],
         },
       },
-      contact_details: {
+      license: {
         items: {
-          order: ['email', 'name', 'curated_relation', 'hidden'],
-          properties: {
-            record: {
-              refFieldConfig: {
-                anchorBuilder: anchorBuilder,
-                displayInputField: true,
-              },
-            },
-          },
-        },
-      },
-      short_description: {
-        order: ['value'],
-      },
-      public_notes: {
-        items: {
-          order: ['value'],
+          alwaysShow: ['license', 'url'],
         },
       },
       _private_notes: {
@@ -156,15 +115,14 @@ export const conferences: JsonEditorConfig = {
           order: ['value'],
         },
       },
-      alternative_titles: {
+      public_notes: {
         items: {
-          alwaysShow: ['title'],
-          order: ['title', 'subtitle', 'source'],
+          order: ['value'],
         },
       },
-      keywords: {
+      urls: {
         items: {
-          order: ['value', 'schema'],
+          alwaysShow: ['description'],
         },
       },
       deleted_records: {
@@ -194,16 +152,7 @@ export const conferences: JsonEditorConfig = {
           },
         },
       },
-      cnum: {
-        disabled: true,
-      },
-      new_record: {
-        disabled: true,
-      },
       $schema: {
-        hidden: true,
-      },
-      _collections: {
         hidden: true,
       },
       self: {


### PR DESCRIPTION
* Adds config for conferences, experiments, journals
* Changes all schemas to make more ref fields editable
* Closes cern-sis/issues-inspire#15 and closes cern-sis/issues-inspire#62