### PR TITLE
ui: query ai endpoint on search

### DIFF
--- a/ui/src/common/containers/SearchBoxContainer.tsx
+++ b/ui/src/common/containers/SearchBoxContainer.tsx
@@ -2,12 +2,13 @@ import { connect, RootStateOrAny } from 'react-redux';
 import { Action, ActionCreator } from 'redux';
 
 import SearchBox from '../components/SearchBox';
-import { searchQueryUpdate } from '../../actions/search';
+import { searchAI, searchQueryUpdate } from '../../actions/search';
 import { LITERATURE_NS } from '../../search/constants';
 import { appendQueryToLocationSearch } from '../../actions/router';
 import { clearLiteratureSelection } from '../../actions/literature';
 import { UI_CITATION_SUMMARY_PARAM } from '../../literature/containers/CitationSummarySwitchContainer';
 import { UI_EXCLUDE_SELF_CITATIONS_PARAM } from '../../literature/containers/ExcludeSelfCitationsContainer';
+import { getConfigFor } from '../config';
 
 const stateToProps = (state: RootStateOrAny) => ({
   value: state.search.getIn([
@@ -30,6 +31,9 @@ export const dispatchToProps = (dispatch: ActionCreator<Action>) => ({
       );
     } else {
       dispatch(clearLiteratureSelection());
+      if (getConfigFor('QUERY_AI_ON_SEARCH_FEATURE_FLAG')) {
+        dispatch(searchAI(value));
+      }
     }
 
     dispatch(searchQueryUpdate(namespace, { q: value }));

--- a/ui/src/common/http.ts
+++ b/ui/src/common/http.ts
@@ -82,6 +82,8 @@ export class HttpClientWrapper {
       config.withCredentials = true;
       config.url = transformBackofficeUrl(url);
       config.headers.Accept = 'application/json';
+    } else if (url.startsWith('/ai')) {
+      config.baseURL = '/';
     } else {
       config.baseURL = '/api';
     }


### PR DESCRIPTION
ref: https://github.com/cern-sis/issues-inspire/issues/718

* Queries the AI endpoint on search, just to collect data on the model's performance. 
* The request runs in parallel and doesn't block the search. 
* The implementation is very simple as it's a temporary feature that will be reworked later on.