### PR TITLE
use harbor registry for base images

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,7 +5,7 @@
 # inspirehep is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-FROM python:3.11
+FROM registry.cern.ch/cern-sis/base-images/python:3.11
 
 WORKDIR /opt/inspire
 

--- a/backoffice/Dockerfile
+++ b/backoffice/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.6-slim-bullseye as python
+FROM registry.cern.ch/cern-sis/base-images/python:3.11.6-slim-bullseye as python
 
 ARG APP_HOME=/app
 WORKDIR ${APP_HOME}
@@ -22,7 +22,7 @@ RUN curl -sSL https://install.python-poetry.org \
   | python - --version "${POETRY_VERSION}" \
   && poetry --version
 
-COPY poetry.lock pyproject.toml .
+COPY poetry.lock pyproject.toml ./
 RUN poetry install --no-root
 
 COPY . ${APP_HOME}

--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/scipy-notebook:python-3.8
+FROM registry.cern.ch/cern-sis/base-images/jupyter/scipy-notebook:python-3.8
 
 USER 0
 

--- a/record-editor/Dockerfile
+++ b/record-editor/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.14.0 as build-stage
+FROM registry.cern.ch/cern-sis/base-images/node:10.14.0 as build-stage
 
 WORKDIR /usr/src/app
 
@@ -7,7 +7,7 @@ COPY . /usr/src/app
 RUN yarn
 RUN yarn build
 
-FROM inspirehep/nginx:1.19-with-vts
+FROM registry.cern.ch/cern-sis/base-images/inspirehep/nginx:1.19-with-vts
 EXPOSE 8081
 
 COPY docker/nginx/config/nginx.conf /etc/nginx/conf.d/default.conf

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.0.0 as build-stage
+FROM registry.cern.ch/cern-sis/base-images/node:20.0.0 as build-stage
 
 WORKDIR /usr/src/app
 
@@ -10,7 +10,7 @@ ARG VERSION
 ENV REACT_APP_VERSION="${VERSION}"
 RUN yarn run build
 
-FROM inspirehep/nginx:1.19-with-vts
+FROM registry.cern.ch/cern-sis/base-images/inspirehep/nginx:1.19-with-vts
 
 EXPOSE 8080
 COPY --from=build-stage /usr/src/app/build /usr/share/nginx/html

--- a/workflows/Dockerfile
+++ b/workflows/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:2.9.3-python3.11
+FROM registry.cern.ch/cern-sis/base-images/apache/airflow:2.9.3-python3.11
 
 WORKDIR /opt/airflow
 


### PR DESCRIPTION
ref: https://github.com/cern-sis/issues-inspire/issues/689

This update will reduce the amount of pulls from dockerhub so we hopefully dont run into quota limits anymore