### PR TITLE
Fix caching of test durations in github CI

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -133,7 +133,7 @@ jobs:
         with:
           path: test_durations
           key: ${{ env.CACHE_PREFIX }}-combined-${{ inputs.ref }}
-          restore-keys: ${{ env.CACHE_PREFIX }}--combined
+          restore-keys: ${{ env.CACHE_PREFIX }}-combined
 
       - name: Download artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Hopefully, this will resolve the issue in https://github.com/cern-sis/issues-inspire/issues/915