### PR TITLE
ui: changed link to button to running dag for admins

### DIFF
--- a/ui/src/backoffice/containers/DetailPageContainer/AuthorDetailPageContainer.tsx
+++ b/ui/src/backoffice/containers/DetailPageContainer/AuthorDetailPageContainer.tsx
@@ -337,10 +337,13 @@ const AuthorDetailPageContainer: React.FC<AuthorDetailPageContainerProps> = ({
                       fullHeight={false}
                       subTitle="Running dags"
                     >
-                      <a
-                        href={`${DAGS_URL}${id}`}
-                        target="_blank"
-                      >{`${DAGS_URL}${id}`}</a>
+                      <div className="flex flex-column items-center">
+                        <Button className="w-75">
+                          <a href={`${DAGS_URL}${id}`} target="_blank">
+                            See running dags
+                          </a>
+                        </Button>
+                      </div>
                     </ContentBox>
                   )}
                   <ContentBox


### PR DESCRIPTION
* ref: cern-sis/issues-inspire#561

<img width="379" alt="Screenshot 2024-09-10 at 12 10 28" src="https://github.com/user-attachments/assets/e5e29905-012a-4b09-bbf0-67222ede7984">
