### PR TITLE
workflows: fix log url

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,7 @@ x-airflow-common: &airflow-common
     context: workflows
     dockerfile: Dockerfile.local
   environment: &airflow-common-env
+    AIRFLOW_BASE_URL: ${AIRFLOW_BASE_URL:http://localhost:8070}
     AIRFLOW__CORE__EXECUTOR: CeleryExecutor
     AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://postgres:postgres@db/workflows
     AIRFLOW__CELERY__RESULT_BACKEND: db+postgresql://postgres:postgres@db/workflows

--- a/workflows/plugins/include/utils/alerts.py
+++ b/workflows/plugins/include/utils/alerts.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from urllib.parse import urlparse, urlunparse
 
 from airflow.utils.email import send_email
 
@@ -14,10 +15,20 @@ def task_failure_alert(context):
         logger.error("Cannot send email.")
         return
 
+    base_url = os.environ.get("AIRFLOW_BASE_URL")
+    task_instance = context["task_instance"]
+    parsed_log_url = urlparse(task_instance.log_url)
+    parsed_base_url = urlparse(base_url)
+    new_log_url = urlunparse(
+        parsed_log_url._replace(
+            scheme=parsed_base_url.scheme, netloc=parsed_base_url.netloc
+        )
+    )
+
     body = f"""
     <b>DAG</b>: `{context['dag'].dag_id}`<br>
-    <b>Task</b>: `{context['task_instance'].task_id}`<br>
-    <b>Log URL</b>: <a href="{context['task_instance'].log_url}">Log URL</a><br>
+    <b>Task</b>: `{task_instance.task_id}`<br>
+    <b>Log URL</b>: <a href="{new_log_url}">Log URL</a><br>
     """
     send_email(
         to=[recipient],


### PR DESCRIPTION
NOTE: Hostname from k8s points to the pod it self. We need the base url for the log to be pointed correctly. 