### PR TITLE
e2e: fixed job submission test

### DIFF
--- a/e2e/cypress/e2e/jobs.test.js
+++ b/e2e/cypress/e2e/jobs.test.js
@@ -57,7 +57,7 @@ describe('Job Submission', () => {
       ranks: ['POSTDOC', 'MASTER'],
       experiments: [{ legacy_name: 'Atlas' }, { legacy_name: 'CMS' }],
       url: 'https://someinfo.com',
-      deadline_date: moment().add(1, 'day'),
+      deadline_date: moment().add(1, 'year'),
       contacts: [
         {
           name: 'John Doe',
@@ -83,17 +83,19 @@ describe('Job Submission', () => {
     });
   });
 
-  it('updates new job', () => {
+  it.only('updates new job', () => {
     const expectedMetadata = {
       position: 'Cherenkov Telescope Array',
     };
 
     cy.visit('/submissions/jobs/1813119');
+
     cy.testUpdateSubmission({
       collection: 'jobs',
       recordId: 1813119,
       formData: {
         title: ': Updated',
+        deadline_date: moment().add(1, 'year'),
       },
       expectedMetadata: {
         position: expectedMetadata.position + ': Updated',

--- a/e2e/cypress/support/commands/form.js
+++ b/e2e/cypress/support/commands/form.js
@@ -190,7 +190,7 @@ Cypress.Commands.add('fillDateRangeField', (path, [startDate, endDate]) => {
 });
 
 Cypress.Commands.add('fillDateField', (path, value) => {
-  cy.getField(path).then(($dateSelect) => {
+  cy.getField(path).clear({ force: true }).then(($dateSelect) => {
     const dateFormat = $dateSelect.attr('data-test-format') || 'YYYY-MM-DD';
     const dateValue = moment(value).format(dateFormat);
     cy.wrap($dateSelect).type(`${dateValue}{enter}`, { force: true });

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test:dev": "cypress open",
-    "test": "cypress run",
+    "test": "cypress run --browser",
     "cypress": "cypress"
   },
   "author": "",


### PR DESCRIPTION
Now deadline date is always a year from now.

* ref: cern-sis/issues-inspire#1078