### PR TITLE
Revert "record editor: upgrade json-editor to 0.25.51"

### DIFF
--- a/record-editor/package.json
+++ b/record-editor/package.json
@@ -42,7 +42,7 @@
     "immutable": "^3.8.1",
     "inspire-schemas": "^61.3.1",
     "lodash": "4.17.2",
-    "ng2-json-editor": "0.25.51",
+    "ng2-json-editor": "^0.25.50",
     "ngx-bootstrap": "2.0.0-beta.7",
     "ngx-toastr": "^6.1.4",
     "raven-js": "3.27.0",

--- a/record-editor/yarn.lock
+++ b/record-editor/yarn.lock
@@ -4997,10 +4997,10 @@ next-tick@~1.0.0:
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
   integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
 
-ng2-json-editor@0.25.51:
-  version "0.25.51"
-  resolved "https://registry.yarnpkg.com/ng2-json-editor/-/ng2-json-editor-0.25.51.tgz#be14314c42ffb3587bd97a05394cfd2c18722a48"
-  integrity sha512-ywytGZN/4DfavIwFpaUJwZk+hhiZt6govpwtcnZ0LxCL0sGM9ty02SiZ05VdndIJCg5csMqlAbnmwBJhQe70bg==
+ng2-json-editor@^0.25.50:
+  version "0.25.50"
+  resolved "https://registry.yarnpkg.com/ng2-json-editor/-/ng2-json-editor-0.25.50.tgz#ce8051150833afeeef453c545a4617c2910f48f5"
+  integrity sha512-Ayl/NqFfQjqBMdTVF/Euy6mTNb4PcAmpW1cxztLV6V7Vk4h0T6w4KFOP5WDMNCRJk99PBW/8ub4jgwr6qEJnPA==
   dependencies:
     ajv "^5.0.0"
     ajv-errors "^1.0.0"


### PR DESCRIPTION
This reverts commit a38b42bd9dcdb70a3532a18486a21e52aa3d1b45 due to https://github.com/cern-sis/issues-inspire/issues/378.