### PR TITLE
record-editor: workaround faulty arXiv redirect

### DIFF
--- a/record-editor/src/app/shared/config/hep/core.config.ts
+++ b/record-editor/src/app/shared/config/hep/core.config.ts
@@ -695,7 +695,7 @@ export const coreHep: JsonEditorConfig = {
       getUrl: (record) => {
         let ePrints: Array<{ value: string }> = record['arxiv_eprints'];
         if (ePrints && ePrints.length > 0) {
-          return `//arxiv.org/pdf/${ePrints[0].value}.pdf#zoom=100`;
+          return `//arxiv.org/pdf/${ePrints[0].value}#zoom=100`;
         } else {
           return undefined;
         }


### PR DESCRIPTION
arXiv recently started redirecting URLs of the form `https://arxiv.org/pdf/yymm.nnnnn.pdf` to
`http://arxiv.org/pdf/yymm.nnnnn`, which breaks the PDF preview in the editor due to security restrictions on mixed active content. This commit fixes the issue by loading the final URL directly with the proper scheme.