### PR TITLE
workflows: fix usage of ds for prev day

### DIFF
--- a/workflows/dags/cds/cds_harvest.py
+++ b/workflows/dags/cds/cds_harvest.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 
 from airflow.decorators import dag, task, task_group
+from airflow.macros import ds_add
 from airflow.models.param import Param
 from hooks.generic_http_hook import GenericHttpHook
 from hooks.inspirehep.inspire_http_record_management_hook import (
@@ -35,7 +36,7 @@ def cds_harvest_dag():
 
         Returns: data from cds
         """
-        since = context["params"]["since"] or context["ds"]
+        since = context["params"]["since"] or ds_add(context["ds"], -1)
         logger.info(f"Harvesting CDS data since {since}")
         cds_response = generic_http_hook.call_api(
             endpoint="/api/inspire2cdsids", method="GET", params={"since": since}

--- a/workflows/dags/cds/cds_rdm_harvest.py
+++ b/workflows/dags/cds/cds_rdm_harvest.py
@@ -57,7 +57,7 @@ def _response_filter(responses):
     tags=["cds_rdm"],
     params={
         "since": Param(type=["string"], default=""),
-        "until": Param(type=["string"], default=datetime.datetime.now().isoformat()),
+        "until": Param(type=["string"], default=""),
     },
     on_failure_callback=task_failure_alert,
 )
@@ -70,7 +70,10 @@ def cds_rdm_harvest_dag():
         method="GET",
         endpoint="/api/records",
         data={
-            "q": "updated:[{{ params.since or ds }} TO {{ params.until }}]",
+            "q": (
+                "updated:[{{ params.since or macros.ds_add(ds, -1) }} "
+                "TO {{ params.until or ds }}]"
+            ),
             "page": 1,
             "size": 50,
             "sort": "newest",

--- a/workflows/dags/data/data_harvest.py
+++ b/workflows/dags/data/data_harvest.py
@@ -54,7 +54,7 @@ def data_harvest_dag():
         from_date = (
             context["params"]["last_updated_from"]
             if context["params"]["last_updated_from"]
-            else ds_add(context["ds"], -1)
+            else ds_add(context["ds"], -2)
         )
         to_date = context["params"]["last_updated_to"]
 

--- a/workflows/dags/literature/arxiv_harvest.py
+++ b/workflows/dags/literature/arxiv_harvest.py
@@ -4,6 +4,7 @@ import logging
 from airflow.decorators import dag, task, task_group
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
+from airflow.macros import ds_add
 from airflow.models.param import Param
 from include.utils.alerts import task_failure_alert
 from sickle import Sickle, oaiexceptions
@@ -83,7 +84,7 @@ def arxiv_harvest_dag():
             Returns: list: The list of raw xml records.
             """
 
-            from_date = context["params"]["from"] or context["ds"]
+            from_date = context["params"]["from"] or ds_add(context["ds"], -1)
             until_date = context["params"]["until"]
 
             oaiargs = {

--- a/workflows/tests/test_arxiv_harvest.py
+++ b/workflows/tests/test_arxiv_harvest.py
@@ -19,7 +19,7 @@ class TestArxivHarvest:
             "params": {"from": "", "until": "", "metadata_prefix": "arXiv"}
         }
         task.op_args = ("physics:hep-th",)
-        res = task.execute(context=Context({"ds": "2025-07-01"}))
+        res = task.execute(context=Context({"ds": "2025-07-02"}))
         assert len(res)
         assert "oai:arXiv.org:2101.11905" in res[0]
         assert "oai:arXiv.org:2207.10712" in res[1]
@@ -35,7 +35,7 @@ class TestArxivHarvest:
             }
         }
         task.op_args = ("physics:hep-th",)
-        res = task.execute(context=Context({"ds": "2025-07-02"}))
+        res = task.execute(context=Context({"ds": "2025-07-03"}))
         assert len(res)
         assert "oai:arXiv.org:2101.11905" in res[0]
         assert "oai:arXiv.org:2207.10712" in res[1]
@@ -48,7 +48,7 @@ class TestArxivHarvest:
         }
         task.op_args = ("physics:hep-th",)
 
-        res = task.execute(context=Context({"ds": "2025-07-01"}))
+        res = task.execute(context=Context({"ds": "2025-07-02"}))
 
         assert len(res) == 0
 

--- a/workflows/tests/test_cds_rdm_tasks.py
+++ b/workflows/tests/test_cds_rdm_tasks.py
@@ -16,7 +16,7 @@ class TestCDSRDMHarvest:
     def test_get_cds_rdm_data_vcr(self):
         task = self.dag.get_task("get_cds_rdm_data")
         context = {
-            "ds": "2025-06-01T00:00:00",
+            "ds": "2025-07-01T00:00:00",
             "params": {
                 "since": "2025-06-01T00:00:00",
                 "until": "2025-07-01T00:00:00",

--- a/workflows/tests/test_cds_tasks.py
+++ b/workflows/tests/test_cds_tasks.py
@@ -16,7 +16,7 @@ class TestCDSHarvest:
     def test_get_cds_data_vcr(self):
         task = self.dag.get_task("get_cds_data")
         res = task.execute(
-            context={"ds": "2025-05-23", "params": {"since": "2025-05-23"}}
+            context={"ds": "2025-06-23", "params": {"since": "2025-05-23"}}
         )
         assert len(res)
 

--- a/workflows/tests/test_data_tasks.py
+++ b/workflows/tests/test_data_tasks.py
@@ -44,7 +44,7 @@ class TestDataHarvest:
                 "last_updated_to": "",
             }
         }
-        res = task.execute(context=Context({"ds": "2024-12-16"}))
+        res = task.execute(context=Context({"ds": "2024-12-17"}))
         assert res == [2693068, 2807749, 2809112]
 
     @pytest.mark.vcr


### PR DESCRIPTION
With the upgrade to Airflow 3, the logic behind the `ds` template was changed, before the upgrade we could use it to get the date of the previous day (of the execution day) now it represents the date of the execution. Because of these changes we have to subtract one day from `ds`, in order to achieve the same results