### PR TITLE
compose: correct mq img tag

### DIFF
--- a/docker-compose.services.yml
+++ b/docker-compose.services.yml
@@ -42,7 +42,7 @@ services:
     ports:
       - '5432:5432'
   mq:
-    image: rabbitmq:3.12.0-management-alpine
+    image: rabbitmq:3.12.0-management
     restart: 'always'
   es:
     build:


### PR DESCRIPTION
* Replace rabbitmq docker image tag with one that offers arm as well as linux as a plattform