### PR TITLE
ui: fix bluesky and mastodon not showing up in author profile

### DIFF
--- a/backend/inspirehep/records/marshmallow/authors/ui.py
+++ b/backend/inspirehep/records/marshmallow/authors/ui.py
@@ -39,6 +39,8 @@ class AuthorsDetailSchema(AuthorsBaseSchema):
     should_display_positions = fields.Method(
         "get_should_display_positions", dump_only=True
     )
+    bluesky = fields.Method("get_bluesky", dump_only=True)
+    mastodon = fields.Method("get_mastodon", dump_only=True)
     twitter = fields.Method("get_twitter", dump_only=True)
     linkedin = fields.Method("get_linkedin", dump_only=True)
     orcid = fields.Method("get_orcid", dump_only=True)
@@ -52,6 +54,14 @@ class AuthorsDetailSchema(AuthorsBaseSchema):
         if facet_author_name is None:
             return get_facet_author_name_for_author(data)
         return facet_author_name
+
+    @staticmethod
+    def get_bluesky(data):
+        return get_first_value_for_schema(data.get("ids", []), "BLUESKY")
+
+    @staticmethod
+    def get_mastodon(data):
+        return get_first_value_for_schema(data.get("ids", []), "MASTODON")
 
     @staticmethod
     def get_twitter(data):

--- a/ui/src/backoffice/components/Links.tsx
+++ b/ui/src/backoffice/components/Links.tsx
@@ -21,6 +21,18 @@ function getLinkData(schema: string, value: string) {
         href: `https://x.com/${value}`,
         icon: <XOutlined className="mr1" />,
       };
+    case 'BLUESKY':
+      return {
+        href: `https://bsky.app/profile/${value}`,
+        icon: <XOutlined className="mr1" />,
+      };
+    case 'MASTODON': {
+      const [user, host] = value.split('@');
+      return {
+        href: `https://${host}/@${user}`,
+        icon: <XOutlined className="mr1" />,
+      };
+    }
     case 'ORCID':
       return {
         href: `https://orcid.org/my-orcid?orcid=${value}`,

--- a/ui/src/backoffice/components/__tests__/Links.test.tsx
+++ b/ui/src/backoffice/components/__tests__/Links.test.tsx
@@ -49,6 +49,29 @@ describe('Links Component', () => {
     );
   });
 
+  it('should render Bluesky link correctly in Ids', () => {
+    const ids = Map([['0', Map({ schema: 'BLUESKY', value: 'john_doe' })]]);
+    const { getByText, getByRole } = render(<Ids ids={ids} />);
+
+    expect(getByText(/bluesky/i)).toBeInTheDocument();
+    expect(getByRole('link', { name: /john_doe/i })).toHaveAttribute(
+      'href',
+      'https://bsky.app/profile/john_doe'
+    );
+  });
+
+  it('should render Mastodon link correctly in Ids', () => {
+    const ids = Map([
+      ['0', Map({ schema: 'MASTODON', value: 'john_doe@example.com' })],
+    ]);
+    const { getByText, getByRole } = render(<Ids ids={ids} />);
+
+    expect(getByText(/mastodon/i)).toBeInTheDocument();
+    expect(
+      getByRole('link', { name: /john_doe@example.com/i })
+    ).toHaveAttribute('href', 'https://example.com/@john_doe');
+  });
+
   it('should render Twitter link correctly in Ids', () => {
     const ids = Map([['0', Map({ schema: 'TWITTER', value: 'john_doe' })]]);
     const { getByText, getByRole } = render(<Ids ids={ids} />);


### PR DESCRIPTION
* related: https://github.com/inspirehep/inspirehep/pull/3324

Bluesky and Mastodon fields were missing from the authors/ui serializer so they weren't being taken from `ids` out into the appropriate metadata field.

Also added both to backoffice.