### PR TITLE
ui: display error link in new holdingpen

### DIFF
--- a/ui/public/config.js
+++ b/ui/public/config.js
@@ -11,6 +11,7 @@
     ASSIGN_NO_PROFILE_UI_FEATURE_FLAG: true,
     ASSIGN_NOT_LOGGED_IN_FEATURE_FLAG: true,
     SELF_CURATION_BUTTON: true,
+    INSPIRE_WORKFLOWS_DAGS_URL: null,
     /* Example:
     BANNERS: [
       {

--- a/ui/src/holdingpen-new/containers/DetailPageContainer/AuthorDetailPageContainer.tsx
+++ b/ui/src/holdingpen-new/containers/DetailPageContainer/AuthorDetailPageContainer.tsx
@@ -25,6 +25,7 @@ import {
   columnsSubject,
   columnsAdvisors,
 } from './columnData';
+import { getConfigFor } from '../../../common/config';
 
 interface AuthorDetailPageContainerProps {
   dispatch: ActionCreator<Action>;
@@ -47,13 +48,14 @@ const AuthorDetailPageContainer: React.FC<AuthorDetailPageContainerProps> = ({
 
   const data = author?.get('data') as Map<any, any>;
   const tickets = author?.get('tickets') as Map<any, any>;
+  const ERRORS_URL = getConfigFor('INSPIRE_WORKFLOWS_DAGS_URL');
 
   const OPEN_SECTIONS = [
     data?.get('positions') && 'institutions',
     data?.get('project_membership') && 'projects',
     (data?.get('urls') || data?.get('ids')) && 'links',
     (data?.get('arxiv_categories') || data?.get('.advisors')) && 'other',
-    author?.get('_error_msg') && 'errors',
+    author?.get('status') === 'error' && 'errors',
     'delete',
   ].filter(Boolean);
 
@@ -177,11 +179,15 @@ const AuthorDetailPageContainer: React.FC<AuthorDetailPageContainerProps> = ({
                       </Col>
                     </Row>
                   </CollapsableForm.Section>
-                  {author?.get('_error_msg') && (
+                  {author?.get('status') === 'error' && (
                     <CollapsableForm.Section header="Errors" key="errors">
-                      <div className="bg-waiting error-code">
-                        {author?.get('_error_msg')}
-                      </div>
+                      <p>
+                        See error details here:{' '}
+                        <a
+                          href={`${ERRORS_URL}/${id}`}
+                          target="_blank"
+                        >{`${ERRORS_URL}/${id}`}</a>
+                      </p>
                     </CollapsableForm.Section>
                   )}
                   <CollapsableForm.Section header="Danger area" key="delete">


### PR DESCRIPTION
* ref: cern-sis/issues-inspire#520

<img width="1496" alt="Screenshot 2024-08-23 at 13 15 12" src="https://github.com/user-attachments/assets/51cc1e6d-5793-4609-8814-c4c6d080570d">
