### PR TITLE
curation: match affiliations by ROR in affiliations_identifiers

### DIFF
--- a/backend/inspirehep/curation/api.py
+++ b/backend/inspirehep/curation/api.py
@@ -13,7 +13,7 @@ from inspirehep.curation.utils import (
     create_accelerator_experiment_from_collaboration_match,
     enhance_collaboration_data_with_collaboration_match,
     find_collaboration_in_multisearch_response,
-    find_institution_by_ror,  # <-- new
+    find_institution_by_ror,
     find_unambiguous_affiliation,
     match_lit_author_affiliation,
 )

--- a/backend/inspirehep/curation/api.py
+++ b/backend/inspirehep/curation/api.py
@@ -13,6 +13,7 @@ from inspirehep.curation.utils import (
     create_accelerator_experiment_from_collaboration_match,
     enhance_collaboration_data_with_collaboration_match,
     find_collaboration_in_multisearch_response,
+    find_institution_by_ror,  # <-- new
     find_unambiguous_affiliation,
     match_lit_author_affiliation,
 )
@@ -66,9 +67,33 @@ def normalize_collaborations(collaborations, wf_id=None):
     }
 
 
+def _match_by_raw_affiliation(raw_aff, cache, workflow_id):
+    if raw_aff in cache:
+        return cache[raw_aff]
+    hits = match_lit_author_affiliation(raw_aff)
+    matched_aff = find_unambiguous_affiliation(hits, workflow_id)
+    if matched_aff:
+        cache[raw_aff] = matched_aff
+    return matched_aff
+
+
+def _match_by_ror(ror, cache):
+    if ror in cache:
+        return cache[ror]
+    institution = find_institution_by_ror(ror)
+    matched_aff = (
+        [{"value": institution["legacy_ICN"], "record": institution["self"]}]
+        if institution
+        else None
+    )
+    cache[ror] = matched_aff
+    return matched_aff
+
+
 def normalize_affiliations(authors, workflow_id=None, **kwargs):
     """
     Normalizes author raw affiliations in literature record.
+
     Params:
         data (dict): data contaning list of authors with affiliations to normalize
         literature_search_object (elasticsearch_dsl.search.Search): Search request to elasticsearch.
@@ -78,28 +103,53 @@ def normalize_affiliations(authors, workflow_id=None, **kwargs):
         ambiguous_affiliations: not matched (not normalized) affiliations
     """
     matched_affiliations = {}
+    matched_ror_affiliations = {}
     normalized_affiliations = []
     ambiguous_affiliations = []
+
     for author in authors:
         author_affiliations = author.get("affiliations", [])
         if author_affiliations:
             normalized_affiliations.append(author_affiliations)
             continue
+
         raw_affs = get_value(author, "raw_affiliations.value", [])
-        for raw_aff in raw_affs:
-            if raw_aff in matched_affiliations:
-                author_affiliations.extend(matched_affiliations[raw_aff])
-                continue
-            matched_author_affiliations_hits = match_lit_author_affiliation(raw_aff)
-            matched_author_affiliations = find_unambiguous_affiliation(
-                matched_author_affiliations_hits, workflow_id
-            )
-            if matched_author_affiliations:
-                matched_affiliations[raw_aff] = matched_author_affiliations
-                author_affiliations.extend(matched_author_affiliations)
-            else:
-                ambiguous_affiliations.append(raw_aff)
+        aff_ids = get_value(author, "affiliations_identifiers", [])
+        rors = [aff_id["value"] for aff_id in aff_ids if aff_id.get("schema") == "ROR"]
+
+        if raw_affs and len(raw_affs) == len(rors):
+            # 1:1 correspondence: prefer ROR, fall back to raw text per-index
+            for raw_aff, ror in zip(raw_affs, rors, strict=False):
+                matched_aff = _match_by_ror(ror, matched_ror_affiliations)
+                if not matched_aff:
+                    matched_aff = _match_by_raw_affiliation(
+                        raw_aff, matched_affiliations, workflow_id
+                    )
+                if matched_aff:
+                    author_affiliations.extend(matched_aff)
+                else:
+                    ambiguous_affiliations.append(raw_aff)
+
+        elif not raw_affs and rors:
+            # ROR-only, no fallback available
+            for ror in rors:
+                matched_aff = _match_by_ror(ror, matched_ror_affiliations)
+                if matched_aff:
+                    author_affiliations.extend(matched_aff)
+
+        else:
+            # counts don't line up unambiguously — leave ROR matching out
+            for raw_aff in raw_affs:
+                matched_aff = _match_by_raw_affiliation(
+                    raw_aff, matched_affiliations, workflow_id
+                )
+                if matched_aff:
+                    author_affiliations.extend(matched_aff)
+                else:
+                    ambiguous_affiliations.append(raw_aff)
+
         normalized_affiliations.append(dedupe_list(author_affiliations))
