### PR TITLE
renderer: add p-limit and other fixes

### DIFF
--- a/renderer/package.json
+++ b/renderer/package.json
@@ -15,6 +15,7 @@
     "cache-manager": "^6.4.3",
     "express": "^5.1.0",
     "keyv-s3": "^2.0.4",
+    "p-limit": "^6.2.0",
     "puppeteer": "^24.9.0"
   }
 }


### PR DESCRIPTION
* Add p-limit to limit concurrency
* Add some additional timeouts
* Add more failsafes for page closing
* Add browser instance refresh
* Remove `/healthz` endpoint as we can just use the render endpoint for health checks