### PR TITLE
backend: report single-record reindex failures

### DIFF
--- a/backend/inspirehep/indexer/cli.py
+++ b/backend/inspirehep/indexer/cli.py
@@ -205,7 +205,12 @@ def reindex_records(
         record = InspireRecord.get_record_by_pid_value(
             pid_value, pid_type, original_record=True
         )
-        record.index()
+        try:
+            record.index(delay=False)
+        except Exception as error:
+            raise click.ClickException(
+                f"Failed to reindex record {pid}: {error}"
+            ) from error
         click.secho(f"Successfully reindexed record {pid}", fg="green")
         ctx.exit(0)
 

--- a/backend/tests/integration-async/records/indexer/test_indexer_cli.py
+++ b/backend/tests/integration-async/records/indexer/test_indexer_cli.py
@@ -138,13 +138,35 @@ def test_reindex_records_lit_using_multiple_batches(
     assert "0 failed" in result.output
 
 
-def test_reindex_only_one_record(inspire_app, clean_celery_session, cli):
+@patch("inspirehep.indexer.cli.InspireRecord.index")
+def test_reindex_only_one_record(mock_index, inspire_app, clean_celery_session, cli):
     generate_records(count=1, data={"control_number": 3}, with_control_number=False)
+    mock_index.reset_mock()
+
     result = cli.invoke(["index", "reindex", "-id", "lit", "3", "-q", ""])
 
     expected_message = "Successfully reindexed record ('lit', '3')"
     assert result.exit_code == 0
     assert expected_message in result.output
+    mock_index.assert_called_once_with(delay=False)
+
+
+@patch("inspirehep.indexer.cli.InspireRecord.index")
+def test_reindex_only_one_record_failure(
+    mock_index, inspire_app, clean_celery_session, cli
+):
+    generate_records(count=1, data={"control_number": 3}, with_control_number=False)
+    mock_index.reset_mock()
+    mock_index.side_effect = RuntimeError("OpenSearch unavailable")
+
+    result = cli.invoke(["index", "reindex", "-id", "lit", "3", "-q", ""])
+
+    assert result.exit_code == 1
+    assert (
+        "Error: Failed to reindex record ('lit', '3'): OpenSearch unavailable"
+        in result.output
+    )
+    assert "Successfully reindexed" not in result.output
 
 
 def test_reindex_only_one_record_fulltext(


### PR DESCRIPTION
* ref: https://github.com/cern-sis/issues-inspire/issues/742

## Summary

- run single-record indexing synchronously so the CLI can observe indexing failures
- report failures with a non-zero exit code instead of printing a false success message
- keep the existing bulk reindexing behavior unchanged

## Tests

- focused single-record reindex CLI tests (2 passed)
- Ruff check and format check