### PR TITLE
backoffice(ui): improvements

### DIFF
--- a/backend/inspirehep/matcher/config.py
+++ b/backend/inspirehep/matcher/config.py
@@ -389,6 +389,7 @@ FUZZY_LITERATURE_MATCH_CONFIG = {
         "abstracts",
         "authors",
         "arxiv_eprints",
+        "document_type",
         "public_notes",
         "number_of_pages",
         "publication_info",

--- a/backend/inspirehep/matcher/serializers.py
+++ b/backend/inspirehep/matcher/serializers.py
@@ -20,6 +20,7 @@ class LiteratureSummary(Schema):
     earliest_date = fields.Raw(dump_only=True)
     public_notes = fields.Method("get_public_notes", dump_only=True)
     publication_info = fields.Raw(dump_only=True, default=missing)
+    document_type = fields.Raw(dump_only=True, default=missing)
 
     @staticmethod
     def get_abstract(data):

--- a/backoffice/backoffice/hep/fixtures/workflows.json
+++ b/backoffice/backoffice/hep/fixtures/workflows.json
@@ -793,6 +793,7 @@
             "authors_count": 1,
             "control_number": 1790396,
             "earliest_date": "2020-03-17",
+            "document_type": ["article"],
             "publication_info": [
               {
                 "artid": "033101",
@@ -818,6 +819,7 @@
             "control_number": 1752989,
             "earliest_date": "2017",
             "number_of_pages": 151,
+            "document_type": ["conference paper"],
             "public_notes": [
               {
                 "value": "Fermilab Library Only"
@@ -839,6 +841,7 @@
             "control_number": 1989726,
             "earliest_date": "2021",
             "number_of_pages": 163,
+            "document_type": ["article"],
             "publication_info": [
               {
                 "year": 2021
@@ -4694,6 +4697,7 @@
             ],
             "earliest_date": "2011-10-14",
             "control_number": 1258254,
+            "document_type": ["article"],
             "number_of_pages": 12
           }
         ]
@@ -4800,6 +4804,7 @@
             "authors_count": 1,
             "earliest_date": "2020-09-28",
             "control_number": 1837351,
+            "document_type": ["thesis"],
             "number_of_pages": 236,
             "publication_info": [
               {

--- a/ui/src/backoffice/__tests__/notifications.test.ts
+++ b/ui/src/backoffice/__tests__/notifications.test.ts
@@ -43,7 +43,6 @@ describe('Notification Functions', () => {
     expect(successSpy).toHaveBeenCalledWith({
       message: 'Success',
       description: 'Delete performed successfully',
-      duration: 10,
     });
   });
 
@@ -56,7 +55,6 @@ describe('Notification Functions', () => {
     expect(errorSpy).toHaveBeenCalledWith({
       message: 'Unable to perform action',
       description: errorMessage,
-      duration: 10,
     });
   });
 });

--- a/ui/src/backoffice/literature/components/LiteratureDocumentTypes.tsx
+++ b/ui/src/backoffice/literature/components/LiteratureDocumentTypes.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { List } from 'immutable';
+import UnclickableTag from '../../../common/components/UnclickableTag';
+
+const LiteratureDocumentTypes = ({
+  documentTypes,
+}: {
+  documentTypes?: List<string>;
+}) => {
+  if (!documentTypes?.size) return null;
+
+  return (
+    <>
+      {documentTypes.map((docType: string) => (
+        <UnclickableTag key={docType}>
+          {docType.charAt(0).toUpperCase() + docType.slice(1)}
+        </UnclickableTag>
+      ))}
+    </>
+  );
+};
+
+export default LiteratureDocumentTypes;

--- a/ui/src/backoffice/literature/components/LiteratureMainInfo.jsx
+++ b/ui/src/backoffice/literature/components/LiteratureMainInfo.jsx
@@ -42,8 +42,9 @@ const LiteratureMainInfo = ({ data, isLiteratureUpdate }) => {
             <AuthorList
               limit={10}
               authors={authors}
-              page="literature backofice"
+              page="literature backoffice"
               unlinked
+              enableShowAll
             />
           </div>
         )}

--- a/ui/src/backoffice/literature/components/LiteratureMatches.jsx
+++ b/ui/src/backoffice/literature/components/LiteratureMatches.jsx
@@ -9,6 +9,7 @@ import Latex from '../../../common/components/Latex';
 import { WorkflowDecisions } from '../../../common/constants';
 import { hasPublicationInfo } from '../../utils/utils';
 import ToggleableAbstract from './ToggleableAbstract';
+import LiteratureDocumentTypes from './LiteratureDocumentTypes';
 
 const { Text, Paragraph } = Typography;
 
@@ -23,6 +24,8 @@ const LiteratureMatchItem = ({ match, selectedBestMatch, onSelect }) => {
   const abstract = abstractValue ? Map({ value: abstractValue }) : null;
   const arxivEprint = match.get('arxiv_eprint');
   const authors = match.get('authors', List());
+  const authorsCount = match.get('authors_count');
+  const documentTypes = match.get('document_type', List());
   const earliestDate = match.get('earliest_date');
   const numberOfPages = match.get('number_of_pages');
   const publicNotes = match.get('public_notes', List());
@@ -35,19 +38,26 @@ const LiteratureMatchItem = ({ match, selectedBestMatch, onSelect }) => {
       style={{ marginBottom: 12 }}
       bodyStyle={{ paddingTop: 8 }}
       title={
-        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
-          <Radio
-            value={controlNumber}
-            checked={selectedBestMatch === controlNumber}
-            onChange={handleRadioChange}
-          />
-          <div
-            style={{ flex: 1, whiteSpace: 'normal', wordBreak: 'break-word' }}
-          >
-            <LinkWithTargetBlank href={`${LITERATURE}/${controlNumber}`}>
-              <Latex>{match.get('title')}</Latex>
-              <ExportOutlined style={{ marginLeft: '4px' }} />
-            </LinkWithTargetBlank>
+        <div>
+          {documentTypes.size > 0 && (
+            <div style={{ marginBottom: 4 }}>
+              <LiteratureDocumentTypes documentTypes={documentTypes} />
+            </div>
+          )}
+          <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
+            <Radio
+              value={controlNumber}
+              checked={selectedBestMatch === controlNumber}
+              onChange={handleRadioChange}
+            />
+            <div
+              style={{ flex: 1, whiteSpace: 'normal', wordBreak: 'break-word' }}
+            >
+              <LinkWithTargetBlank href={`${LITERATURE}/${controlNumber}`}>
+                <Latex>{match.get('title')}</Latex>
+                <ExportOutlined style={{ marginLeft: '4px' }} />
+              </LinkWithTargetBlank>
+            </div>
           </div>
         </div>
       }
@@ -56,7 +66,7 @@ const LiteratureMatchItem = ({ match, selectedBestMatch, onSelect }) => {
         <div style={{ marginBottom: 8 }}>
           <Text>
             {authors.map((a) => a.get('full_name')).join('; ')}
-            {authors.size > 1 && <> ({authors.size} authors)</>}
+            {authorsCount > 1 && <> ({authorsCount} authors)</>}
           </Text>
         </div>
       )}

--- a/ui/src/backoffice/literature/components/LiteratureResultItem.tsx
+++ b/ui/src/backoffice/literature/components/LiteratureResultItem.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import UnclickableTag from '../../../common/components/UnclickableTag';
 import Latex from '../../../common/components/Latex';
+import LiteratureDocumentTypes from './LiteratureDocumentTypes';
+import { BACKOFFICE } from '../../../common/routes';
+import { LITERATURE_PID_TYPE } from '../../../common/constants';
 import {
   resolveDecision,
   filterDecisions,
@@ -8,11 +12,13 @@ import {
 } from '../../utils/utils';
 
 const LiteratureResultItem = ({ item }: { item: any }) => {
+  const workflowId = item?.get('id');
   const data = item?.get('data');
   const title = data?.getIn(['titles', 0, 'title']);
   const isLiteratureUpdate = isLiteratureUpdateWorkflow(
     item?.get('workflow_type')
   );
+  const documentTypes = data?.get('document_type');
   const decisions = item?.get('decisions');
   const filteredDecisions = filterDecisions(decisions);
   const decision = filteredDecisions?.first();
@@ -24,6 +30,7 @@ const LiteratureResultItem = ({ item }: { item: any }) => {
         {isLiteratureUpdate && (
           <UnclickableTag color="processing">Update</UnclickableTag>
         )}
+        <LiteratureDocumentTypes documentTypes={documentTypes} />
         {resolvedDecision && (
           <UnclickableTag
             className={`decision-pill ${resolvedDecision?.bg}`}
@@ -34,7 +41,13 @@ const LiteratureResultItem = ({ item }: { item: any }) => {
         )}
       </div>
       <div>
-        <Latex>{title}</Latex>
+        <Link
+          className="result-item-title"
+          to={`${BACKOFFICE}/${LITERATURE_PID_TYPE}/${workflowId}`}
+          target="_blank"
+        >
+          <Latex>{title}</Latex>
+        </Link>
       </div>
     </div>
   );

--- a/ui/src/backoffice/literature/components/WorkflowResultItem.tsx
+++ b/ui/src/backoffice/literature/components/WorkflowResultItem.tsx
@@ -3,15 +3,12 @@ import { Row, Col, Card, Checkbox, Descriptions, Typography } from 'antd';
 import { List } from 'immutable';
 
 import '../../common/components/ResultItem/ResultItem.less';
-import { Link } from 'react-router-dom';
 import {
   formatDateTime,
   hasPublicationInfo,
   isFullCoverageWorkflow,
 } from '../../utils/utils';
-import { LITERATURE_PID_TYPE } from '../../../common/constants';
 import ResultItem from '../../../common/components/ResultItem';
-import { BACKOFFICE } from '../../../common/routes';
 import AcquisitionSourceInfo from '../../common/components/AcquisitionSourceInfo/AcquisitionSourceInfo';
 import LiteratureActionButtons from './LiteratureActionButtons';
 import LiteratureSubjectAreas from './LiteratureSubjectAreas';
@@ -104,13 +101,7 @@ const WorkflowResultItem = ({
                   aria-label={`Select workflow ${workflowId}`}
                 />
               )}
-              <Link
-                className="result-item-title"
-                to={`${BACKOFFICE}/${LITERATURE_PID_TYPE}/${workflowId}`}
-                target="_blank"
-              >
-                <LiteratureResultItem item={item} />
-              </Link>
+              <LiteratureResultItem item={item} />
             </div>
             {hasAuthors && (
               <div className="mb2">
@@ -118,8 +109,9 @@ const WorkflowResultItem = ({
                   wrapperClassName="author-list-wrapper"
                   limit={10}
                   authors={authors}
-                  page="literature results backofice"
+                  page="literature results backoffice"
                   unlinked
+                  enableShowAll
                 />
               </div>
             )}

--- a/ui/src/backoffice/literature/components/__tests__/LiteratureMatches.test.jsx
+++ b/ui/src/backoffice/literature/components/__tests__/LiteratureMatches.test.jsx
@@ -17,7 +17,7 @@ const MATCHES = List([
         full_name: 'Ioannis, Heinrich',
       }),
     ]),
-    authors_count: 1,
+    authors_count: 2,
     control_number: 1790396,
     earliest_date: '2020-03-17',
     publication_info: List([
@@ -233,5 +233,49 @@ describe('LiteratureMatches', () => {
       'href',
       expect.stringContaining(`/literature/${firstControlNumber}`)
     );
+  });
+
+  it('does not render document type tags when document_type is absent', () => {
+    setup();
+
+    expect(screen.queryByText('Article')).not.toBeInTheDocument();
+  });
+
+  it('renders document type tags with capitalized first letter', () => {
+    const handleResolveAction = jest.fn();
+    const matchesWithDocType = List([
+      MATCHES.get(0).set('document_type', List(['article'])),
+      ...MATCHES.slice(1).toArray(),
+    ]);
+
+    renderWithRouter(
+      <LiteratureMatches
+        fuzzyMatches={matchesWithDocType}
+        handleResolveAction={handleResolveAction}
+      />
+    );
+
+    expect(screen.getByText('Article')).toBeInTheDocument();
+  });
+
+  it('renders multiple document type tags for a match', () => {
+    const handleResolveAction = jest.fn();
+    const matchesWithDocTypes = List([
+      MATCHES.get(0).set(
+        'document_type',
+        List(['article', 'conference paper'])
+      ),
+      ...MATCHES.slice(1).toArray(),
+    ]);
+
+    renderWithRouter(
+      <LiteratureMatches
+        fuzzyMatches={matchesWithDocTypes}
+        handleResolveAction={handleResolveAction}
+      />
+    );
+
+    expect(screen.getByText('Article')).toBeInTheDocument();
+    expect(screen.getByText('Conference paper')).toBeInTheDocument();
   });
 });

--- a/ui/src/backoffice/literature/components/__tests__/LiteratureResultItem.test.tsx
+++ b/ui/src/backoffice/literature/components/__tests__/LiteratureResultItem.test.tsx
@@ -1,26 +1,69 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { fromJS } from 'immutable';
 
+import { renderWithRouter } from '../../../../fixtures/render';
 import { WorkflowTypes } from '../../../constants';
 import LiteratureResultItem from '../LiteratureResultItem';
 
 describe('LiteratureResultItem component', () => {
   const item = fromJS({
+    id: 'wf-123',
     workflow_type: WorkflowTypes.HEP_CREATE,
     data: fromJS({
-      titles: fromJS([
-        {
-          title: 'Test title',
-        },
-      ]),
+      titles: fromJS([{ title: 'Test title' }]),
     }),
   });
 
   it('renders the LiteratureResultItem component', () => {
-    render(<LiteratureResultItem item={item} />);
+    renderWithRouter(<LiteratureResultItem item={item} />);
 
     expect(screen.getByText('Test title')).toBeInTheDocument();
     expect(screen.queryByText('Update')).not.toBeInTheDocument();
+  });
+
+  it('renders the title as a link to the workflow detail page', () => {
+    renderWithRouter(<LiteratureResultItem item={item} />);
+
+    const link = screen.getByRole('link', { name: 'Test title' });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', expect.stringContaining('wf-123'));
+  });
+
+  it('does not render document type tags when document_type is absent', () => {
+    renderWithRouter(<LiteratureResultItem item={item} />);
+
+    expect(screen.queryByText('Article')).not.toBeInTheDocument();
+  });
+
+  it('renders a single document type with capitalized first letter', () => {
+    const itemWithDocType = fromJS({
+      id: 'wf-123',
+      workflow_type: WorkflowTypes.HEP_CREATE,
+      data: {
+        titles: [{ title: 'Test title' }],
+        document_type: ['article'],
+      },
+    });
+
+    renderWithRouter(<LiteratureResultItem item={itemWithDocType} />);
+
+    expect(screen.getByText('Article')).toBeInTheDocument();
+  });
+
+  it('renders multiple document types each with capitalized first letter', () => {
+    const itemWithDocTypes = fromJS({
+      id: 'wf-123',
+      workflow_type: WorkflowTypes.HEP_CREATE,
+      data: {
+        titles: [{ title: 'Test title' }],
+        document_type: ['article', 'conference paper'],
+      },
+    });
+
+    renderWithRouter(<LiteratureResultItem item={itemWithDocTypes} />);
+
+    expect(screen.getByText('Article')).toBeInTheDocument();
+    expect(screen.getByText('Conference paper')).toBeInTheDocument();
   });
 });

--- a/ui/src/backoffice/notifications.ts
+++ b/ui/src/backoffice/notifications.ts
@@ -18,7 +18,6 @@ export function notifyActionSuccess(action: string) {
   notification.success({
     message: 'Success',
     description: `${_.capitalize(displayAction)} performed successfully`,
-    duration: 10,
   });
 }
 
@@ -26,7 +25,6 @@ export function notifyActionError(error: string) {
   notification.error({
     message: 'Unable to perform action',
     description: error,
-    duration: 10,
   });
 }
 
@@ -34,7 +32,6 @@ export function notifyDeleteSuccess() {
   notification.success({
     message: 'Success',
     description: 'Workflow deleted successfully',
-    duration: 10,
   });
 }
 
@@ -42,6 +39,5 @@ export function notifyDeleteError(error: string) {
   notification.error({
     message: 'Unable to delete workflow',
     description: error,
-    duration: 10,
   });
 }


### PR DESCRIPTION
 * ref https://github.com/cern-sis/issues-inspire/issues/1476

Document types as requests + show all with the number of authors
<img width="1207" height="731" alt="Screenshot 2026-04-29 at 16 59 36" src="https://github.com/user-attachments/assets/62212d58-7ba1-417a-a317-78ba8b3476e9" />


Toast now disappears in 4 seconds
Correct number of authors is displayed in the match candidate