### PR TITLE
ui: Fix TypeError on author pages

### DIFF
--- a/ui/src/common/constants.ts
+++ b/ui/src/common/constants.ts
@@ -4,7 +4,8 @@ export const PUBLISHED_BAR_TYPE = 'published';
 export const CITEABLE_BAR_TYPE = 'citeable';
 
 export const POST_DOC_RANK_VALUE = 'POSTDOC';
-export const CONTACT_URL = "https://help.inspirehep.net/knowledge-base/contact-us"
+export const CONTACT_URL =
+  'https://help.inspirehep.net/knowledge-base/contact-us';
 export const RANK_VALUE_TO_DISPLAY = {
   SENIOR: 'Senior (permanent)',
   JUNIOR: 'Junior (leads to Senior)',
@@ -72,4 +73,5 @@ export const CITATION_COUNT_WITHOUT_SELF_CITATIONS_PARAM =
 
 export const SEARCH_PAGE_GUTTER = { xs: 0, lg: 32 };
 
-export const LOCAL_TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone;
+export const LOCAL_TIMEZONE =
+  Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';


### PR DESCRIPTION
Closes https://github.com/cern-sis/issues-inspire/issues/400. The issue happens in `RecordUpdateInfo.jsx` because the `LOCAL_TIMEZONE` which is calculated in `common/constants.js` with `Intl.DateTimeFormat().resolvedOptions().timeZone` returns undefined in certain situations. I thought at first that it could be related to https://bugs.chromium.org/p/chromium/issues/detail?id=1487920 but it actually happens with different OS and Chrome versions. I added `UTC` as fallback so that the page doesn't crash in those situations.