### PR TITLE
records: exclude obsolete ICN institutions from affiliation autocomplete

### DIFF
--- a/backend/inspirehep/records/marshmallow/institutions/es.py
+++ b/backend/inspirehep/records/marshmallow/institutions/es.py
@@ -21,6 +21,9 @@ class InstitutionsElasticSearchSchema(ElasticSearchBaseSchema, InstitutionsRawSc
         ICN = original_object.get("ICN", [])
         legacy_ICN = original_object.get("legacy_ICN", "")
 
+        if "obsolete" in ICN:
+            return []
+
         institution_acronyms = original_object.get_value(
             "institution_hierarchy.acronym", default=[]
         )

--- a/backend/tests/unit/records/marshmallow/institutions/test_es.py
+++ b/backend/tests/unit/records/marshmallow/institutions/test_es.py
@@ -220,3 +220,21 @@ def test_populate_affiliation_search_as_you_type_to_ref(
     expected = ["CERN"]
 
     assert expected == result
+
+
+@mock.patch("inspirehep.records.api.institutions.InstitutionLiterature")
+def test_populate_affiliation_search_as_you_type_excludes_obsolete_icn(
+    mock_institution_literature_table,
+):
+    data = {
+        "$schema": "http://localhost:5000/schemas/records/institutions.json",
+        "ICN": ["obsolete"],
+        "legacy_ICN": "Harvard U.",
+        "name_variants": [{"value": "Harvard University"}],
+    }
+    record = InstitutionsRecord(faker.record("ins", data))
+
+    schema = InstitutionsElasticSearchSchema()
+    result = schema.dump(record).data
+
+    assert "affiliation_search_as_you_type" not in result


### PR DESCRIPTION
added the line to exclude obsolete institutions from affiliation autocomplete and the unit test for the same