+
     return {
         "normalized_affiliations": normalized_affiliations,
         "ambiguous_affiliations": ambiguous_affiliations,

--- a/backend/inspirehep/curation/utils.py
+++ b/backend/inspirehep/curation/utils.py
@@ -303,3 +303,32 @@ def assign_institution(matched_affiliation):
     if result:
         matched_affiliation["record"] = result.hits[0].to_dict()["self"]
         return matched_affiliation
+
+
+def find_institution_by_ror(ror):
+    """Find a non-obsolete institution record with the given ROR id.
+
+    Args:
+        ror (str): a full ROR URL, e.g. "https://ror.org/042949r55" — this is
+            the format stored in external_system_identifiers.value, and matches
+            the format used in authors.affiliations_identifiers on literature
+            records, so no conversion is needed between the two.
+
+    Returns:
+        dict or None: institution record with ``self`` and ``legacy_ICN``,
+        or None if no matching non-obsolete institution exists.
+    """
+    query = (
+        Q("term", external_system_identifiers__schema="ROR")
+        & Q("term", external_system_identifiers__value=ror)
+        & ~Q("match", ICN="obsolete")
+    )
+    result = (
+        InstitutionsSearch()
+        .query(query)
+        .source(["self", "legacy_ICN"])
+        .params(size=1)
+        .execute()
+    )
+    if result:
+        return result.hits[0].to_dict()

--- a/backend/tests/integration/curation/test_api.py
+++ b/backend/tests/integration/curation/test_api.py
@@ -15,6 +15,7 @@ from inspirehep.curation.api import (
     normalize_affiliations,
     normalize_collaborations,
 )
+from inspirehep.curation.utils import find_institution_by_ror
 
 
 @pytest.mark.usefixtures("_insert_experiments_into_db")
@@ -568,3 +569,159 @@ def test_assign_institution_reference_to_affiliations(inspire_app):
     affiliations = [{"value": "CERN"}, {"value": "Warsaw U."}]
     assign_institution_reference_to_affiliations(affiliations, {})
     assert ["record" in affiliation for affiliation in affiliations]
+
+
+@pytest.mark.usefixtures("_insert_institutions_in_db")
+def test_find_institution_by_ror_returns_match(inspire_app):
+    result = find_institution_by_ror("https://ror.org/00nzsxq20")
+
+    assert result["legacy_ICN"] == "NCBJ, Swierk"
+    assert result["self"]["$ref"] == "http://localhost:5000/api/institutions/1126070"
+
+
+@pytest.mark.usefixtures("_insert_institutions_in_db")
+def test_find_institution_by_ror_excludes_obsolete_institution(inspire_app):
+    result = find_institution_by_ror("https://ror.org/0testxx99")
+
+    assert result is None
+
+
+def test_find_institution_by_ror_returns_none_when_not_found(inspire_app):
+    result = find_institution_by_ror("https://ror.org/does-not-exist")
+
+    assert result is None
+
+
+@pytest.mark.usefixtures("_insert_institutions_in_db")
+def test_normalize_affiliations_one_to_one_ror_match(inspire_app):
+    record = {
+        "_collections": ["Literature"],
+        "titles": ["A title"],
+        "document_type": ["report"],
+        "authors": [
+            {
+                "full_name": "Kozioł, Karol",
+                "raw_affiliations": [{"value": "NCBJ Świerk"}],
+                "affiliations_identifiers": [
+                    {"schema": "ROR", "value": "https://ror.org/00nzsxq20"}
+                ],
+            }
+        ],
+    }
+
+    data = normalize_affiliations(record["authors"])
+
+    assert data["normalized_affiliations"][0] == [
+        {
+            "record": {"$ref": "http://localhost:5000/api/institutions/1126070"},
+            "value": "NCBJ, Swierk",
+        }
+    ]
+    assert data["ambiguous_affiliations"] == []
+
+
+@pytest.mark.usefixtures("_insert_institutions_in_db", "_insert_literature_in_db")
+def test_normalize_affiliations_one_to_one_ror_miss_falls_back_to_raw(inspire_app):
+    record = {
+        "_collections": ["Literature"],
+        "titles": ["A title"],
+        "document_type": ["report"],
+        "authors": [
+            {
+                "full_name": "Latacz, Barbara",
+                "raw_affiliations": [{"value": "CERN, Genève, Switzerland"}],
+                "affiliations_identifiers": [
+                    {"schema": "ROR", "value": "https://ror.org/does-not-exist"}
+                ],
+            }
+        ],
+    }
+
+    data = normalize_affiliations(record["authors"])
+
+    assert data["normalized_affiliations"][0] == [
+        {
+            "record": {"$ref": "http:/localhost:5000/api/institutions/902725"},
+            "value": "CERN",
+        }
+    ]
+
+
+@pytest.mark.usefixtures("_insert_institutions_in_db")
+def test_normalize_affiliations_ror_only_no_fallback_match(inspire_app):
+    record = {
+        "_collections": ["Literature"],
+        "titles": ["A title"],
+        "document_type": ["report"],
+        "authors": [
+            {
+                "full_name": "Kozioł, Karol",
+                "affiliations_identifiers": [
+                    {"schema": "ROR", "value": "https://ror.org/00nzsxq20"}
+                ],
+            }
+        ],
+    }
+
+    data = normalize_affiliations(record["authors"])
+
+    assert data["normalized_affiliations"][0] == [
+        {
+            "record": {"$ref": "http://localhost:5000/api/institutions/1126070"},
+            "value": "NCBJ, Swierk",
+        }
+    ]
+
+
+@pytest.mark.usefixtures("_insert_institutions_in_db")
+def test_normalize_affiliations_ror_only_no_match_no_fallback(inspire_app):
+    record = {
+        "_collections": ["Literature"],
+        "titles": ["A title"],
+        "document_type": ["report"],
+        "authors": [
+            {
+                "full_name": "Kozioł, Karol",
+                "affiliations_identifiers": [
+                    {"schema": "ROR", "value": "https://ror.org/does-not-exist"}
+                ],
+            }
+        ],
+    }
+
+    data = normalize_affiliations(record["authors"])
+
+    # no raw_affiliations to fall back to and no raw string to flag as ambiguous
+    assert data["normalized_affiliations"][0] == []
+    assert data["ambiguous_affiliations"] == []
+
+
+@pytest.mark.usefixtures("_insert_institutions_in_db", "_insert_literature_in_db")
+def test_normalize_affiliations_mismatched_counts_ignores_ror(inspire_app):
+    # 2 raw_affiliations but only 1 ROR id: falls into "everything else",
+    # ROR matching must not be attempted at all
+    record = {
+        "_collections": ["Literature"],
+        "titles": ["A title"],
+        "document_type": ["report"],
+        "authors": [
+            {
+                "full_name": "Kozioł, Karol",
+                "raw_affiliations": [
+                    {"value": "NCBJ Świerk"},
+                    {"value": "CERN, Genève, Switzerland"},
+                ],
+                "affiliations_identifiers": [
+                    {"schema": "ROR", "value": "https://ror.org/00nzsxq20"}
+                ],
+            }
+        ],
+    }
+
+    data = normalize_affiliations(record["authors"])
+
+    assert {"value": "NCBJ, Swierk"} in data["normalized_affiliations"][0]
+    assert {
+        "record": {"$ref": "http:/localhost:5000/api/institutions/902725"},
+        "value": "CERN",
+    } in data["normalized_affiliations"][0]

--- a/backend/tests/integration/curation/test_api/institutions/institution_obsolete_with_ror.json
+++ b/backend/tests/integration/curation/test_api/institutions/institution_obsolete_with_ror.json
@@ -1,0 +1,17 @@
+{
+  "ICN": ["Test Obsolete Inst.", "obsolete"],
+  "core": true,
+  "self": {
+    "$ref": "https://inspirehep.net/api/institutions/1300002"
+  },
+  "$schema": "https://inspirehep.net/schemas/records/institutions.json",
+  "legacy_ICN": "Test Obsolete Inst.",
+  "_collections": ["Institutions"],
+  "control_number": 1300002,
+  "external_system_identifiers": [
+    {
+      "value": "https://ror.org/0testxx99",
+      "schema": "ROR"
+    }
+  ]
+}


### PR DESCRIPTION
Summary:
Extends `normalize_affiliations` to match affiliations via ROR (`affiliations_identifiers`) before falling back to the existing raw-text matching.

- Only non-obsolete institutions are matched (`ICN` excludes `"obsolete"`).
- 1:1 case (equal counts of `raw_affiliations` and ROR ids): prefer ROR match; fall back to raw-text matching per entry on miss.
- ROR-only case (no `raw_affiliations`): match on ROR only, no fallback.
- Everything else (mismatched counts): ROR matching skipped, original raw-text-only behavior unchanged.

Implementation:

- `curation/utils.py`: new `find_institution_by_ror(ror)` — queries `InstitutionsSearch` for a non-obsolete institution with a matching ROR.
- `curation/api.py`: `normalize_affiliations` branches into the three cases above, using cached lookups for both ROR and raw-text matching.

Testing:

Added integration tests for all branches (ROR match, obsolete exclusion, no-match, 1:1 fallback, ROR-only, mismatched counts). Full `test_api.py` suite passes (25/25), no regressions.