### PR TITLE
workflows: elsevier failed records go to separate folder

### DIFF
--- a/workflows/dags/literature/elsevier_harvest.py
+++ b/workflows/dags/literature/elsevier_harvest.py
@@ -92,11 +92,13 @@ def elsevier_harvest_dag():
                 )
             )
 
-        return s3_store.write_object(
-            {
-                "failed_records": failed_records,
-            }
-        )
+        if len(failed_records) > 0:
+            return s3_store.write_object(
+                {
+                    "failed_records": failed_records,
+                },
+                key=f"failed/{context['run_id']}.json",
+            )
 
     packages = fetch_package_feed()
     new_package_keys = download_new_packages(packages)

--- a/workflows/tests/test_elsevier_harvest.py
+++ b/workflows/tests/test_elsevier_harvest.py
@@ -176,9 +176,8 @@ class TestElsevierHarvest:
             context={"run_id": "test_run_id"},
         )
 
-        failures = self.s3_publisher_store.read_object(failed_records_key)
+        assert failed_records_key is None
 
-        assert len(failures["failed_records"]) == 0
         assert mock_post_workflow.call_count == 3
         for call_idx, article_file in enumerate(processed_article_files):
             assert (


### PR DESCRIPTION
* ref: cern-sis/issues-inspire/issues/1450