### PR TITLE
ui: make ant-message position fixed

### DIFF
--- a/ui/src/App.less
+++ b/ui/src/App.less
@@ -241,7 +241,7 @@ body {
 
 .ant-message {
   z-index: @zindex-message;
-  position: absolute;
+  position: fixed;
   bottom: 20px !important;
   top: unset !important;
 }


### PR DESCRIPTION
The position was off in dev, probably due to some kind of race condition, although locally it worked correctly. I changed `position: absolute` to `position: fixed` which makes sure the element is position relative to the viewport and not to the body or nearest positioned ancestor. This should work in all cases.