### PR TITLE
renderer: add disable-gpu arg

### DIFF
--- a/renderer/server.js
+++ b/renderer/server.js
@@ -26,6 +26,7 @@ async function getBrowser() {
     browser = await puppeteer.launch({
       headless: true,
       ignoreHTTPSErrors: true,
+      args:['--no-sandbox --disable-gpu']
     });
   }
   return browser;


### PR DESCRIPTION
hopefully fixes the `Render error: ProtocolError: Network.enable timed out. Increase the 'protocolTimeout' setting in launch/connect calls for a higher timeout if needed.` error on the renderer pods