### PR TITLE
backoffice: moving batchresolve into view

### DIFF
--- a/backoffice/backoffice/hep/api/views.py
+++ b/backoffice/backoffice/hep/api/views.py
@@ -163,6 +163,31 @@ class HepWorkflowViewSet(BaseWorkflowViewSet):
         workflow_serializer = self.serializer_class(workflow)
         return Response(workflow_serializer.data)
 
+    @action(
+        detail=False,
+        methods=["post"],
+        url_path="resolve",
+        url_name="batch-resolve-list",
+    )
+    def batch_resolve(self, request):
+        serializer = HepBatchResolutionSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        data = serializer.validated_data
+        data["ids"] = [str(wf_id) for wf_id in data["ids"]]
+        for wf_id in data["ids"]:
+            workflow = get_object_or_404(HepWorkflow, pk=wf_id)
+            add_hep_decision(wf_id, request.user, data["action"], data.get("value"))
+            workflow.status = HepStatusChoices.RUNNING
+            workflow.save()
+
+        transaction.on_commit(lambda: batch_resolve_workflows.delay(data))
+
+        return Response(
+            {"message": "Batch resolution started.", "ids": data["ids"]},
+            status=status.HTTP_202_ACCEPTED,
+        )
+
     @action(detail=True, methods=["post"])
     def discard(self, request, pk=None):
         workflow = complete_workflow(pk, request.data)
@@ -278,27 +303,6 @@ class HepWorkflowViewSet(BaseWorkflowViewSet):
             )
 
         return Response(wf_serializer.data)
-
-
-class HepWorkflowBatchResolveViewSet(viewsets.ViewSet):
-    def create(self, request):
-        serializer = HepBatchResolutionSerializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-
-        data = serializer.validated_data
-        data["ids"] = [str(wf_id) for wf_id in data["ids"]]
-        for wf_id in data["ids"]:
-            workflow = get_object_or_404(HepWorkflow, pk=wf_id)
-            add_hep_decision(wf_id, request.user, data["action"], data.get("value"))
-            workflow.status = HepStatusChoices.RUNNING
-            workflow.save()
-
-        transaction.on_commit(lambda: batch_resolve_workflows.delay(data))
-
-        return Response(
-            {"message": "Batch resolution started.", "ids": data["ids"]},
-            status=status.HTTP_202_ACCEPTED,
-        )
 
 
 @extend_schema_view(

--- a/backoffice/config/api_router.py
+++ b/backoffice/config/api_router.py
@@ -8,7 +8,6 @@ from backoffice.hep.api.views import (
     HepWorkflowViewSet,
     HepDecisionViewSet,
     HepWorkflowTicketViewSet,
-    HepWorkflowBatchResolveViewSet,
 )
 from django.conf import settings
 from rest_framework.routers import DefaultRouter, SimpleRouter
@@ -31,11 +30,6 @@ router.register(
 )
 router.register(
     "workflows/literature/decisions", HepDecisionViewSet, basename="hep-decisions"
-)
-router.register(
-    "workflows/literature/resolve",
-    HepWorkflowBatchResolveViewSet,
-    basename="hep-batch-resolve",
 )
 router.register("workflows/literature", HepWorkflowViewSet, basename="hep")
 


### PR DESCRIPTION
We had initially moved it out of the view in order to take advantages of the different atomicity settings. 
Since we moved the airflow triggering functionality into celery, there's no advantage to having it isolated it. 
so in order to simplify the code lets move it back to its original view